### PR TITLE
define how the pipeline works

### DIFF
--- a/docs/gwcs/create_wcs.rst
+++ b/docs/gwcs/create_wcs.rst
@@ -61,9 +61,9 @@ by CRPIX, a rotation by the PC matrix, a tangent deprojection and a sky rotation
 `astropy.modeling <http://docs.astropy.org/en/stable/modeling>`__ this can be written as
 
   >>> shift = models.Shift(CRPIX1, name="x_shift") & models.Shift(CRPIX2, name="y_shift")
-  >>> plane_rotation = models.AffineTransformation2D(matrix=np.array([[PC1_1, PC1_2], [PC2_1], PC2_2]])
+  >>> plane_rotation = models.AffineTransformation2D(matrix=np.array([[PC1_1, PC1_2], [PC2_1, PC2_2]]))
   >>> tangent = models.Pix2Sky_TAN()
-  >>> sky_roations = models.RotateNative2Celestial(CRVAL1, CRVAL2, LONPOLE)
+  >>> sky_rotation = models.RotateNative2Celestial(CRVAL1, CRVAL2, LONPOLE)
 
 Chaining these models into one compound models creates the total transformation from focal plane to sky
 
@@ -73,7 +73,7 @@ Chaining these models into one compound models creates the total transformation 
 Create the coordinate systems
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-  >>> icrs = coordinates.ICRS()
+  >>> icrs = coord.ICRS()
   >>> final_system = gwcs.CelestialFrame(reference_frame=icrs)
   >>> final_system.unit
   <CelestialFrame(reference_frame=<ICRS Frame>, axes_order=(0, 1), reference_position=Barycenter,
@@ -99,6 +99,11 @@ A slightly more detailed approach gives some more control over the transformatio
   >>> image_wcs.add_transform(w.input_coordinate_system, focal_plane, distortion)
   >>> image_wcs.add_transform(focal_plane, w.output_coordinate_system, focal2sky)
 
+Transform Coordinates from detector to world coordinate system
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+  >>> image_wcs(1, 2)
+  (5.736718396223817, -72.057214400243)
 
 A spectral example
 -------------------

--- a/docs/gwcs/create_wcs.rst
+++ b/docs/gwcs/create_wcs.rst
@@ -76,8 +76,7 @@ Create the coordinate systems
   >>> icrs = coord.ICRS()
   >>> final_system = gwcs.CelestialFrame(reference_frame=icrs)
   >>> final_system.unit
-  <CelestialFrame(reference_frame=<ICRS Frame>, axes_order=(0, 1), reference_position=Barycenter,
-  unit=[Unit("deg"), Unit("deg")], name="ICRS")>
+  [Unit("deg"), Unit("deg")]
   >>> start_system = gwcs.DetectorFrame()
   >>> print start_system.unit
   [Unit("pix"), Unit("pix")]
@@ -91,23 +90,30 @@ The easiest way to create the WCS object is to pass the total transform and the 
 The default value for th input coordinate system is `~gwcs.cooridnate_frames.DetectorFrame`.
 
   >>> total_transform = distortion | focal2sky
-  >>> image_wcs = gwcs.WCS(forward_transform=total_transform, output_coordinate_system=final_system)
+  >>> image_wcs = gwcs.WCS(forward_transform=total_transform, output_frame=final_system)
 
-A slightly more detailed approach gives some more control over the transformations:
+It is possible to have more control over the transformations by passing a list or (frame, transform)
+tuple to `forward_transform`.
 
-  >>> image_wcs = gwcs.WCS(output_coordinate_system=final_system)
-  >>> image_wcs.add_transform(w.input_coordinate_system, focal_plane, distortion)
-  >>> image_wcs.add_transform(focal_plane, w.output_coordinate_system, focal2sky)
+  >>> pipeline = [(start_system, distortion),
+                  (focal_plane, focal2sky),
+                  (final_system, None)
+                  ]
+  >>> image_wcs = gwcs.WCS(output_frame=final_system, forward_transform=pipeline)
+  >>> print image_wcs.available_frames
+  {'icrs': <CelestialFrame(reference_frame=<ICRS Frame>, axes_order=(0, 1), unit=[Unit("deg"), Unit("deg")], name=icrs)>,
+  'detector': <DetectorFrame(axes_order=(0, 1), name=detector, reference_position=Local, axes_names=['x', 'y'],
+  'focal_plane': <FocalPlaneFrame(2, axes_order=(0, 1), reference_frame=<Focal Frame>, unit=[Unit("pix"), Unit("pix")]>
+  }
+
 
 Transform Coordinates from detector to world coordinate system
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
   >>> image_wcs(1, 2)
   (5.736718396223817, -72.057214400243)
-
-A spectral example
--------------------
-
+  >>> image_wcs.transform(image_wcs.input_frame, image_wcs.output_frame, 1, 2)
+  (5.526473706453078, -72.05173013244713)
 
 
 

--- a/docs/gwcs/selector_model.rst
+++ b/docs/gwcs/selector_model.rst
@@ -34,12 +34,11 @@ Next we need to create the output coordinate system - a `~gwcs.coordinate_frames
 
 The WCS for the IFU observation is created by passing the input and output coordinate systems and the transform between them. To transform from pixel to world coordinates we simply call the WCS object. ``x`` and ``y`` below are coordinates in the detector pixel space.
 
-  >>> wifu = gwcs.WCS(input_coordinate_system='detector', output_coordinate_system=output_system, forward_transform=forward)
+  >>> wifu = gwcs.WCS(input_frame='detector', output_frame=output_system, forward_transform=forward)
   >>> x, y = 1, 2
   >>> result = wifu(x, y)
   >>> print result
-  (<SkyCoord (ICRS): (ra, dec) in deg (5.63043056, -72.05454345)>,
-  <Wavelength Coordinate (reference_position=BARYCENTER): (lam) in m (0.00000344)>)
+  (5.63043056, -72.05454345, 0.00000344)
 
 
 Because the transform is an instance of `~gwcs.selector.RegionsSelectorModel`, we can
@@ -47,10 +46,9 @@ pass a ``region_id`` to the WCS function and perform the transform for a particu
 For example, to transform coordinates in slice 4:
 
   >>> transform(x, y, 4)
-  (<SkyCoord (ICRS): (ra, dec) in deg (5.63024693, -72.05452058)>,
-  <Wavelength Coordinate (reference_position=BARYCENTER): (lam) in m (0.00000344)>)
+  (5.63024693, -72.05452058, 0.00000344)
 
-Note that ``x``, ``y`` now are pixels in the coordinate system associated with the 4th slice,
+Note that ``x``and ``y`` are now pixels in the coordinate system associated with the 4th slice,
 not the entire detector.
 
 

--- a/docs/gwcs/selector_model.rst
+++ b/docs/gwcs/selector_model.rst
@@ -27,8 +27,8 @@ Next we need to create the output coordinate system - a `~gwcs.coordinate_frames
 
   >>> celestial = gwcs.CelestialFrame(coord.ICRS())
   >>> spec = gwcs.SpectralFrame(gwcs.spectral_builtin_frames.Wavelength(), unit=[u.micron], axes_names=['lambda'])
-  >>> output_system = gwcs.CompositeCoordinateFrame([celestial, spec])
-  >>> print output_system.units
+  >>> output_system = gwcs.CompositeFrame([celestial, spec])
+  >>> print output_system.unit
   [Unit("deg"), Unit("deg"), Unit("micron")]
 
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -44,21 +44,25 @@ Given positions on the detector, the WCS computes positions
 on the sky. To convert a pixel (x, y) = (1,2) to sky coordinates:
 
 
-  >>> sky_coord = nddata_image.wcs(1, 2)
-  >>> print sky_coord
-  <SkyCoord (ICRS): (ra, dec) in deg
-    (5.52509373, -72.05190053)>
+  >>> sky = nddata_image.wcs(1, 2)
+  >>> print sky
+  (5.52509373, -72.05190053)
+
 
 If available, the backward transform can be evaluated using the :meth:`~gwcs.wcs.WCS.invert` method.
 
 
-  >>> nddata_image.wcs.invert(sky_coord.ra.value, sky_coord.dec.value)
+  >>> nddata_image.wcs.invert(*sky)
   (1.0000000938994162, 2.000000047071694)
 
-The forward transform returns a SkyCoord object which can be used to transform to other
-standard coordinate systems transparently using the `astropy.coordinates` framework.
+The result of the forward transform can be turned into a SkyCoord object which then can be used to
+transform to other standard coordinate systems using the `astropy.coordinates` framework.
 
 
+  >>> sky_coord = nddata_image.wcs.output_frame.world_coordinates(*sky)
+  >>> print sky_coord
+  <SkyCoord (ICRS): (ra, dec) in deg
+  (5.52509373, -72.05190053)>
   >>> sky_coord.transform_to('galactic')
   <SkyCoord (Galactic): (l, b) in deg
       (306.11529787, -44.89457423)>
@@ -70,11 +74,15 @@ transformations.
 
 Let part of the transform in the above example include distortion correction which
 converts positions on the detector to positions in a system associated with the focal
-plane of the telescope (called ``FocalPlaneFrame``). There are several ways to perform
-the transformation from detector to focal plane coordinates.
-
+plane of the telescope (called ``FocalPlaneFrame``). There are a couple of ways to perform
+the transformation from detector to focal plane coordinates - The :meth:`~gwcs.wcs.transform`
+method
 
   >>> nddata_image.wcs.transform('detector', 'focal_plane', 1, 2)
+
+or in two steps, getting the transform first using :meth:`~gwcs.wcs.get_transform`
+and then evaluating it:
+
   >>> distoriton = nddata_image.wcs.get_transform('detector', 'focal_plane')
   >>> distortion(1, 2)
 

--- a/gwcs/coordinate_frames.py
+++ b/gwcs/coordinate_frames.py
@@ -99,7 +99,7 @@ class CoordinateFrame(object):
         else:
             return ""
         '''
-        fmt = "<{0}({1}, axes_order={2}, reference_frame={3}, reference_position{4},"
+        fmt = "<{0}({1}, axes_order={2}, reference_frame={3}, reference_position{4}," \
         "unit={5}, axes_names={6}, name={7})>".format(
             self.__class__.__name__, self.naxes, self.axes_order,
             self.reference_frame, self.reference_position, self.unit,
@@ -332,7 +332,6 @@ class CompositeFrame(CoordinateFrame):
 
 class Detector(BaseCoordinateFrame):
     default_representation = Cartesian2DRepresentation
-    reference_position = FrameAttribute(default='Local')
     frame_specific_representation_info = {
         'cartesian2d': [RepresentationMapping('x', 'x', u.pixel),
                         RepresentationMapping('y', 'y', u.pixel)]
@@ -354,10 +353,20 @@ class DetectorFrame(CoordinateFrame):
         axes_names={3}".format(self.axes_order, self.name, self.reference_position, self.axes_names)
         return fmt
 
+
+class Focal(BaseCoordinateFrame):
+    default_representation = Cartesian2DRepresentation
+    frame_specific_representation_info = {
+        'cartesian2d': [RepresentationMapping('x', 'x', u.pixel),
+                        RepresentationMapping('y', 'y', u.pixel)]
+        }
+
+
 class FocalPlaneFrame(CoordinateFrame):
     def __init__(self, reference_pixel=[0., 0.], unit=[u.pixel, u.pixel], name='focal_plane',
                  reference_position="Local", axes_names=None):
-        super(FocalPlaneFrame, self).__init__(2, reference_frame=Detector(), reference_position=reference_position, unit=unit, name=name, axes_names=axes_names)
+        super(FocalPlaneFrame, self).__init__(2, reference_frame=Focal(), reference_position=reference_position,
+                                              unit=unit, name=name, axes_names=axes_names)
         self._reference_pixel = reference_pixel
 
 

--- a/gwcs/coordinate_frames.py
+++ b/gwcs/coordinate_frames.py
@@ -8,7 +8,7 @@ import numpy as np
 from astropy import time
 from astropy import units as u
 from astropy import utils as astutil
-from astropy import coordinates as coo
+from astropy import coordinates as coord
 from astropy.coordinates import (BaseCoordinateFrame, FrameAttribute,
                                  RepresentationMapping)
 
@@ -180,8 +180,8 @@ class CelestialFrame(CoordinateFrame):
 
     def __init__(self, reference_frame, axes_order=(0, 1), reference_position=None,
                  unit=[u.degree, u.degree], name=None):
-        reference_position = 'Barycenter' #??
-        if reference_frame.name.upper() in coo.builtin_frames.__all__:
+        reference_position = 'Barycenter'
+        if reference_frame.name.upper() in coord.builtin_frames.__all__:
             axes_names = reference_frame.representation_component_names.keys()[:2]
         super(CelestialFrame, self).__init__(naxes=2, reference_frame=reference_frame,
                                              unit=unit, axes_order= axes_order,
@@ -197,7 +197,7 @@ class CelestialFrame(CoordinateFrame):
         lon, lat : float
             longitude and latitude
         """
-        return coo.SkyCoord(lon, lat, unit=self.unit, frame=self._reference_frame)
+        return coord.SkyCoord(lon, lat, unit=self.unit, frame=self._reference_frame)
 
     def __repr__(self):
 

--- a/gwcs/coordinate_frames.py
+++ b/gwcs/coordinate_frames.py
@@ -163,7 +163,7 @@ class CoordinateFrame(object):
 
 class CelestialFrame(CoordinateFrame):
     """
-    Celestial Frame Representation.
+    Celestial Frame Representation
 
     Parameters
     ----------
@@ -179,7 +179,7 @@ class CelestialFrame(CoordinateFrame):
     """
 
     def __init__(self, reference_frame, axes_order=(0, 1), reference_position=None,
-                 unit=[u.degree, u.degree], name=""):
+                 unit=[u.degree, u.degree], name=None):
         reference_position = 'Barycenter' #??
         if reference_frame.name.upper() in coo.builtin_frames.__all__:
             axes_names = reference_frame.representation_component_names.keys()[:2]
@@ -241,7 +241,7 @@ class SpectralFrame(CoordinateFrame):
 
     """
 
-    def __init__(self, reference_frame, axes_order=(0,), unit=None, axes_names=None, name=""):
+    def __init__(self, reference_frame, axes_order=(0,), unit=None, axes_names=None, name=None):
         super(SpectralFrame, self).__init__(naxes=1, reference_frame=reference_frame,
                                             axes_order=axes_order,
                                             axes_names=axes_names,
@@ -340,7 +340,10 @@ class Detector(BaseCoordinateFrame):
 
 
 class DetectorFrame(CoordinateFrame):
-    def __init__(self, axes_order=(0, 1), name='Detector', reference_position='Local'):
+    """
+    Represents a Cartesian coordinate system on a detector.
+    """
+    def __init__(self, axes_order=(0, 1), name='detector', reference_position='Local'):
         axes_names = ['x', 'y']
         super(DetectorFrame, self).__init__(2, name=name, axes_names=axes_names,
                                             reference_frame=Detector(),
@@ -352,9 +355,9 @@ class DetectorFrame(CoordinateFrame):
         return fmt
 
 class FocalPlaneFrame(CoordinateFrame):
-    def __init__(self, reference_pixel=[0., 0.], units=[u.pixel, u.pixel], name='FocalPlane',
+    def __init__(self, reference_pixel=[0., 0.], unit=[u.pixel, u.pixel], name='focal_plane',
                  reference_position="Local", axes_names=None):
-        super(FocalPlaneFrame, self).__init__(2, reference_position=reference_position, units=units, name=name, axes_names=axes_names)
+        super(FocalPlaneFrame, self).__init__(2, reference_frame=Detector(), reference_position=reference_position, unit=unit, name=name, axes_names=axes_names)
         self._reference_pixel = reference_pixel
 
 

--- a/gwcs/selector.py
+++ b/gwcs/selector.py
@@ -2,12 +2,14 @@ from __future__ import division, print_function
 
 import copy
 import numpy as np
+import warnings
 
 from astropy.modeling.core import Model
 from astropy.utils.misc import isiterable
 
-#from .transforms_asdf import transform_from_json, CompositeSpectralWCS
-from .util import UnknownRegionError
+
+from .util import RegionError
+
 
 class SelectorModel(Model):
     """
@@ -21,7 +23,6 @@ class SelectorModel(Model):
 
     linear = False
     fittable = False
-    #standard_broadcasting = False
 
     def __init__(self, labels, transforms):
         # labels should be unique
@@ -148,8 +149,9 @@ class RegionsSelector(SelectorModel):
 
         unique_regions = self.get_unique_regions(result)
         if unique_regions == []:
-            warnings.warning('There are no regions with valid transforms.')
-            return
+            #warnings.warning('There are no regions with valid transforms.')
+            #return
+            raise RegionError("The input positions are not inside any region.")
         nout = self._selector[unique_regions[0]].n_outputs
         output_arrays = [np.zeros(self.regions_mask.shape, dtype=np.float) for i in range(nout)]
         for ar in output_arrays:
@@ -177,7 +179,7 @@ class RegionsSelector(SelectorModel):
             try:
                 tr = self._selector[label]
             except KeyError:
-                raise UnknownRegionError("Region {0} does not exist".format(label))
+                raise RegionError("Region {0} does not exist".format(label))
             evaluate = tr.evaluate
             parameters = tr._param_sets(raw=True)
             inputs = inputs[:2]

--- a/gwcs/tests/data/acs.hdr
+++ b/gwcs/tests/data/acs.hdr
@@ -1,0 +1,403 @@
+SIMPLE  =                    T / Fits standard                                  
+BITPIX  =                   16 / Bits per pixel                                 
+NAXIS   =                    0 / Number of axes                                 
+EXTEND  =                    T / File may contain extensions                    
+ORIGIN  = 'NOAO-IRAF FITS Image Kernel July 2003' / FITS file originator        
+IRAF-TLM= '2014-04-11T18:05:59' / Time of last modification                     
+NEXTEND =                   12 / Number of standard extensions                  
+DATE    = '2007-02-08T21:38:46' / date this file was written (yyyy-mm-dd)       
+FILENAME= 'j94f05bgq_flt.fits' / name of file                                   
+FILETYPE= 'SCI      '          / type of data found in data file                
+                                                                                
+TELESCOP= 'HST'                / telescope used to acquire data                 
+INSTRUME= 'ACS   '             / identifier for instrument used to acquire data 
+EQUINOX =               2000.0 / equinox of celestial coord. system             
+                                                                                
+              / DATA DESCRIPTION KEYWORDS                                       
+                                                                                
+ROOTNAME= 'j94f05bgq                         ' / rootname of the observation set
+IMAGETYP= 'EXT               ' / type of exposure identifier                    
+PRIMESI = 'ACS   '             / instrument designated as prime                 
+                                                                                
+              / TARGET INFORMATION                                              
+                                                                                
+TARGNAME= 'NGC104                        ' / proposer's target name             
+RA_TARG =   5.655000000000E+00 / right ascension of the target (deg) (J2000)    
+DEC_TARG=  -7.207055555556E+01 / declination of the target (deg) (J2000)        
+                                                                                
+              / PROPOSAL INFORMATION                                            
+                                                                                
+PROPOSID=                10368 / PEP proposal identifier                        
+LINENUM = '05.004         '    / proposal logsheet line number                  
+PR_INV_L= 'Riess                         ' / last name of principal investigator
+PR_INV_F= 'Adam                ' / first name of principal investigator         
+PR_INV_M= '                    ' / middle name / initial of principal investigat
+                                                                                
+              / EXPOSURE INFORMATION                                            
+                                                                                
+SUNANGLE=            67.819656 / angle between sun and V1 axis                  
+MOONANGL=            57.400970 / angle between moon and V1 axis                 
+SUN_ALT =            -5.746915 / altitude of the sun above Earth's limb         
+FGSLOCK = 'FINE              ' / commanded FGS lock (FINE,COARSE,GYROS,UNKNOWN) 
+GYROMODE= '3'                  / observation scheduled with only two gyros (Y/N)
+REFFRAME= 'GSC1    '           / guide star catalog version                     
+                                                                                
+DATE-OBS= '2005-03-07'         / UT date of start of observation (yyyy-mm-dd)   
+TIME-OBS= '06:51:26'           / UT time of start of observation (hh:mm:ss)     
+EXPSTART=   5.343628571938E+04 / exposure start time (Modified Julian Date)     
+EXPEND  =   5.343629036114E+04 / exposure end time (Modified Julian Date)       
+EXPTIME =           400.000000 / exposure duration (seconds)--calculated        
+EXPFLAG = 'NORMAL       '      / Exposure interruption indicator                
+QUALCOM1= '                                                                    '
+QUALCOM2= '                                                                    '
+QUALCOM3= '                                                                    '
+QUALITY = '                                                                    '
+                                                                                
+                                                                                
+              / POINTING INFORMATION                                            
+                                                                                
+PA_V3   =           337.125305 / position angle of V3-axis of HST (deg)         
+                                                                                
+              / TARGET OFFSETS (POSTARGS)                                       
+                                                                                
+POSTARG1=             0.000000 / POSTARG in axis 1 direction                    
+POSTARG2=             0.000000 / POSTARG in axis 2 direction                    
+                                                                                
+              / DIAGNOSTIC KEYWORDS                                             
+                                                                                
+OPUS_VER= 'OPUS 2006_6       ' / OPUS software system version number            
+CAL_VER = '4.6.1 (13-Mar-2006)' / CALACS code version                           
+PROCTIME=   5.413989813657E+04 / Pipeline processing time (MJD)                 
+                                                                                
+              / SCIENCE INSTRUMENT CONFIGURATION                                
+                                                                                
+OBSTYPE = 'IMAGING       '     / observation type - imaging or spectroscopic    
+OBSMODE = 'ACCUM     '         / operating mode                                 
+CTEIMAGE= 'NONE'               / type of Charge Transfer Image, if applicable   
+SCLAMP  = 'NONE     '          / lamp status, NONE or name of lamp which is on  
+NRPTEXP =                    1 / number of repeat exposures in set: default 1   
+SUBARRAY=                    F / data from a subarray (T) or full frame (F)     
+DETECTOR= 'WFC'                / detector in use: WFC, HRC, or SBC              
+FILTER1 = 'F606W             ' / element selected from filter wheel 1           
+FILTER2 = 'CLEAR2L           ' / element selected from filter wheel 2           
+FWOFFSET=                    0 / computed filter wheel offset                   
+FWERROR =                    F / filter wheel position error flag               
+LRFWAVE =             0.000000 / proposed linear ramp filter wavelength         
+APERTURE= 'WFC             '   / aperture name                                  
+PROPAPER= 'WFC             '   / proposed aperture name                         
+DIRIMAGE= 'NONE     '          / direct image for grism or prism exposure       
+CTEDIR  = 'NONE    '           / CTE measurement direction: serial or parallel  
+CRSPLIT =                    1 / number of cosmic ray split exposures           
+                                                                                
+              / CALIBRATION SWITCHES: PERFORM, OMIT, COMPLETE                   
+                                                                                
+STATFLAG=                    F / Calculate statistics?                          
+WRTERR  =                    T / write out error array extension                
+DQICORR = 'COMPLETE'           / data quality initialization                    
+ATODCORR= 'OMIT    '           / correct for A to D conversion errors           
+BLEVCORR= 'COMPLETE'           / subtract bias level computed from overscan img 
+BIASCORR= 'COMPLETE'           / Subtract bias image                            
+FLSHCORR= 'OMIT    '           / post flash correction                          
+CRCORR  = 'OMIT    '           / combine observations to reject cosmic rays     
+EXPSCORR= 'COMPLETE'           / process individual observations after cr-reject
+SHADCORR= 'OMIT    '           / apply shutter shading correction               
+DARKCORR= 'COMPLETE'           / Subtract dark image                            
+FLATCORR= 'COMPLETE'           / flat field data                                
+PHOTCORR= 'COMPLETE'           / populate photometric header keywords           
+RPTCORR = 'OMIT    '           / add individual repeat observations             
+DRIZCORR= 'COMPLETE'           / drizzle processing                             
+                                                                                
+              / CALIBRATION REFERENCE FILES                                     
+                                                                                
+BPIXTAB = 'jref$q860440tj_bpx.fits' / bad pixel table                           
+CCDTAB  = 'jref$o151506fj_ccd.fits' / CCD calibration parameters                
+ATODTAB = 'jref$kcb1734hj_a2d.fits' / analog to digital correction file         
+OSCNTAB = 'jref$lch1459bj_osc.fits' / CCD overscan table                        
+BIASFILE= 'jref$p3v2228mj_bia.fits' / bias image file name                      
+FLSHFILE= 'jref$nad14594j_fls.fits' / post flash correction file name           
+CRREJTAB= 'jref$n4e12511j_crr.fits' / cosmic ray rejection parameters           
+SHADFILE= 'jref$kcb17349j_shd.fits' / shutter shading correction file           
+DARKFILE= 'jref$p3v2228qj_drk.fits' / dark image file name                      
+PFLTFILE= 'jref$nar1136nj_pfl.fits' / pixel to pixel flat field file name       
+DFLTFILE= 'N/A                    ' / delta flat field file name                
+LFLTFILE= 'N/A                    ' / low order flat                            
+PHOTTAB = 'N/A                    ' / Photometric throughput table              
+GRAPHTAB= 'mtab$r1m18595m_tmg.fits' / the HST graph table                       
+COMPTAB = 'mtab$r1j2146sm_tmc.fits' / the HST components table                  
+IDCTAB  = 'postsm4_idc.fits'   / image distortion correction table              
+DGEOFILE= 'jref$qbu16424j_dxy.fits' / Distortion correction image               
+MDRIZTAB= 'jref$p3p16511j_mdz.fits' / MultiDrizzle parameter table              
+CFLTFILE= 'N/A               ' / Coronagraphic spot image                       
+SPOTTAB = 'N/A               ' / Coronagraphic spot offset table                
+                                                                                
+              / COSMIC RAY REJECTION ALGORITHM PARAMETERS                       
+                                                                                
+MEANEXP =             0.000000 / reference exposure time for parameters         
+SCALENSE=             0.000000 / multiplicative scale factor applied to noise   
+INITGUES= '   '                / initial guess method (MIN or MED)              
+SKYSUB  = '    '               / sky value subtracted (MODE or NONE)            
+SKYSUM  =                  0.0 / sky level from the sum of all constituent image
+CRSIGMAS= '               '    / statistical rejection criteria                 
+CRRADIUS=             0.000000 / rejection propagation radius (pixels)          
+CRTHRESH=             0.000000 / rejection propagation threshold                
+BADINPDQ=                    0 / data quality flag bits to reject               
+REJ_RATE=                  0.0 / rate at which pixels are affected by cosmic ray
+CRMASK  =                    F / flag CR-rejected pixels in input files (T/F)   
+                                                                                
+              / OTFR KEYWORDS                                                   
+                                                                                
+T_SGSTAR= '                  ' / OMS calculated guide star control              
+                                                                                
+              / PATTERN KEYWORDS                                                
+                                                                                
+PATTERN1= 'NONE                    ' / primary pattern type                     
+P1_SHAPE= '                  ' / primary pattern shape                          
+P1_PURPS= '          '         / primary pattern purpose                        
+P1_NPTS =                    0 / number of points in primary pattern            
+P1_PSPAC=             0.000000 / point spacing for primary pattern (arc-sec)    
+P1_LSPAC=             0.000000 / line spacing for primary pattern (arc-sec)     
+P1_ANGLE=             0.000000 / angle between sides of parallelogram patt (deg)
+P1_FRAME= '         '          / coordinate frame of primary pattern            
+P1_ORINT=             0.000000 / orientation of pattern to coordinate frame (deg
+P1_CENTR= '   '                / center pattern relative to pointing (yes/no)   
+PATTSTEP=                    0 / position number of this point in the pattern   
+                                                                                
+              / POST FLASH  PARAMETERS                                          
+                                                                                
+FLASHDUR=                  1.0 / Exposure time in seconds: 0.1 to 409.5         
+FLASHCUR= 'MED '               / Post flash current: OFF, LOW, MED, HIGH        
+FLASHSTA= 'SUCCESSFUL      '   / Status: SUCCESSFUL, ABORTED, NOT PERFORMED     
+SHUTRPOS= 'B    '              / Shutter position: A or B                       
+                                                                                
+              / ENGINEERING PARAMETERS                                          
+                                                                                
+CCDAMP  = 'ABCD'               / CCD Amplifier Readout Configuration            
+CCDGAIN =                    1 / commanded gain of CCD                          
+CCDOFSTA=                    3 / commanded CCD bias offset for amplifier A      
+CCDOFSTB=                    3 / commanded CCD bias offset for amplifier B      
+CCDOFSTC=                    3 / commanded CCD bias offset for amplifier C      
+CCDOFSTD=                    3 / commanded CCD bias offset for amplifier D      
+                                                                                
+              / CALIBRATED ENGINEERING PARAMETERS                               
+                                                                                
+ATODGNA =        9.9989998E-01 / calibrated gain for amplifier A                
+ATODGNB =        9.7210002E-01 / calibrated gain for amplifier B                
+ATODGNC =        1.0107000E+00 / calibrated gain for amplifier C                
+ATODGND =        1.0180000E+00 / calibrated gain for amplifier D                
+READNSEA=        4.9699998E+00 / calibrated read noise for amplifier A          
+READNSEB=        4.8499999E+00 / calibrated read noise for amplifier B          
+READNSEC=        5.2399998E+00 / calibrated read noise for amplifier C          
+READNSED=        4.8499999E+00 / calibrated read noise for amplifier D          
+BIASLEVA=        2.4281760E+03 / bias level for amplifier A                     
+BIASLEVB=        2.5189324E+03 / bias level for amplifier B                     
+BIASLEVC=        2.4417756E+03 / bias level for amplifier C                     
+BIASLEVD=        2.4699448E+03 / bias level for amplifier D                     
+                                                                                
+              / ASSOCIATION KEYWORDS                                            
+                                                                                
+ASN_ID  = 'NONE      '         / unique identifier assigned to association      
+ASN_TAB = 'NONE                   ' / name of the association table             
+ASN_MTYP= '            '       / Role of the Member in the Association          
+UPWCSVER= '1.1.4.dev31014'     / Version of STWCS used to updated the WCS       
+PYWCSVER= '1.12.1.dev4001'     / Version of PYWCS used to updated the WCS       
+HISTORY CCD parameters table:                                                   
+HISTORY   reference table jref$o151506fj_ccd.fits                               
+HISTORY     inflight                                                            
+HISTORY     June 2002                                                           
+HISTORY Uncertainty array initialized.                                          
+HISTORY DQICORR complete ...                                                    
+HISTORY   values checked for saturation                                         
+HISTORY   DQ array initialized ...                                              
+HISTORY   reference table jref$q860440tj_bpx.fits                               
+HISTORY BLEVCORR complete; bias level from overscan was subtracted.             
+HISTORY BLEVCORR does not include correction for drift along lines.             
+HISTORY   Overscan region table:                                                
+HISTORY   reference table jref$lch1459bj_osc.fits                               
+HISTORY BIASCORR complete ...                                                   
+HISTORY   reference image jref$p3v2228mj_bia.fits                               
+HISTORY     INFLIGHT 05/03/2005 23/03/2005                                      
+HISTORY     Superbias by Ray Lucas from proposal 10367 or 10370                 
+HISTORY CCD parameters table:                                                   
+HISTORY   reference table jref$o151506fj_ccd.fits                               
+HISTORY     inflight                                                            
+HISTORY     June 2002                                                           
+HISTORY DARKCORR complete ...                                                   
+HISTORY   reference image jref$p3v2228qj_drk.fits                               
+HISTORY     INFLIGHT 05/03/2005 23/03/2005                                      
+HISTORY     Superdark by Ray Lucas from proposal 10367 or 10370                 
+HISTORY FLATCORR complete ...                                                   
+HISTORY   reference image jref$nar1136nj_pfl.fits                               
+HISTORY     InFlight 18/04/2002 - 09/05/2002                                    
+HISTORY     F606W step +1 flat w/ mote shifted to -1 step                       
+HISTORY PHOTCORR complete ...                                                   
+HISTORY   reference table mtab$r1m18595m_tmg.fits                               
+HISTORY   reference table mtab$r1j2146sm_tmc.fits                               
+HISTORY EXPSCORR complete ...                                                   
+TDDCORR = 'PERFORM '                                                            
+WFCTDD  = 'T       '                                                            
+DISTNAME= 'j94f05bgq_postsm4-v971826kj-x5u17177j'                               
+SIPNAME = 'j94f05bgq_postsm4'                                                   
+ORIGIN  = 'NOAO-IRAF FITS Image Kernel July 2003' / FITS file originator        
+EXTNAME = 'SCI     '           / Extension name                                 
+EXTVER  =                    1 / Extension version                              
+DATE    = '2007-02-08T21:38:47' / Date FITS file was generated                  
+IRAF-TLM= '13:38:23 (20/08/2008)' / Time of last modification                   
+INHERIT =                    T / inherit the primary header                     
+EXPNAME = 'j94f05bgq                ' / exposure identifier                     
+BUNIT   = 'ELECTRONS'          / brightness units                               
+CCDCHIP =                    2 / CCD chip (1 or 2)                              
+WCSAXES =                    2 / number of World Coordinate System axes         
+CRPIX1  =               2048.0 / x-coordinate of reference pixel                
+CRPIX2  =               1024.0 / y-coordinate of reference pixel                
+CRVAL1  =        5.63056810618 / first axis value at reference pixel            
+CRVAL2  =       -72.0545718428 / second axis value at reference pixel           
+CTYPE1  = 'RA---TAN-SIP'       / the coordinate type for the first axis         
+CTYPE2  = 'DEC--TAN-SIP'       / the coordinate type for the second axis        
+CD1_1   = 1.29058667557984E-05 / partial of first axis coordinate w.r.t. x      
+CD1_2   = 5.95320245884555E-06 / partial of first axis coordinate w.r.t. y      
+CD2_1   = 5.02215195623825E-06 / partial of second axis coordinate w.r.t. x     
+CD2_2   = -1.2645010396976E-05 / partial of second axis coordinate w.r.t. y     
+LTV1    =        0.0000000E+00 / offset in X to subsection start                
+LTV2    =        0.0000000E+00 / offset in Y to subsection start                
+LTM1_1  =                  1.0 / reciprocal of sampling rate in X               
+LTM2_2  =                  1.0 / reciprocal of sampling rate in Y               
+ORIENTAT=    154.7891975615789 / position angle of image y axis (deg. e of n)   
+RA_APER =   5.655000000000E+00 / RA of aperture reference position              
+DEC_APER=  -7.207055555556E+01 / Declination of aperture reference position     
+PA_APER =              154.533 / Position Angle of reference aperture center (de
+VAFACTOR=   1.000018683511E+00 / velocity aberration plate scale factor         
+CENTERA1=                 2073 / subarray axis1 center pt in unbinned dect. pix 
+CENTERA2=                 1035 / subarray axis2 center pt in unbinned dect. pix 
+SIZAXIS1=                 4096 / subarray axis1 size in unbinned detector pixels
+SIZAXIS2=                 2048 / subarray axis2 size in unbinned detector pixels
+BINAXIS1=                    1 / axis1 data bin size in unbinned detector pixels
+BINAXIS2=                    1 / axis2 data bin size in unbinned detector pixels
+PHOTMODE= 'ACS WFC1 F606W'     / observation con                                
+PHOTFLAM=        7.9064521E-20 / inverse sensitivity, ergs/cm2/Ang/electron     
+PHOTZPT =       -2.1100000E+01 / ST magnitude zero point                        
+PHOTPLAM=        5.9176797E+03 / Pivot wavelength (Angstroms)                   
+PHOTBW  =        6.7231146E+02 / RMS bandwidth of filter plus detector          
+NCOMBINE=                    1 / number of image sets combined during CR rejecti
+FILLCNT =                    0 / number of segments containing fill             
+ERRCNT  =                    0 / number of segments containing errors           
+PODPSFF =                    F / podps fill present (T/F)                       
+STDCFFF =                    F / ST DDF fill present (T/F)                      
+STDCFFP = 'x5569 '             / ST DDF fill pattern (hex)                      
+WFCMPRSD=                    F / was WFC data compressed? (T/F)                 
+CBLKSIZ =                    0 / size of compression block in 2-byte words      
+LOSTPIX =                    0 / #pixels lost due to buffer overflow            
+COMPTYP = 'None    '           / compression type performed (Partial/Full/None) 
+NGOODPIX=              7822781 / number of good pixels                          
+SDQFLAGS=                31743 / serious data quality flags                     
+GOODMIN =       -2.5959351E+02 / minimum value of good pixels                   
+GOODMAX =        6.5220551E+04 / maximum value of good pixels                   
+GOODMEAN=        2.0491536E+02 / mean value of good pixels                      
+SOFTERRS=                    0 / number of soft error pixels (DQF=1)            
+SNRMIN  =       -8.0327058E-01 / minimum signal to noise of good pixels         
+SNRMAX  =        2.1379723E+02 / maximum signal to noise of good pixels         
+SNRMEAN =        1.0889255E+01 / mean value of signal to noise of good pixels   
+MEANDARK=        1.5474443E+00 / average of the dark values subtracted          
+MEANBLEV=        2.4558604E+03 / average of all bias levels subtracted          
+MEANFLSH=             0.000000 / Mean number of counts in post flash exposure   
+OCRVAL1 =        5.63056810618 / first axis value at reference pixel            
+OCRVAL2 =      -72.05457184279 / second axis value at reference pixel           
+OCRPIX2 =               1024.0 / y-coordinate of reference pixel                
+OCRPIX1 =               2048.0 / x-coordinate of reference pixel                
+ONAXIS2 =                 2048 / Axis length                                    
+ONAXIS1 =                 4096 / Axis length                                    
+OCD2_2  =         -1.26445E-05 / partial of second axis coordinate w.r.t. y     
+OCD2_1  =          5.02243E-06 / partial of second axis coordinate w.r.t. x     
+OORIENTA=    154.7886863186197 / position angle of image y axis (deg. e of n)   
+OCTYPE1 = 'RA---TAN'           / the coordinate type for the first axis         
+OCD1_1  =          1.29046E-05 / partial of first axis coordinate w.r.t. x      
+OCD1_2  =           5.9531E-06 / partial of first axis coordinate w.r.t. y      
+OCTYPE2 = 'DEC--TAN'           / the coordinate type for the second axis        
+WCSCDATE= '21:39:44 (08/02/2007)' / Time WCS keywords were copied.              
+A_0_2   = 2.16615952976212E-06                                                  
+B_0_2   = -7.2168814507744E-06                                                  
+A_1_1   = -5.1974576466834E-06                                                  
+B_1_1   = 6.18443235774478E-06                                                  
+A_2_0   = 8.55127758255650E-06                                                  
+B_2_0   = -1.746491877058669E-06                                                
+A_0_3   = 1.08193519820265E-11                                                  
+B_0_3   = -4.175472049274932E-10                                                
+A_1_2   = -5.234870743692412E-10                                                
+B_1_2   = -6.169265268681388E-11                                                
+A_2_1   = -3.9771547747287E-11                                                  
+B_2_1   = -5.0857161673862E-10                                                  
+A_3_0   = -4.7304448292227E-10                                                  
+B_3_0   = 8.56763542781631E-11                                                  
+A_0_4   = 1.49356171166049E-14                                                  
+B_0_4   = -9.9570490655478E-15                                                  
+A_1_3   = -2.4569975537746E-14                                                  
+B_1_3   = 1.21743011568848E-14                                                  
+A_2_2   = 3.46791267104378E-14                                                  
+B_2_2   = -3.66143259286574E-14                                                 
+A_3_1   = 1.97102297166030E-15                                                  
+B_3_1   = -3.779506805487476E-15                                                
+A_4_0   = 2.37430106240231E-14                                                  
+B_4_0   = -1.7687653826004E-14                                                  
+A_ORDER =                    4                                                  
+B_ORDER =                    4                                                  
+CPERR1  =  0.08311891555786133 / Maximum error of NPOL correction for axis 1    
+CPERR2  =   0.0758458599448204 / Maximum error of NPOL correction for axis 2    
+TDDALPHA=  0.03676157754622637                                                  
+TDDBETA = -0.00958719251540879                                                  
+IDCSCALE=                 0.05                                                  
+IDCV2REF=    256.6222229003906                                                  
+IDCV3REF=    302.2264099121094                                                  
+IDCTHETA=                  0.0                                                  
+OCX10   = 0.001959713482071437                                                  
+OCX11   =  0.04983122487595928                                                  
+OCY10   =  0.05027393143048926                                                  
+OCY11   =  0.00148847536166365                                                  
+SORIENTA=    154.7925383197021 / position angle of image y axis (deg. e of n)   
+SCRVAL1 =        5.63056810618 / first axis value at reference pixel            
+SNAXIS2 =                 2048 / Axis length                                    
+SNAXIS1 =                 4096 / Axis length                                    
+SCRVAL2 =      -72.05457184279 / second axis value at reference pixel           
+SCTYPE1 = 'RA---TAN-SIP'       / the coordinate type for the first axis         
+SCTYPE2 = 'DEC--TAN-SIP'       / the coordinate type for the second axis        
+SCD2_2  = -1.264489181627715E-05 / partial of second axis coordinate w.r.t. y   
+SCD2_1  = 5.022886862247075E-06 / partial of second axis coordinate w.r.t. x    
+SCD1_2  = 5.952245949610081E-06 / partial of first axis coordinate w.r.t. y     
+SCRPIX2 =               1024.0 / y-coordinate of reference pixel                
+SCRPIX1 =               2048.0 / x-coordinate of reference pixel                
+SCD1_1  = 1.290545120875315E-05 / partial of first axis coordinate w.r.t. x     
+IDCXREF =               2048.0                                                  
+IDCYREF =               1024.0                                                  
+WCSNAMEO= 'OPUS    '                                                            
+WCSAXESO=                    2                                                  
+CRPIX1O =                 2048                                                  
+CRPIX2O =                 1024                                                  
+CDELT1O =                    1                                                  
+CDELT2O =                    1                                                  
+CUNIT1O = 'deg     '                                                            
+CUNIT2O = 'deg     '                                                            
+CTYPE1O = 'RA---TAN-SIP'                                                        
+CTYPE2O = 'DEC--TAN-SIP'                                                        
+CRVAL1O =        5.63056810618                                                  
+CRVAL2O =       -72.0545718428                                                  
+LONPOLEO=                  180                                                  
+LATPOLEO=       -72.0545718428                                                  
+RESTFRQO=                    0                                                  
+RESTWAVO=                    0                                                  
+CD1_1O  =    1.29056256334E-05                                                  
+CD1_2O  =     5.9530912342E-06                                                  
+CD2_1O  =    5.02205812656E-06                                                  
+CD2_2O  =   -1.26447741482E-05                                                  
+IDCTAB  = 'postsm4_idc.fits'                                                    
+WCSNAME = 'IDC_postsm4'                                                         
+NPOLEXT = 'jref$v971826kj_npl.fits'                                             
+              / WFC CCD CHIP IDENTIFICATION                                     
+              / World Coordinate System and Related Parameters                  
+              / READOUT DEFINITION PARAMETERS                                   
+              / PHOTOMETRY KEYWORDS                                             
+              / REPEATED EXPOSURES INFO                                         
+              / DATA PACKET INFORMATION                                         
+              / ON-BOARD COMPRESSION INFORMATION                                
+              / IMAGE STATISTICS AND DATA QUALITY FLAGS                         
+HISTORY The following throughput tables were used: crotacomp$hst_ota_007_syn.fit
+HISTORY s, cracscomp$acs_wfc_im123_004_syn.fits, cracscomp$acs_f606w_005_syn.fit
+HISTORY s, cracscomp$acs_wfc_ebe_win12f_005_syn.fits, cracscomp$acs_wfc_ccd1_017
+HISTORY _syn.fits                                                               

--- a/gwcs/tests/test_coordinate_systems.py
+++ b/gwcs/tests/test_coordinate_systems.py
@@ -1,22 +1,22 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from astropy import units as u
 from astropy import coordinates as coo
-from .. import coordinate_frames as cs
+from .. import coordinate_frames as cf
 from .. import spectral_builtin_frames
 
 icrs=coo.ICRS()
 fk5 = coo.FK5()
-cel1 = cs.CelestialFrame(icrs)
-cel2 = cs.CelestialFrame(fk5)
+cel1 = cf.CelestialFrame(icrs)
+cel2 = cf.CelestialFrame(fk5)
 
 freq=spectral_builtin_frames.Frequency()
 wave=spectral_builtin_frames.Wavelength()
-spec1 = cs.SpectralFrame(freq)
-spec2 = cs.SpectralFrame(wave)
+spec1 = cf.SpectralFrame(freq)
+spec2 = cf.SpectralFrame(wave)
 
-comp1 = cs.CompositeFrame([cel1, spec1])
-comp2 = cs.CompositeFrame([cel2, spec2])
-comp = cs.CompositeFrame([comp1, comp2])
+comp1 = cf.CompositeFrame([cel1, spec1])
+comp2 = cf.CompositeFrame([cel2, spec2])
+comp = cf.CompositeFrame([comp1, comp2])
 
 def test_units():
     assert(comp1.unit == [u.deg, u.deg, u.Hz])
@@ -24,7 +24,7 @@ def test_units():
     assert(comp.unit == [u.deg, u.deg, u.Hz, u.deg, u.deg, u.m])
 
 def test_transform_to():
-    spec = cs.SpectralFrame(wave, unit=u.micron)
+    spec = cf.SpectralFrame(wave, unit=u.micron)
     q = spec.transform_to(5, freq)
     assert(isinstance(q, spectral_builtin_frames.Frequency))
     assert(q.freq == 59958491600000.01 * u.Hz)

--- a/gwcs/tests/test_wcs.py
+++ b/gwcs/tests/test_wcs.py
@@ -93,10 +93,6 @@ class TestImaging(object):
 
     def test_forward(self):
         sky_coord = self.wcs(self.xv, self.yv)
-        #ra = np.array([[ 5.5263946 ,  5.52639421,  5.52639382,  5.52639343,  5.52639304],
-                       #[ 5.52639473,  5.52639434,  5.52639395,  5.52639356,  5.52639317]])
-        #dec = np.array([[-72.0517097 , -72.05170975, -72.05170979, -72.05170984, -72.05170989],
-                        #[-72.05170966, -72.05170971, -72.05170976, -72.05170981, -72.05170986]])
         ra, dec = self.fitsw.all_pix2world(self.xv, self.yv, 1)
         assert_almost_equal(sky_coord[0], ra)
         assert_almost_equal(sky_coord[1], dec)
@@ -110,8 +106,8 @@ class TestImaging(object):
 
     def test_footprint(self):
         footprint = self.wcs.footprint((4096, 2048))
-        #wfits.footprint()
-        #assert_almost_equal([footprint.ra.value, footprint.dec.value], fits_footprint)
+        fits_footprint = self.fitsw.calc_footprint(axes=(4096, 2048))
+        assert_allclose(footprint, fits_footprint)
 
     def test_inverse(self):
         sky_coord = self.wcs(1, 2)
@@ -120,13 +116,6 @@ class TestImaging(object):
 
     def test_units(self):
         assert(self.wcs.unit == [u.degree, u.degree])
-
-    #def test_slicing(self):
-        #foc2sky = self.wcs.forward_transform['x_translation' : ]
-        #foc2sky2 = self.wcs.forward_transform['x_translation' : 'sky_rotation']
-        #foc2sky3 = self.wcs.forward_transform[1 : ]
-        #assert (foc2sky.submodel_names == foc2sky2.submodel_names)
-        #assert (foc2sky.submodel_names == foc2sky3.submodel_names)
 
 
     def test_get_transform(self):

--- a/gwcs/tests/test_wcs.py
+++ b/gwcs/tests/test_wcs.py
@@ -1,27 +1,65 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 import numpy as np
-from numpy.testing import assert_almost_equal
+from numpy.testing import assert_almost_equal, assert_allclose
 from astropy.modeling import models
 from astropy import coordinates as coord
 from astropy.io import fits
 from astropy import units as u
 from astropy.tests.helper import pytest
 from astropy.utils.data import get_pkg_data_filename
+from astropy import wcs as astwcs
 
-from ..wcs import WCS
-from .. import coordinate_frames as cs
+from .. import wcs
+from .. import coordinate_frames as cf
+
+
+def test_create_wcs():
+    m = models.Shift(12.4)
+    icrs = cf.CelestialFrame(coord.ICRS())
+    det = cf.DetectorFrame()
+    gw1 = wcs.WCS(output_frame='icrs', input_frame='detector', forward_transform=m)
+    gw2 = wcs.WCS(output_frame='icrs', forward_transform=m)
+    gw3 = wcs.WCS(output_frame=icrs, input_frame=det, forward_transform=m)
+    assert(gw1._input_frame == gw2._input_frame == gw3._input_frame == 'detector')
+    assert(gw1._output_frame == gw2._output_frame == gw3._output_frame == 'icrs')
+    assert(gw1.forward_transform.__class__ == gw2.forward_transform.__class__ == gw3.forward_transform.__class__ == m.__class__)
+    assert(gw1._coord_frames == gw2._coord_frames == {'detector': None, 'icrs': None})
+
+
+def test_pipeline_init():
+    gw = wcs.WCS(output_frame='icrs')
+    assert gw._pipeline == [('detector', None), ('icrs', None)]
+    assert(gw.available_frames == {'detector' : None, 'icrs': None})
+    icrs = cf.CelestialFrame(coord.ICRS())
+    det = cf.DetectorFrame()
+    gw = wcs.WCS(output_frame=icrs, input_frame=det)
+    assert gw._pipeline == [('detector', None), ('icrs', None)]
+    assert(gw.available_frames == {'detector' : det, 'icrs': icrs})
+
+
+def test_insert_transform():
+    m1 = models.Shift(12.4)
+    m2 = models.Scale(3.1)
+    gw = wcs.WCS(output_frame='icrs', forward_transform=m1)
+    assert(gw.forward_transform(1.2) == m1(1.2))
+    gw.insert_transform(frame='icrs', transform=m2)
+    assert(gw.forward_transform(1.2) == (m1 | m2)(1.2))
+
+
+
 
 class TestImaging(object):
     def setup_class(self):
-        hdr = fits.Header.fromtextfile(get_pkg_data_filename("data/acs_wfc.hdr"), endcard=False)
+        hdr = fits.Header.fromtextfile(get_pkg_data_filename("data/acs.hdr"), endcard=False)
+        self.fitsw = astwcs.WCS(hdr)
         a_coeff = hdr['A_*']
         a_order = a_coeff.pop('A_ORDER')
         b_coeff = hdr['B_*']
         b_order = b_coeff.pop('B_ORDER')
 
         crpix = [hdr['CRPIX1'], hdr['CRPIX2']]
-        distortion = models.SIP(crpix, a_order, b_order, a_coeff, b_coeff, name='sip_distorion')
+        distortion = models.SIP(crpix, a_order, b_order, a_coeff, b_coeff, name='sip_distorion') + models.Identity(2)
 
         cdmat = np.array([[hdr['CD1_1'], hdr['CD1_2']], [hdr['CD2_1'], hdr['CD2_2']]])
         aff = models.AffineTransformation2D(matrix=cdmat, name='rotation')
@@ -37,12 +75,16 @@ class TestImaging(object):
         n2c = models.RotateNative2Celestial(phi, lon, theta, name='sky_rotation')
 
         tan = models.Pix2Sky_TAN(name='tangent_projection')
+        sky_cs = cf.CelestialFrame(reference_frame=coord.ICRS())
+        wcs_forward = wcslin | tan | n2c
+        pipeline = [('detector', distortion),
+                    ('focal', wcs_forward),
+                    (sky_cs, None)
+                    ]
 
-        wcs_forward = distortion | wcslin | tan | n2c
-        sky_cs = cs.CelestialFrame(reference_frame=coord.ICRS())
-        self.wcs = WCS(input_coordinate_system = 'detector',
-                     output_coordinate_system = sky_cs,
-                     forward_transform = wcs_forward)
+        self.wcs = wcs.WCS(input_frame = 'detector',
+                     output_frame = sky_cs,
+                     forward_transform = pipeline)
         nx, ny = (5, 2)
         x = np.linspace(0, 1, nx)
         y = np.linspace(0, 1, ny)
@@ -51,12 +93,20 @@ class TestImaging(object):
 
     def test_forward(self):
         sky_coord = self.wcs(self.xv, self.yv)
-        ra = np.array([[ 5.5263946 ,  5.52639421,  5.52639382,  5.52639343,  5.52639304],
-                       [ 5.52639473,  5.52639434,  5.52639395,  5.52639356,  5.52639317]])
-        dec = np.array([[-72.0517097 , -72.05170975, -72.05170979, -72.05170984, -72.05170989],
-                        [-72.05170966, -72.05170971, -72.05170976, -72.05170981, -72.05170986]])
-        assert_almost_equal(sky_coord.ra.value, ra)
-        assert_almost_equal(sky_coord.dec.value, dec)
+        #ra = np.array([[ 5.5263946 ,  5.52639421,  5.52639382,  5.52639343,  5.52639304],
+                       #[ 5.52639473,  5.52639434,  5.52639395,  5.52639356,  5.52639317]])
+        #dec = np.array([[-72.0517097 , -72.05170975, -72.05170979, -72.05170984, -72.05170989],
+                        #[-72.05170966, -72.05170971, -72.05170976, -72.05170981, -72.05170986]])
+        ra, dec = self.fitsw.all_pix2world(self.xv, self.yv, 1)
+        assert_almost_equal(sky_coord[0], ra)
+        assert_almost_equal(sky_coord[1], dec)
+
+    def test_backward(self):
+        transform = self.wcs.get_transform(from_frame='focal', to_frame=self.wcs.output_frame)
+        sky_coord = self.wcs.transform('focal', self.wcs.output_frame, self.xv, self.yv)
+        px_coord = transform.inverse(*sky_coord)
+        assert_allclose(px_coord[0], self.xv, atol=10**-6)
+        assert_allclose(px_coord[1], self.yv, atol=10**-6)
 
     def test_footprint(self):
         footprint = self.wcs.footprint((4096, 2048))
@@ -66,28 +116,21 @@ class TestImaging(object):
     def test_inverse(self):
         sky_coord = self.wcs(1, 2)
         with pytest.raises(NotImplementedError) as exc:
-            detector_coord = self.wcs.invert(sky_coord.ra.value, sky_coord.dec.value)
+            detector_coord = self.wcs.invert(sky_coord[0], sky_coord[1])
 
     def test_units(self):
         assert(self.wcs.unit == [u.degree, u.degree])
 
-    def test_slicing(self):
-        foc2sky = self.wcs.forward_transform['x_translation' : ]
-        foc2sky2 = self.wcs.forward_transform['x_translation' : 'sky_rotation']
-        foc2sky3 = self.wcs.forward_transform[1 : ]
-        assert (foc2sky.submodel_names == foc2sky2.submodel_names)
-        assert (foc2sky.submodel_names == foc2sky3.submodel_names)
+    #def test_slicing(self):
+        #foc2sky = self.wcs.forward_transform['x_translation' : ]
+        #foc2sky2 = self.wcs.forward_transform['x_translation' : 'sky_rotation']
+        #foc2sky3 = self.wcs.forward_transform[1 : ]
+        #assert (foc2sky.submodel_names == foc2sky2.submodel_names)
+        #assert (foc2sky.submodel_names == foc2sky3.submodel_names)
 
-    def output_coordinate_system(self):
-        #need to impement equality
-        pass
-
-
-    def test_name(self):
-        pass
 
     def test_get_transform(self):
-        #with valid and invalid cs
-        assert(self.wcs.get_transform('x_translation', 'sky_rotation').submodel_names ==
-               self.wcs.forward_transform[1:].submodel_names)
+        with pytest.raises(wcs.CoordinateFrameError):
+            assert(self.wcs.get_transform('x_translation', 'sky_rotation').submodel_names ==
+                   self.wcs.forward_transform[1:].submodel_names)
 

--- a/gwcs/util.py
+++ b/gwcs/util.py
@@ -5,7 +5,7 @@ Utility function for WCS
 from __future__ import division, print_function
 
 import numpy as np
-from jwst_lib.modeling.projections import projcodes
+from astropy.modeling.projections import projcodes
 try:
     from astropy import time
     HAS_TIME = True

--- a/gwcs/util.py
+++ b/gwcs/util.py
@@ -5,7 +5,7 @@ Utility function for WCS
 from __future__ import division, print_function
 
 import numpy as np
-from astropy.modeling.projections import projcodes
+from jwst_lib.modeling.projections import projcodes
 try:
     from astropy import time
     HAS_TIME = True
@@ -37,7 +37,7 @@ class ModelDimensionalityError(Exception):
         super(ModelDimensionalityError, self).__init__()
 
 
-class UnknownRegionError(Exception):
+class RegionError(Exception):
     def __init__(self, message):
         self.message = message
         super(UnknownRegionError, self).__init__()

--- a/gwcs/wcs.py
+++ b/gwcs/wcs.py
@@ -188,11 +188,6 @@ class WCS(object):
             frame_obj = frame
         return name, frame_obj
 
-    @property
-    def name(self):
-        """Return the name for this WCS."""
-        return self._name
-
 
     def __call__(self, *args):
         """
@@ -204,10 +199,6 @@ class WCS(object):
         """
         if self.forward_transform is not None:
             return self.forward_transform(*args)
-        #if self.output_coordinate_system is not None:
-            #return self.output_coordinate_system.world_coordinates(*result)
-        #else:
-            #return result
 
     def invert(self, *args, **kwargs):
         """
@@ -312,6 +303,11 @@ class WCS(object):
         else:
             return self._input_frame
 
+    @property
+    def name(self):
+        """Return the name for this WCS."""
+        return self._name
+
     @name.setter
     def name(self, value):
         """Set the name for the WCS."""
@@ -344,7 +340,8 @@ class WCS(object):
                                 [0.5, naxis2 + 0.5],
                                 [naxis1 + 0.5, naxis2 + 0.5],
                                 [naxis1 + 0.5, 0.5]], dtype = np.float64)
-        return self.__call__(corners[:,0], corners[:,1])
+        result =  self.__call__(corners[:,0], corners[:,1])
+        return np.asarray(result).T
         #result = np.vstack(self.__call__(corners[:,0], corners[:,1])).T
         #try:
             #return self.output_coordinate_system.world_coordinates(result[:,0], result[:,1])

--- a/gwcs/wcs.py
+++ b/gwcs/wcs.py
@@ -1,12 +1,14 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import division, print_function
 
+import functools
 import numpy as np
+from astropy.extern import six
+from astropy.io import fits
 from astropy.modeling import models
+from astropy.utils import isiterable
 
-
-#from . import coordinate_frames
-
+from . import coordinate_frames
 from .util import ModelDimensionalityError, CoordinateFrameError
 from .selector import *
 
@@ -16,61 +18,89 @@ __all__ = ['WCS']
 
 class WCS(object):
     """
-    Basic WCS class
+    Basic WCS class.
 
     Parameters
     ----------
-    output_coordinate_system : str, gwcs.coordinate_frames.CoordinateFrame
+    output_coordinate_system : str, `~gwcs.coordinate_frames.CoordinateFrame`
         A coordinates object or a string label
-    input_coordinate_system : str, gwcs.coordinate_frames.CoordinateFrame
+    input_coordinate_system : str, `~gwcs.coordinate_frames.CoordinateFrame`
         A coordinates object or a string label
-    forward_transform : astropy.modeling.Model
+    forward_transform : `~astropy.modeling.Model`
         a model to do the forward transform
     name : str
         a name for this WCS
     """
     def __init__(self, output_coordinate_system,  input_coordinate_system='detector',
                  forward_transform=None, name=""):
-        self._forward_transform = forward_transform
-        self._input_coordinate_system = input_coordinate_system
-        self._output_coordinate_system = output_coordinate_system
+        self._coord_frames = {}
+        self._pipeline = {}
+        if isinstance(input_coordinate_system, six.string_types):
+            self._input_coordinate_system = input_coordinate_system
+            self._coord_frames[self._input_coordinate_system] = None
+        else:
+            self._input_coordinate_system = input_coordinate_system.name
+            self._coord_frames[self._input_coordinate_system] = input_coordinate_system
+        if isinstance(output_coordinate_system, six.string_types):
+            self._output_coordinate_system = output_coordinate_system
+            self._coord_frames[self._output_coordinate_system] = None
+        else:
+            self._output_coordinate_system = output_coordinate_system.name
+            self._coord_frames[self._output_coordinate_system] = output_coordinate_system
         self._name = name
-        '''
-        if forward_transform is not None and input_coordinate_system is not None \
-           and output_coordinate_system is not None:
-            self._pipeline.add_transform(self._input_coordinate_system.__class__,
-                                         self._output_coordinate_system.__class__,
-                                         forward_transform)
-        '''
+        if forward_transform is not None:
+            self.add_transform(self.input_coordinate_system,
+                               self.output_coordinate_system,
+                               forward_transform)
 
     @property
     def unit(self):
         """The unit of the coordinates in the output coordinate system."""
-        return self._output_coordinate_system._unit
+        try:
+            return self._coord_frames[self._output_coordinate_system].unit
+        except AttributeError:
+            return None
 
     @property
     def output_coordinate_system(self):
-        return self._output_coordinate_system
+        """Return the output coordinate system."""
+        if self._coord_frames[self._output_coordinate_system] is not None:
+            return self._coord_frames[self._output_coordinate_system]
+        else:
+            return self._output_coordinate_system
 
     @property
     def input_coordinate_system(self):
-        return self._input_coordinate_system
+        """Return the input coordinate system."""
+        if self._coord_frames[self._input_coordinate_system] is not None:
+            return self._coord_frames[self._input_coordinate_system]
+        else:
+            return self._input_coordinate_system
 
     @property
     def forward_transform(self):
-        return self._forward_transform
+        """ Return the total forward transform - from input to output coordinate system."""
+        return self.get_transform(self._input_coordinate_system, self._output_coordinate_system)
 
-    @forward_transform.setter
-    def forward_transform(self, value):
-        self._forward_transform = value.copy()
+    @property
+    def backward_transform(self):
+        """
+        Return the total backward transform if available - from output to input coordinate system.
+        """
+        try:
+            backward = self.forward_transform.inverse
+            return backward
+        except NotImplementedError:
+            return None
 
     @property
     def name(self):
-        """ Name for this WCS (optional)."""
+        """Name for this WCS."""
         return self._name
 
     @name.setter
     def name(self, value):
+        """Set the name for the WCS."""
         self._name = value
 
     def __call__(self, *args):
@@ -78,16 +108,15 @@ class WCS(object):
         Executes the forward transform.
 
         args : float or array-like
-            Coordinates in the input coordinate system, separate inputs for each dimension.
-
+            Inputs in the input coordinate system, separate inputs for each dimension.
 
         """
-        if self._forward_transform is not None:
-            result = self._forward_transform(*args)
-        if self.output_coordinate_system is not None:
-            return self.output_coordinate_system.world_coordinates(*result)
-        else:
-            return result
+        if self.forward_transform is not None:
+            return self.forward_transform(*args)
+        #if self.output_coordinate_system is not None:
+            #return self.output_coordinate_system.world_coordinates(*result)
+        #else:
+            #return result
 
     def invert(self, *args, **kwargs):
         """
@@ -114,52 +143,97 @@ class WCS(object):
         """
         raise NotImplementedError
 
-    def transform(self, fromsys, tosys, *args):
+    def transform(self, from_frame, to_frame, *args):
         """
-        Perform coordinate transformation beteen two frames inclusive.
+        Transform potitions between two frames.
+
 
         Parameters
         ----------
-        fromsys : CoordinateFrame
-            an instance of CoordinateFrame
-        tosys : CoordinateFrame
-            an instance of CoordinateFrame
+        from_frame : str or `~gwcs.coordinate_frame.CoordinateFrame`
+            Initial coordinate frame.
+        to_frame : str, or instance of `~gwcs.cordinate_frames.CoordinateFrame`
+            Coordinate frame into which to transform.
         args : float
             input coordinates to transform
         """
-        transform = self._forward_transform[fromsys : tosys]
+        transform = self.get_transform(from_frame, to_frame)
         return transform(*args)
 
 
-    def get_transform(self, fromsys, tosys):
+    def get_transform(self, from_frame, to_frame):
         """
-        Return a transform between two coordinate frames inclusive.
+        Return a transform between two coordinate frames
 
         Parameters
         ----------
-        fromsys : CoordinateFrame
-            an instance of CoordinateFrame
-        tosys : CoordinateFrame
-            an instance of CoordinateFrame
+        from_frame : str or `~gwcs.coordinate_frame.CoordinateFrame`
+            Initial coordinate frame.
+        to_frame : str, or instance of `~gwcs.cordinate_frames.CoordinateFrame`
+            Coordinate frame into which to transform.
         """
-        try:
-            return self._forward_transform[fromsys : tosys]
-        except ValueError:
-            try:
-                transform = self._forward_transform[tosys : fromsys]
-            except ValueError:
-                return None
-            try:
-                return transform.inverse
-            except NotImplementedError:
-                return None
+        if not self._pipeline:
+            return None
+        if not isinstance(from_frame, six.string_types):
+            from_frame = from_frame.name
+        if not isinstance(to_frame, six.string_types):
+            to_frame = to_frame.name
+        if from_frame not in self.available_frames:
+            raise ValueError("Frame {0} is not in the available frames".format(from_frame))
+        if to_frame not in self.available_frames:
+            raise ValueError("Frame {0} is not in the available frames".format(to_frame))
+        transforms = []
+        frame = from_frame
+        while frame != to_frame:
+            frame, transform = self._pipeline[frame].items()[0]
+            transforms.append(transform)
+
+        return functools.reduce(lambda x, y: x | y , transforms)
 
     @property
     def available_frames(self):
         """
-        Print the names of the available coordinate frames.
+        List all frames in this WCS object.
+
+        Returns
+        -------
+        available_frames : dict
+            {frame_name: frame_object or None}
         """
-        return self.forward_transform.submodel_names
+        return self._coord_frames
+
+    def add_transform(self, from_frame, to_frame, transform):
+        """
+        Add a transform between two coordinate frames.
+
+        At least one of the frames must already exist in the pipeline.
+        If both already exist, the transform relaces the existing transform.
+
+        Parameters
+        ----------
+        from_frame : str or `~gwcs.coordinate_frame.CoordinateFrame`
+            Coordinate frame.
+        to_frame : str, or instance of `~gwcs.cordinate_frames.CoordinateFrame`
+            Coordinate frame.
+        transform : `~astropy.modeling.Model`
+            Transform.
+        """
+        if isinstance(from_frame, six.string_types):
+            from_name = from_frame
+            from_frame_obj = None
+        else:
+            from_name = from_frame.name
+            from_frame_obj = from_frame
+
+        if isinstance(to_frame, six.string_types):
+            to_name = to_frame
+            to_frame_obj = None
+        else:
+            to_name = to_frame.name
+            to_frame_obj = to_frame
+        self._pipeline[from_name] = {to_name: transform}
+        self._coord_frames[from_name] = from_frame_obj
+        self._coord_frames[to_name] = to_frame_obj
 
     def footprint(self, axes, center=True):
         """

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,3 +24,4 @@ license = BSD
 url = http://gwcs.readthedocs.org/en/latest/
 edit_on_github = False
 github_project = spacetelescope/gwcs
+


### PR DESCRIPTION
This PR implements the WCS pipeline.
The pipeline represents a linear path from input to output coordinate frame but it is possible that this path is a composite of several paths if intermediate coordinate frames are defined.
The total path is implemented as a dictionary (`WCS._pipeline`) whose keys are the names of the coordinate frames at the beginning of a path and values are dictionaries with key, value pairs equal to 
{name_of_final_coordsys_in_a_path: transform}. For example, the transformation detector->focal_plane->sky will be represented like

```
wcs._pipeline = {'detector': {'focal_plane': det2foc_tranform},
                          'focal_plane', : {'sky': foc2sky_transform}
                         }
```

Note that all coordinate systems are represented with their names (strings). There's a separate dictionary,
accessed through `wcs.available_frames` which holds the mapping between the names of the coordinate frames and the concrete coordinate frame objects.

There are examples in the documentation but for the purpose of explaining the implementation here's a subset of the API it supports. 

```
wobj = WCS(input_coordinate_system="detector", output_coordinate_system="icrs", forward_transform)
wobj.available_frames
Out[13]: {'detector': None, 'icrs': None}
wobj._pipeline
Out[14]: {'detector': {'icrs': <CompoundModel1(offset_0=1.0, offset_1=2.0)>}}

or 

det = gwcs.DetectorFrame()
celestial = gwcs.CelestialFrame(reference_frame=coord.ICRS())

wobj=wcs.WCS(input_coordinate_system=det, output_coordinate_system=celestial, forward_transform=transform)

wobj.available_frames
Out[21]: 
{'detector': <DetectorFrame(axes_order=(0, 1), name=detector, reference_position=Local,       axes_names=['x', 'y'],
 'icrs': <CelestialFrame(reference_frame=<ICRS Frame>, axes_order=(0, 1), reference_position=Barycenter,         unit=[Unit("deg"), Unit("deg")], name=icrs)>}

 wobj._pipeline
Out[22]: {'detector': {'icrs': <CompoundModel1(offset_0=1.0, offset_1=2.0)>}}

```

Also it is possible to incrementally add transforms/frames:

```
wobj=wcs.WCS(output_coordinate_system=celestial)
wobj.add_transform(det, focal, m1)
wobj.add_transform(focal, celestial, m2)
wobj._pipeline
Out[28]: 
{'detector': {'focal_plane': <Shift(offset=1.0, name='m1')>},
 'focal_plane': {'icrs': <Shift(offset=2.0, name='m2')>}}
wobj.available_frames
Out[29]: 
{'detector': <DetectorFrame(axes_order=(0, 1), name=detector, reference_position=Local,         axes_names=['x', 'y'],
 'focal_plane': <FocalPlane(axes_order={2}, reference_frame={3}, reference_position{4},,
 'icrs': <CelestialFrame(reference_frame=<ICRS Frame>, axes_order=(0, 1), reference_position=Barycenter,         unit=[Unit("deg"), Unit("deg")], name=icrs)>}

```
The `add_transform()` method works with coordinate frame objects and with coordinate frame names.
`get_transform` works with names only.

One open question is what should the call to the WCS object return - numbers or world coordinates. The main example in the "Getting started" documentation section returns SkyCoord objects. The section with the "Imaging Example" returns numbers. I don't see a clear preferred way to do this. In some cases the result of the WCS transformation will be used in other calculations which means returning  numbers is better. In some cases the result will be used to transform the coordinates to other systems, so coordinate objects are better. It isn't straightforward to return Coordinate objects and get their values since in astropy.coordinates depending on the system the objetcs have different names, as in `skycoord.ra.value, skycoord.dec.value` vs `skycoord.l.value, skycoord.b.value`. If this is the approach we take then possible a WorldCoordinates object which wraps the different coordinate objects can be used. 