### PR TITLE
add new selector model

### DIFF
--- a/docs/gwcs/selector_model.rst
+++ b/docs/gwcs/selector_model.rst
@@ -17,9 +17,9 @@ The image above shows the projection of the 6 slits on the detector and represen
 
 Assuming the transforms from pixel to world coordinates for each slit are named "p2w_#", where "#" is the slit label, the pixel to world transform for the entire IFU can be created:
 
-  >>> slit_labels = [1, 2, 3, 4, 5, 6]
-  >>> slit_transforms = [p2w_1, p2w_2, p2w_3, p2w_4, p2w_5, p2w_6]
-  >>> forward = gwcs.RegionsSelector(mask, labels=slit_labels, transforms=slit_transforms, undefined_transform_value=np.nan)
+  >>> mapping = {1: p2w_1, 2: p2w_2, 3: p2w_3, 4: p2w_4, 5: p2w_5, 6: p2w_6]
+  >>> mask = selector.SelectorMask(masked_array)
+  >>> forward = gwcs.RegionsSelector(inputs=['x','y'], outputs=['ra', 'dec', 'lam'], selector=mapping, mask=mask, undefined_transform_value=np.nan)
 
 We have chosen in this example to set the world coordinate value for pixels which do not belong to any slit to NaN but any number is an acceptable value.
 

--- a/gwcs/coordinate_frames.py
+++ b/gwcs/coordinate_frames.py
@@ -27,6 +27,7 @@ STANDARD_REFERENCE_POSITION = ["GEOCENTER", "BARYCENTER", "HELIOCENTER",
 
 
 class CoordinateFrame(object):
+
     """
     Base class for CoordinateFrames
 
@@ -47,6 +48,7 @@ class CoordinateFrame(object):
     name : str
         Name of this frame.
     """
+
     def __init__(self, naxes, axes_order=(0, 1), reference_frame=None, reference_position=None,
                  unit=None, axes_names=None, name=None):
         """ Initialize a frame"""
@@ -100,10 +102,10 @@ class CoordinateFrame(object):
             return ""
         '''
         fmt = "<{0}({1}, axes_order={2}, reference_frame={3}, reference_position{4}," \
-        "unit={5}, axes_names={6}, name={7})>".format(
-            self.__class__.__name__, self.naxes, self.axes_order,
-            self.reference_frame, self.reference_position, self.unit,
-            self.axes_names, self.name)
+            "unit={5}, axes_names={6}, name={7})>".format(
+                self.__class__.__name__, self.naxes, self.axes_order,
+                self.reference_frame, self.reference_position, self.unit,
+                self.axes_names, self.name)
         return fmt
 
     def __str__(self):
@@ -158,10 +160,8 @@ class CoordinateFrame(object):
         raise NotImplementedError("Subclasses may implement this")
 
 
-
-
-
 class CelestialFrame(CoordinateFrame):
+
     """
     Celestial Frame Representation
 
@@ -184,7 +184,7 @@ class CelestialFrame(CoordinateFrame):
         if reference_frame.name.upper() in coord.builtin_frames.__all__:
             axes_names = reference_frame.representation_component_names.keys()[:2]
         super(CelestialFrame, self).__init__(naxes=2, reference_frame=reference_frame,
-                                             unit=unit, axes_order= axes_order,
+                                             unit=unit, axes_order=axes_order,
                                              reference_position=reference_position,
                                              axes_names=axes_names, name=name)
 
@@ -203,10 +203,9 @@ class CelestialFrame(CoordinateFrame):
 
         fmt = "<CelestialFrame(reference_frame={0}, axes_order={1}, reference_position={2}, \
         unit={3}, name={4})>".format(
-                                 self.reference_frame, self.axes_order,
-                                 self.reference_position, self.unit, self.name)
+            self.reference_frame, self.axes_order,
+            self.reference_position, self.unit, self.name)
         return fmt
-
 
     def transform_to(self, lat, lon, other):
         """
@@ -223,6 +222,7 @@ class CelestialFrame(CoordinateFrame):
 
 
 class SpectralFrame(CoordinateFrame):
+
     """
     Represents Spectral Frame
 
@@ -278,6 +278,7 @@ class SpectralFrame(CoordinateFrame):
 
 
 class CompositeFrame(CoordinateFrame):
+
     """
     Represents one or more frames.
 
@@ -289,6 +290,7 @@ class CompositeFrame(CoordinateFrame):
         Name for this frame.
 
     """
+
     def __init__(self, frames, name=""):
         """
         naxes, axes_order=(0, 1), reference_frame=None, reference_position=None,
@@ -325,7 +327,7 @@ class CompositeFrame(CoordinateFrame):
         result = ()
         n = 0
         for frame in self.frames:
-            result += (frame.world_coordinates(*args[n : frame.naxes + n]), )
+            result += (frame.world_coordinates(*args[n: frame.naxes + n]), )
             n += frame.naxes
         return result
 
@@ -335,13 +337,15 @@ class Detector(BaseCoordinateFrame):
     frame_specific_representation_info = {
         'cartesian2d': [RepresentationMapping('x', 'x', u.pixel),
                         RepresentationMapping('y', 'y', u.pixel)]
-        }
+    }
 
 
 class DetectorFrame(CoordinateFrame):
+
     """
     Represents a Cartesian coordinate system on a detector.
     """
+
     def __init__(self, axes_order=(0, 1), name='detector', reference_position='Local'):
         axes_names = ['x', 'y']
         super(DetectorFrame, self).__init__(2, name=name, axes_names=axes_names,
@@ -359,10 +363,11 @@ class Focal(BaseCoordinateFrame):
     frame_specific_representation_info = {
         'cartesian2d': [RepresentationMapping('x', 'x', u.pixel),
                         RepresentationMapping('y', 'y', u.pixel)]
-        }
+    }
 
 
 class FocalPlaneFrame(CoordinateFrame):
+
     def __init__(self, reference_pixel=[0., 0.], unit=[u.pixel, u.pixel], name='focal_plane',
                  reference_position="Local", axes_names=None):
         super(FocalPlaneFrame, self).__init__(2, reference_frame=Focal(), reference_position=reference_position,

--- a/gwcs/region.py
+++ b/gwcs/region.py
@@ -1,0 +1,324 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import division, print_function
+
+import abc
+from collections import OrderedDict
+import os
+import numpy as np
+
+class Region(object):
+    """
+    Base class for regions.
+
+    Parameters
+    ----------
+    rid : int or str
+        region ID
+    coordinate_frame : `~gwcs.coordinate_frames.CoordinateFrame`
+        Coordinate frame in which the region is defined.
+    """
+    __metaclass__ = abc.ABCMeta
+
+    def __init__(self, rid, coordinate_frame):
+        self._coordinate_system = coordinate_frame
+        self._rid = rid
+
+    @abc.abstractmethod
+    def __contains__(self, x, y):
+        """
+        Determines if a pixel is within a region.
+
+        Parameters
+        ----------
+        x, y : float
+            x , y values of a pixel
+
+        Returns
+        -------
+        True or False
+
+        Subclasses must define this method.
+        """
+
+    def scan(self, mask):
+        """
+        Sets mask values to region id for all pixels within the region.
+        Subclasses must define this method.
+
+        Parameters
+        ----------
+        mask : ndarray
+            An array with the shape of the mask to be uised in `~gwcs.selector.RegionsSelector`.
+
+        Returns
+        -------
+        mask : ndarray
+            An array where the value of the elements is the region ID.
+            Pixels which are not included in any region are marked with 0 or "".
+        """
+
+class Polygon(Region):
+    """
+    Represents a 2D polygon region with multiple vertices.
+
+    Parameters
+    ----------
+    rid : str
+         polygon id
+    vertices : list of (x,y) tuples or lists
+         The list is ordered in such a way that when traversed in a
+         counterclockwise direction, the enclosed area is the polygon.
+         The last vertex must coincide with the first vertex, minimum
+         4 vertices are needed to define a triangle
+    coord_frame : str or `~gwcs.coordinate_frames.CoordinateFrame`
+        Coordinate frame in which the polygon is defined.
+
+    """
+    def __init__(self, rid, vertices, coord_frame="detector"):
+        assert len(vertices) >= 4, ("Expected vertices to be "
+                                    "a list of minimum 4 tuples (x,y)")
+        super(Polygon, self).__init__(rid, coord_frame)
+
+        self._vertices = np.asarray(vertices)
+        self._bbox = self._get_bounding_box()
+        self._scan_line_range=range(self._bbox[1], self._bbox[3]+self._bbox[1]+1)
+        #constructs a Global Edge Table (GET) in bbox coordinates
+        self._GET = self._construct_ordered_GET()
+
+    def _get_bounding_box(self):
+        x = self._vertices[:,0].min()
+        y = self._vertices[:,1].min()
+        w = self._vertices[:,0].max() - x
+        h = self._vertices[:,1].max() - y
+        return (x, y, w, h)
+
+    def  _construct_ordered_GET(self):
+        """
+        Construct a Global Edge Table (GET)
+
+        The GET is an OrderedDict. Keys are scan  line numbers,
+        ordered from bbox.ymin to bbox.ymax, where bbox is the
+        bounding box of the polygon.
+        Values are lists of edges for which edge.ymin==scan_line_number.
+
+        Returns
+        -------
+        GET: OrderedDict
+            {scan_line: [edge1, edge2]}
+        """
+        # edges is a list of Edge objects which define a polygon
+        # with these vertices
+        edges = self.get_edges()
+        GET = OrderedDict.fromkeys(self._scan_line_range)
+        ymin=np.asarray([e._ymin for e in edges])
+        for i in self._scan_line_range:
+            ymin_ind = (ymin == i).nonzero()[0]
+            if ymin_ind.any():
+                GET[i] = [edges[ymin_ind[0]]]
+                for j in ymin_ind[1:]:
+                    GET[i].append(edges[j])
+        return GET
+
+    def get_edges(self):
+        """
+        Create a list of Edge objects from vertices
+        """
+        edges = []
+        for i in range(1, len(self._vertices)):
+            name = 'E'+str(i-1)
+            edges.append(Edge(name=name, start=self._vertices[i-1], stop=self._vertices[i]))
+        return edges
+
+    def scan(self, data):
+        """
+        This is the main function which scans the polygon and creates the mask
+
+        Parameters
+        ----------
+        data : array
+            the mask array
+            it has all zeros initially, elements within a region are set to
+            the region's ID
+
+        Algorithm:
+        - Set the Global Edge Table (GET)
+        - Set y to be the smallest y coordinate that has an entry in GET
+        - Initialize the Active Edge Table (AET) to be empty
+        - For each scan line:
+          1. Add edges from GET to AET for which ymin==y
+          2. Remove edges from AET fro which ymax==y
+          3. Compute the intersection of the current scan line with all edges in the AET
+          4. Sort on X of intersection point
+          5. Set elements between pairs of X in the AET to the Edge's ID
+
+        """
+        ##TODO: 1.This algorithm does not mark pixels in the top row and left most column.
+        ## Pad the initial pixel description on top and left with 1 px to prevent this.
+        ## 2. Currently it uses intersection of the scan line with edges. If this is
+        ## too slow it should use the 1/m increment (replace 3 above) (or the increment
+        ## should be removed from the GET entry).
+        y = np.min(self._GET.keys())
+        AET = []
+        scline = self._scan_line_range[-1]
+        while y <=scline:
+            AET = self.update_AET(y, AET)
+            scan_line = Edge('scan_line', start=[self._bbox[0], y],
+                                            stop=[self._bbox[0]+self._bbox[2], y])
+            x = [np.ceil(e.compute_AET_entry(scan_line)[1]) for e in AET if e is not None]
+            xnew=np.sort(x)
+            for i,j in zip(xnew[::2], xnew[1::2]):
+                data[y][i:j+1] = self._rid
+            y = y+1
+        return data
+
+    def update_AET(self, y, AET):
+        """
+        Update the Active Edge Table (AET)
+
+        Add edges from GET to AET for which ymin of the edge is
+        equal to the y of the scan line.
+        Remove edges from AET for which ymax of the edge is
+        equal to y of the scan line.
+
+        """
+        edge_cont = self._GET[y]
+        if edge_cont is not None:
+            for edge in edge_cont:
+                if edge._start[1] != edge._stop[1] and edge._ymin == y:
+                    AET.append(edge)
+        for edge in AET[::-1]:
+            if edge is not None:
+                if edge._ymax == y:
+                    AET.remove(edge)
+        return AET
+
+    def __contains__(self, px):
+        """even-odd algorithm or smth else better sould be used"""
+        minx = self._vertices[:,0].min()
+        maxx = self._vertices[:,0].max()
+        miny = self._vertices[:,1].min()
+        maxy = self._vertices[:,1].max()
+        return px[0] >= self._bbox[0] and px[0] <= self._bbox[0]+self._bbox[2] and \
+               px[1] >=self._bbox[1] and px[1] <=self._bbox[1]+self._bbox[3]
+
+class Edge(object):
+    """
+    Edge representation.
+
+    An edge has a "start" and "stop" (x,y) vertices and an entry in the
+    GET table of a polygon. The GET entry is a list of these values:
+
+    [ymax, x_at_ymin, delta_x/delta_y]
+
+    """
+    def __init__(self, name=None, start=None, stop=None, next=None):
+        self._start = None
+        if start is not None:
+            self._start = np.asarray(start)
+        self._name= name
+        self._stop = stop
+        if stop is not None:
+            self._stop = np.asarray(stop)
+        self._next=next
+
+        if self._stop is not None and self._start is not None:
+            if self._start[1] < self._stop[1]:
+                self._ymin = self._start[1]
+                self._yminx = self._start[0]
+            else:
+                self._ymin = self._stop[1]
+                self._yminx = self._stop[0]
+            self._ymax = max(self._start[1], self._stop[1])
+            self._xmin = min(self._start[0], self._stop[0])
+            self._xmax = max(self._start[0], self._stop[1])
+        else:
+            self._ymin = None
+            self._yminx = None
+            self._ymax = None
+            self._xmin = None
+            self._xmax = None
+        self.GET_entry = self.compute_GET_entry()
+
+    @property
+    def ymin(self):
+        return self._ymin
+
+    @property
+    def start(self):
+        return self._start
+
+    @property
+    def stop(self):
+        return self._stop
+
+    @property
+    def ymax(self):
+        return self._ymax
+
+    def compute_GET_entry(self):
+        """
+        Compute the entry in the Global Edge Table
+
+        [ymax, x@ymin, 1/m]
+
+        """
+        if self._start is None:
+            entry = None
+        else:
+            earr = np.asarray([self._start, self._stop])
+            if np.diff(earr[:,1]).item() == 0:
+                return None
+            else:
+                entry=[self._ymax, self._yminx, (np.diff(earr[:,0]) / np.diff(earr[:,1])).item(), None]
+        return entry
+
+    def compute_AET_entry(self, edge):
+        """
+        Compute the entry for an edge in the current Active Edge Table
+
+        [ymax, x_intersect, 1/m]
+        note: currently 1/m is not used
+        """
+        x = self.intersection(edge)[0]
+        return [self._ymax, x, self.GET_entry[2]]
+
+    def __repr__(self):
+        fmt = ""
+        if self._name is not None:
+            fmt += self._name
+            next=self.next
+            while next is not None:
+                fmt += "-->"
+                fmt += next._name
+                next = next.next
+        return fmt
+
+    @property
+    def next(self):
+        return self._next
+
+    @next.setter
+    def next(self, edge):
+        if self._name is None:
+            self._name = edge._name
+            self._stop = edge._stop
+            self._start = edge._start
+            self._next = edge.next
+        else:
+            self._next = edge
+
+    def intersection(self, edge):
+        u = self._stop - self._start
+        v = edge._stop - edge._start
+        w = self._start - edge._start
+        D = np.cross(u, v)
+        return np.cross(v, w)/D * u + self._start
+
+    def is_parallel(self, edge):
+        u = self._stop - self._start
+        v = edge._stop - edge._start
+        if np.cross(u, v):
+            return False
+        else:
+            return True
+

--- a/gwcs/region.py
+++ b/gwcs/region.py
@@ -2,9 +2,11 @@
 from __future__ import division, print_function
 
 import abc
-from collections import OrderedDict
 import os
 import numpy as np
+
+from astropy.utils import OrderedDict
+
 
 class Region(object):
     """

--- a/gwcs/representation.py
+++ b/gwcs/representation.py
@@ -11,6 +11,7 @@ __all__ = ['Cartesian1DRepresentation', 'Cartesian2DRepresentation']
 
 
 class Cartesian1DRepresentation(BaseRepresentation):
+
     """
     Representation of a one dimensional cartesian coordinate.
 
@@ -42,14 +43,15 @@ class Cartesian1DRepresentation(BaseRepresentation):
         return self._x
 
     #@classmethod
-    #def from_cartesian(cls, other):
-        #return other
+    # def from_cartesian(cls, other):
+        # return other
 
-    #def to_cartesian(self):
-        #return self
+    # def to_cartesian(self):
+        # return self
 
 
 class Cartesian2DRepresentation(BaseRepresentation):
+
     """
     Representation of a two dimensional cartesian coordinate system
 
@@ -100,5 +102,3 @@ class Cartesian2DRepresentation(BaseRepresentation):
         The y component of the point(s).
         """
         return self._y
-
-

--- a/gwcs/selector.py
+++ b/gwcs/selector.py
@@ -58,7 +58,7 @@ class SelectorMask(Model):
     fittable = False
 
     def __init__(self, mask):
-        if mask.dtype.type is not np.string_:
+        if mask.dtype.type is not np.str_:
             self._mask = np.asanyarray(mask, dtype=np.int)
         else:
             self._mask = mask
@@ -119,6 +119,7 @@ class SelectorMask(Model):
         for rid, vert in regions.iteritems():
             pol = region.Polygon(rid, vert)
             mask = pol.scan(mask)
+
         return cls(mask)
 
 

--- a/gwcs/selector.py
+++ b/gwcs/selector.py
@@ -36,6 +36,7 @@ def _toindex(value):
 
 
 class SelectorMask(Model):
+
     """
     A mask model to be used with the `~gwcs.selector.RegionsSelector` transform.
 
@@ -55,7 +56,6 @@ class SelectorMask(Model):
 
     linear = False
     fittable = False
-
 
     def __init__(self, mask):
         if mask.dtype.type is not np.string_:
@@ -113,20 +113,17 @@ class SelectorMask(Model):
         mask = region.create_regions_mask_from_json((300,300), 'regions.json',
         'region_schema.json')
         """
-        if isinstance(regions.keys()[0], six.string_types):
-            np_dtype = np.string_
-        else:
-            np_dtype = np.int32
-        mask = np.zeros(mask_shape, dtype=np_dtype)
+        labels = np.array(regions.keys())
+        mask = np.zeros(mask_shape, dtype=labels.dtype)
 
         for rid, vert in regions.iteritems():
-            pol = region.Polygon(rid, vert)#, 'Cartesian')
+            pol = region.Polygon(rid, vert)
             mask = pol.scan(mask)
         return cls(mask)
 
 
-
 class RegionsSelector(Model):
+
     """
     A model which maps regions to their corresponding transforms.
     It evaluates the model matching inputs to the correct region/transform.
@@ -209,7 +206,7 @@ class RegionsSelector(Model):
         Sets one of the inputs and returns a transform associated with it.
         """
         def _eval_input(x, y):
-            return self._selector[rid]( x, y)
+            return self._selector[rid](x, y)
         return _eval_input
 
     def evaluate(self, x, y):
@@ -229,7 +226,8 @@ class RegionsSelector(Model):
         if (rids == self.mask.no_transform_value).all():
             raise RegionError("The input positions are not inside any region.")
 
-        # Create output arrays and set any pixels not withing regions to  "undefined_transform_value"
+        # Create output arrays and set any pixels not withing regions to
+        # "undefined_transform_value"
         no_trans_ind = (rids == self.mask.no_transform_value).nonzero()
         outputs = [np.empty(rids.shape) for n in range(self.n_outputs)]
         for out in outputs:

--- a/gwcs/selector.py
+++ b/gwcs/selector.py
@@ -1,87 +1,171 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import division, print_function
 
 import copy
 import numpy as np
 import warnings
 
+from astropy.extern import six
 from astropy.modeling.core import Model
-from astropy.utils.misc import isiterable
+from astropy.modeling.parameters import Parameter
 
-
+from . import region
 from .util import RegionError
 
 
-class SelectorModel(Model):
+def _toindex(value):
     """
+    Convert value to an int or an int array.
+
+    Input coordinates should be turned into integers
+    corresponding to the center of the pixel.
+    They are used to index the mask.
+
+    Examples
+    --------
+    >>> _toindex(np.array([-0.5, 0.49999]))
+    array([0, 0])
+    >>> _toindex(np.array([0.5, 1.49999]))
+    array([1, 1])
+    >>> _toindex(np.array([1.5, 2.49999]))
+    array([2, 2])
+    """
+    indx = np.empty(value.shape, dtype=np.int32)
+    indx = np.floor(value + 0.5, out=indx)
+    return indx
+
+
+class SelectorMask(Model):
+    """
+    A mask model to be used with the `~gwcs.selector.RegionsSelector` transform.
+
+    For an IFU observation, the values of the mask
+    correspond to the region (slice)  label.
+
     Parameters
     ----------
-    labels : a list of strings or objects
-    transforms : a list of transforms
-        transforms match labels
+    mask : ndarray
+        An array of integers or strings where the values
+        correspond to a transform label in `~gwcs.selector.RegionsSelector` model.
+        If a transform is not defined the value shoul dbe set to 0 or " ".
+    """
+
+    inputs = ('x', 'y')
+    outputs = ('z')
+
+    linear = False
+    fittable = False
+
+
+    def __init__(self, mask):
+        if mask.dtype.type is not np.string_:
+            self._mask = np.asarray(mask, dtype=np.int)
+        else:
+            self._mask = mask
+        if mask.dtype.type is np.string_:
+            self._no_transform_value = ""
+        else:
+            self._no_transform_value = 0
+        super(SelectorMask, self).__init__()
+
+    @property
+    def mask(self):
+        return self._mask
+
+    @property
+    def no_transform_value(self):
+        return self._no_transform_value
+
+    def evaluate(self, x, y):
+
+        indx = _toindex(x)
+        indy = _toindex(y)
+        return self.mask[indx, indy]
+
+    @classmethod
+    def from_vertices(cls, mask_shape, regions):
+        """
+        Create a `~gwcs.selector.SelectorMask` from
+        polygon vertices read in from a json file.
+
+        Parameters
+        ----------
+        mask_shape : tuple
+            shape of mask array
+        regions: dict
+            {region_label : list_of_polygon_vertices}
+
+            The keys in this dictionary should match the region labels
+            in `~gwcs.selector.RegionsSelector`.
+
+            The list of vertices is ordered in such a way that when traversed in a
+            counterclockwise direction, the enclosed area is the polygon.
+            The last vertex must coincide with the first vertex, minimum
+            4 vertices are needed to define a triangle.
+
+        Returns
+        -------
+        mask : `~gwcs.selectorSelectorMask`
+            Mask to be used with `~gwcs.selector.SelectorModel`.
+
+        Examples
+        -------_
+        mask = region.create_regions_mask_from_json((300,300), 'regions.json',
+        'region_schema.json')
+        """
+        if isinstance(regions.keys()[0], six.string_types):
+            np_dtype = np.string_
+        else:
+            np_dtype = np.int32
+        mask = np.zeros(mask_shape, dtype=np_dtype)
+
+        for rid, vert in regions.iteritems():
+            pol = region.Polygon(rid, vert)#, 'Cartesian')
+            mask = pol.scan(mask)
+        return cls(mask)
+
+
+
+class RegionsSelector(Model):
+    """
+    A model which maps regions to their corresponding transforms.
+    It evaluates the model matching inputs to the correct region/transform.
+
+    Parameters
+    ----------
+    inputs : list of str
+        Names of the inputs.
+    outputs : list of str
+        Names of the outputs.
+    selector : dict
+        Mapping of region labels to transforms.
+        Labels can be of type int or str, transforms are of type `~astropy.modeling.core.Model`
+    mask : `~gwcs.selector.SelectorMask`
+        Mask with region labels.
+    undefined_transform_value : float, np.nan (default)
+        Value to be returned if there's no transform defined for the inputs.
     """
     _param_names = ()
 
     linear = False
     fittable = False
 
-    def __init__(self, labels, transforms):
-        # labels should be unique
-        if (np.unique(labels)).size != np.asarray(labels).size:
-            raise ValueError("Labels should be unique.")
-        # every label should have a corresponding transform
-        if len(labels) != len(transforms):
-            raise ValueError("Expected labels and transforms to be of equal length.")
-        if " " in labels or 0 in labels:
-            raise ValueError('"0" and " " are not allowed as labels.')
-        self._selector = dict(zip(labels, transforms))
-        super(SelectorModel, self).__init__(n_models=1)
+    def __init__(self, inputs, outputs, selector, mask, undefined_transform_value=np.nan):
+        self._inputs = inputs
+        self._outputs = outputs
+        self.mask = mask.copy()
+        self._undefined_transform_value = undefined_transform_value
+        self._selector = copy.deepcopy(selector)
 
-    @property
-    def labels(self):
-        return self._selector.keys()
+        if " " in selector.keys() or 0 in selector.keys():
+            raise ValueError('"0" and " " are not allowed as keys.')
 
-    @property
-    def transforms(self):
-        return self._selector.values()
-
-
-
-class RegionsSelector(SelectorModel):
-    """
-    Parameters
-    ----------
-    regions_mask : ndarray
-        An array where regions are indicated by int or str labels.
-        " " and 0 indicate a pixel on the detector which is not within any region.
-        Evaluating the model in these locations returns NaN or ``undefined_transform_value`` if provided.
-    labels : list
-        A list of str or int labels in the same order as transforms.
-        It does not contain 0 or " "  and matches all labels in regions_mask.
-    transforms : list of transforms
-        a transform is an instance of modeling.Model or a callable
-        which performs the transformation from the region's coordinate system
-        to some other coordinate system
-    undefined_transform_value : float
-        A value to be returned for locations not within any region.
-        Default is np.NaN.
-
-    """
-    inputs = ('x', 'y')#, 'region')
-    outputs = ('lat', 'lon', 'lambda')
-    #inputs = ()
-    #outputs = ()
-
-    def __init__(self, regions_mask, labels, transforms, undefined_transform_value=np.nan, coord_sys='DetectorFrame'):
-        self.regions_mask = regions_mask.copy()
-        self.undefined_transform_value = undefined_transform_value
-        # get the list of region labels
-        labels_mask = self.labels_from_mask(regions_mask)
-        if not np.in1d(labels_mask, labels, assume_unique=True).all() or \
-           not np.in1d(labels, labels_mask, assume_unique=True).all():
+        super(RegionsSelector, self).__init__(n_models=1)
+        # make sure that keys in mapping match labels in mask
+        labels_mask = self.labels_from_mask(mask.mask)
+        if not np.in1d(labels_mask, self._selector.keys(), assume_unique=True).all() or \
+           not np.in1d(self._selector.keys(), labels_mask, assume_unique=True).all():
             raise ValueError("Labels don't match regions_mask.")
-
-        super(RegionsSelector, self).__init__(labels, transforms)#,
-                                              #n_inputs=3, n_outputs=3)
 
     @staticmethod
     def labels_from_mask(regions_mask):
@@ -105,103 +189,6 @@ class RegionsSelector(SelectorModel):
             pass
         return labels
 
-    @classmethod
-    def reconstruct_wcs(cls, rid_wcs, wcs_info):
-        reference_regions_wcs = copy.deepcopy(wcs_info)
-        reference_regions_wcs['CRVAL'][0] += rid_wcs['CRVAL_DELTA'][0]
-        reference_regions_wcs['CRVAL'][1] += rid_wcs['CRVAL_DELTA'][1]
-        reference_regions_wcs['CRPIX'][0] += rid_wcs['CRPIX_DELTA'][0]
-        reference_regions_wcs['CRPIX'][1] += rid_wcs['CRPIX_DELTA'][1]
-        return reference_regions_wcs
-
-
-    def evaluate(self, x, y):#region=None
-        """
-        Parameters
-        ----------
-        x : float
-            Input pixel coordinate
-        y : float
-            Input pixel coordinate
-        region : int or str
-            Region id
-        """
-        #if region is not None:
-        #if not np.isnan(region):
-        #    return self._selector[region.item()](x, y)
-        # use input_values for indexing the output arrays
-        input_values = (x, y)
-        idx = np.empty(x.shape, dtype=np.int)
-        idy = np.empty(y.shape, dtype=np.int)
-        idx = np.around(x, out=idx)
-        idy = np.around(y, out=idy)
-        result = self.regions_mask[idy, idx]
-        if not isiterable(result) or isinstance(result, np.string_):
-            if result != 0 and result != '':
-                result = self._selector[result](*input_values)
-                if np.isscalar(result[0]):
-                    result = [np.array(ar) for ar in result]
-                return result
-            else:
-                broadcast_missing_value = np.broadcast_arrays(
-                    self.undefined_transform_value, input_values[0])[0]
-                return [broadcast_missing_value for output in range(self.n_outputs)] #input_values
-
-        unique_regions = self.get_unique_regions(result)
-        if unique_regions == []:
-            #warnings.warning('There are no regions with valid transforms.')
-            #return
-            raise RegionError("The input positions are not inside any region.")
-        nout = self._selector[unique_regions[0]].n_outputs
-        output_arrays = [np.zeros(self.regions_mask.shape, dtype=np.float) for i in range(nout)]
-        for ar in output_arrays:
-            ar[self.regions_mask == 0] = self.undefined_transform_value
-        for i in unique_regions:
-            transform = self._selector[i]
-            indices = (self.regions_mask==i).nonzero()
-            outputs = transform(*indices)
-            for out, tr_out in zip(output_arrays, outputs):
-                out[indices] = tr_out
-
-        result = [ar[idx, idy] for ar in output_arrays]
-        if np.isscalar(result[0]):
-            result = [np.array(ar) for ar in result]
-        return tuple(result)
-
-    def __call__(self, *inputs, **kwargs):
-        """
-        Evaluate this model using the given input(s) and the parameter values
-        that were specified when the model was instantiated.
-        """
-        import itertools
-        if len(inputs) == 3:
-            label = inputs[-1]
-            try:
-                tr = self._selector[label]
-            except KeyError:
-                raise RegionError("Region {0} does not exist".format(label))
-            evaluate = tr.evaluate
-            parameters = tr._param_sets(raw=True)
-            inputs = inputs[:2]
-        else:
-            parameters = self._param_sets(raw=True)
-            evaluate = self.evaluate
-        inputs, format_info = self.prepare_inputs(*inputs, **kwargs)
-
-        outputs = evaluate(*itertools.chain(inputs, parameters))
-
-        if self.n_outputs == 1:
-            outputs = (outputs,)
-        return self.prepare_outputs(format_info, *outputs, **kwargs)
-
-    def evaluate_region(self, region_id):
-        transform = self._selector[region_id]
-        indices = (self.regions_mask==region_id).nonzero()
-        outputs = transform(*indices)
-        for out, tr_out in zip(output_arrays, outputs):
-            out[indices] = tr_out
-        return out
-
     @staticmethod
     def get_unique_regions(mask):
         unique_regions = np.unique(mask).tolist()
@@ -217,7 +204,95 @@ class RegionsSelector(SelectorModel):
             pass
         return unique_regions
 
-    def inverse(self, x, y):
+    def set_input(self, rid):
         """
-        Need to invert the regions and construct an InverseSelectorModel
+        Sets one of the inputs and returns a transform associated with it.
         """
+        def _eval_input(x, y):
+            return self._selector[rid]( x, y)
+        return _eval_input
+
+    def evaluate(self, x, y):
+        """
+        Parameters
+        ----------
+        x : float or ndarray
+            Input pixel coordinate.
+        y : float or ndarray
+            Input pixel coordinate.
+        """
+        # Get the region labels corresponding to these inputs
+        indx = _toindex(x)
+        indy = _toindex(y)
+        rids = self.mask(indx, indy).flatten()
+        # Raise an error if all pixels are outside regions
+        if (rids == self.mask.no_transform_value).all():
+            raise RegionError("The input positions are not inside any region.")
+
+        # Create output arrays and set any pixels not withing regions to  "undefined_transform_value"
+        no_trans_ind = (rids == self.mask.no_transform_value).nonzero()
+        outputs = [np.empty(rids.shape) for n in range(self.n_outputs)]
+        for out in outputs:
+            out[no_trans_ind] = self.undefined_transform_value
+
+        # Compute the transformations
+        x = x.flatten()
+        y = y.flatten()
+        uniq = self.get_unique_regions(rids)
+        for rid in uniq:
+            ind = (rids == rid)
+            result = self._selector[rid](x[ind], y[ind])
+            for j in range(self.n_outputs):
+                outputs[j][ind] = result[j]
+        return outputs
+
+    def __call__(self, *inputs, **kwargs):
+        """
+        Evaluate this model using the given input(s) and the parameter values
+        that were specified when the model was instantiated.
+        """
+        import itertools
+
+        parameters = self._param_sets(raw=True)
+        evaluate = self.evaluate
+        inputs, format_info = self.prepare_inputs(*inputs, **kwargs)
+        outputs = evaluate(*itertools.chain(inputs, parameters))
+
+        if self.n_outputs == 1:
+            outputs = (outputs,)
+        return self.prepare_outputs(format_info, *outputs, **kwargs)
+
+    def inverse(self):
+        """
+        The inverse exists if all transforms have an inverse
+        and the mask has an inverse.
+        """
+        selector_inverse = copy.deepcopy(self._selector)
+        for tr in selector_inverse:
+            selector_inverse[tr] = selector_inverse[tr].inverse
+        try:
+            mask = self.mask.inverse
+        except NotImplementedError:
+            raise
+        return self.__class__(self.outputs, self.inputs, selector_inverse,
+                              mask, self.undefined_transform_value)
+
+    @property
+    def undefined_transform_value(self):
+        return self._undefined_transform_value
+
+    @undefined_transform_value.setter
+    def undefined_transform_value(self, value):
+        self._undefined_transform_value = value
+
+    @property
+    def inputs(self):
+        """
+        The name(s) of the input variable(s) on which a model is evaluated.
+        """
+        return self._inputs
+
+    @property
+    def outputs(self):
+        """The name(s) of the output(s) of the model."""
+        return self._outputs

--- a/gwcs/selector.py
+++ b/gwcs/selector.py
@@ -59,7 +59,7 @@ class SelectorMask(Model):
 
     def __init__(self, mask):
         if mask.dtype.type is not np.string_:
-            self._mask = np.asarray(mask, dtype=np.int)
+            self._mask = np.asanyarray(mask, dtype=np.int)
         else:
             self._mask = mask
         if mask.dtype.type is np.string_:

--- a/gwcs/spectral_builtin_frames.py
+++ b/gwcs/spectral_builtin_frames.py
@@ -18,7 +18,7 @@ class Wavelength(BaseCoordinateFrame):
     reference_position = FrameAttribute(default='BARYCENTER')
     frame_specific_representation_info = {
         'cartesian1d': [RepresentationMapping('x', 'lam', 'm')]
-        }
+    }
 
 
 class Frequency(BaseCoordinateFrame):
@@ -26,7 +26,7 @@ class Frequency(BaseCoordinateFrame):
     reference_position = FrameAttribute(default='BARYCENTER')
     frame_specific_representation_info = {
         'cartesian1d': [RepresentationMapping('x', 'freq', 'Hz')]
-        }
+    }
 
 
 class OpticalVelocity(BaseCoordinateFrame):
@@ -35,7 +35,7 @@ class OpticalVelocity(BaseCoordinateFrame):
     rest = FrameAttribute()
     frame_specific_representation_info = {
         'cartesian1d': [RepresentationMapping('x', 'v', 'm/s')]
-        }
+    }
 
 
 @frame_transform_graph.transform(coo.FunctionTransform, Wavelength, Frequency)
@@ -56,5 +56,3 @@ def wave_to_velo(wavecoord, veloframe):
 @frame_transform_graph.transform(coo.FunctionTransform, Frequency, OpticalVelocity)
 def freq_to_velo(freqcoord, veloframe):
     return OpticalVelocity(freqcoord.f.to(veloframe.representation_component_units.values()[0], equivalencies=eq.doppler_optical(veloframe.rest)))
-
-

--- a/gwcs/tests/test_coordinate_systems.py
+++ b/gwcs/tests/test_coordinate_systems.py
@@ -4,13 +4,13 @@ from astropy import coordinates as coo
 from .. import coordinate_frames as cf
 from .. import spectral_builtin_frames
 
-icrs=coo.ICRS()
+icrs = coo.ICRS()
 fk5 = coo.FK5()
 cel1 = cf.CelestialFrame(icrs)
 cel2 = cf.CelestialFrame(fk5)
 
-freq=spectral_builtin_frames.Frequency()
-wave=spectral_builtin_frames.Wavelength()
+freq = spectral_builtin_frames.Frequency()
+wave = spectral_builtin_frames.Wavelength()
 spec1 = cf.SpectralFrame(freq)
 spec2 = cf.SpectralFrame(wave)
 

--- a/gwcs/tests/test_region.py
+++ b/gwcs/tests/test_region.py
@@ -42,12 +42,13 @@ def polygon1(shape=(9, 9)):
     ar[1, 2] = 1
     ar[2][2:4] = 1
     ar[3][1:4] = 1
-    ar[4][:4] = 1
-    ar[5][1:4] = 1
-    ar[6][2:7] = 1
-    ar[7][3:6] = 1
-    # ar[8][3:4] =1 ##need to include this in the future if padding top and left
+    ar[4][:4] =1
+    ar[5][1:4] =1
+    ar[6][2:7] =1
+    ar[7][3:6] =1
+    #ar[8][3:4] =1 ##need to include this in the future if padding top and left
     return ar
+
 
 def two_polygons():
     ar = np.zeros((301, 301))
@@ -76,13 +77,4 @@ def test_create_mask_two_polygons():
                 2: [[10, 0], [30, 0], [30, 30], [10, 30], [10, 0]]}
     mask = selector.SelectorMask.from_vertices((301, 301), vertices)
     pol2 = two_polygons()
-    #pol2 = np.zeros((301, 301))
-    #pol2[1, 2] = 1
-    #pol2[2][2:4] = 1
-    #pol2[3][1:4] = 1
-    #pol2[4][:4] = 1
-    #pol2[5][1:4] = 1
-    #pol2[6][2:7] = 1
-    #pol2[7][3:6] = 1
-    #pol2[:30, 10:31] = 2
     utils.assert_equal(mask.mask, pol2)

--- a/gwcs/tests/test_region.py
+++ b/gwcs/tests/test_region.py
@@ -1,0 +1,88 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+Test regions
+"""
+from __future__ import division, print_function
+
+import numpy as np
+from numpy.testing import utils
+
+from .. import region, selector
+
+
+def test_SelectorMask_from_vertices_int():
+    regions = {1: [[795, 970], [2047, 970], [2047, 999], [795, 999], [795, 970]],
+               2: [[844, 1067], [2047, 1067], [2047, 1113], [844, 1113], [844, 1067]],
+               3: [[654, 1029], [2047, 1029], [2047, 1078], [654, 1078], [654, 1029]],
+               4: [[772, 990], [2047, 990], [2047, 1042], [772, 1042], [772, 990]]
+               }
+    mask = selector.SelectorMask.from_vertices((2400, 2400), regions)
+    labels = regions.keys()
+    labels.append(0)
+    mask_labels = np.unique(mask.mask).tolist()
+    assert(np.sort(labels) == np.sort(mask_labels)).all()
+
+
+def test_SelectorMask_from_vertices_string():
+    regions = {'S1600A1': [[795, 970], [2047, 970], [2047, 999], [795, 999], [795, 970]],
+               'S200A1': [[844, 1067], [2047, 1067], [2047, 1113], [844, 1113], [844, 1067]],
+               'S200A2': [[654, 1029], [2047, 1029], [2047, 1078], [654, 1078], [654, 1029]],
+               'S400A1': [[772, 990], [2047, 990], [2047, 1042], [772, 1042], [772, 990]]
+               }
+    mask = selector.SelectorMask.from_vertices((1400, 1400), regions)
+    labels = regions.keys()
+    labels.append('')
+    mask_labels = np.unique(mask.mask).tolist()
+    assert(np.sort(labels) == np.sort(mask_labels)).all()
+
+
+#### These tests below check the scanning algorithm for two shapes ##########
+def polygon1(shape=(9, 9)):
+    ar = np.zeros(shape)
+    ar[1, 2] = 1
+    ar[2][2:4] = 1
+    ar[3][1:4] = 1
+    ar[4][:4] = 1
+    ar[5][1:4] = 1
+    ar[6][2:7] = 1
+    ar[7][3:6] = 1
+    # ar[8][3:4] =1 ##need to include this in the future if padding top and left
+    return ar
+
+def two_polygons():
+    ar = np.zeros((301, 301))
+    ar[1, 2] = 1
+    ar[2][2:4] = 1
+    ar[3][1:4] = 1
+    ar[4][:4] = 1
+    ar[5][1:4] = 1
+    ar[6][2:7] = 1
+    ar[7][3:6] = 1
+    ar[:30, 10:31] = 2
+    return ar
+
+
+def test_polygon1():
+    vert = [(2, 1), (3, 5), (6, 6), (3, 8), (0, 4), (2, 1)]
+    pol = region.Polygon('1', vert)
+    mask = np.zeros((9, 9), dtype=np.int)
+    mask = pol.scan(mask)
+    pol1 = polygon1()
+    utils.assert_equal(mask, pol1)
+
+
+def test_create_mask_two_polygons():
+    vertices = {1: [[2, 1], [3, 5], [6, 6], [3, 8], [0, 4], [2, 1]],
+                2: [[10, 0], [30, 0], [30, 30], [10, 30], [10, 0]]}
+    mask = selector.SelectorMask.from_vertices((301, 301), vertices)
+    pol2 = two_polygons()
+    #pol2 = np.zeros((301, 301))
+    #pol2[1, 2] = 1
+    #pol2[2][2:4] = 1
+    #pol2[3][1:4] = 1
+    #pol2[4][:4] = 1
+    #pol2[5][1:4] = 1
+    #pol2[6][2:7] = 1
+    #pol2[7][3:6] = 1
+    #pol2[:30, 10:31] = 2
+    utils.assert_equal(mask.mask, pol2)

--- a/gwcs/tests/test_wcs.py
+++ b/gwcs/tests/test_wcs.py
@@ -23,19 +23,20 @@ def test_create_wcs():
     gw3 = wcs.WCS(output_frame=icrs, input_frame=det, forward_transform=m)
     assert(gw1._input_frame == gw2._input_frame == gw3._input_frame == 'detector')
     assert(gw1._output_frame == gw2._output_frame == gw3._output_frame == 'icrs')
-    assert(gw1.forward_transform.__class__ == gw2.forward_transform.__class__ == gw3.forward_transform.__class__ == m.__class__)
+    assert(gw1.forward_transform.__class__ == gw2.forward_transform.__class__ ==
+           gw3.forward_transform.__class__ == m.__class__)
     assert(gw1._coord_frames == gw2._coord_frames == {'detector': None, 'icrs': None})
 
 
 def test_pipeline_init():
     gw = wcs.WCS(output_frame='icrs')
     assert gw._pipeline == [('detector', None), ('icrs', None)]
-    assert(gw.available_frames == {'detector' : None, 'icrs': None})
+    assert(gw.available_frames == {'detector': None, 'icrs': None})
     icrs = cf.CelestialFrame(coord.ICRS())
     det = cf.DetectorFrame()
     gw = wcs.WCS(output_frame=icrs, input_frame=det)
     assert gw._pipeline == [('detector', None), ('icrs', None)]
-    assert(gw.available_frames == {'detector' : det, 'icrs': icrs})
+    assert(gw.available_frames == {'detector': det, 'icrs': icrs})
 
 
 def test_insert_transform():
@@ -47,9 +48,8 @@ def test_insert_transform():
     assert(gw.forward_transform(1.2) == (m1 | m2)(1.2))
 
 
-
-
 class TestImaging(object):
+
     def setup_class(self):
         hdr = fits.Header.fromtextfile(get_pkg_data_filename("data/acs.hdr"), endcard=False)
         self.fitsw = astwcs.WCS(hdr)
@@ -59,7 +59,8 @@ class TestImaging(object):
         b_order = b_coeff.pop('B_ORDER')
 
         crpix = [hdr['CRPIX1'], hdr['CRPIX2']]
-        distortion = models.SIP(crpix, a_order, b_order, a_coeff, b_coeff, name='sip_distorion') + models.Identity(2)
+        distortion = models.SIP(
+            crpix, a_order, b_order, a_coeff, b_coeff, name='sip_distorion') + models.Identity(2)
 
         cdmat = np.array([[hdr['CD1_1'], hdr['CD1_2']], [hdr['CD2_1'], hdr['CD2_2']]])
         aff = models.AffineTransformation2D(matrix=cdmat, name='rotation')
@@ -71,7 +72,7 @@ class TestImaging(object):
 
         phi = hdr['CRVAL1']
         lon = hdr['CRVAL2']
-        theta= 180
+        theta = 180
         n2c = models.RotateNative2Celestial(phi, lon, theta, name='sky_rotation')
 
         tan = models.Pix2Sky_TAN(name='tangent_projection')
@@ -82,14 +83,13 @@ class TestImaging(object):
                     (sky_cs, None)
                     ]
 
-        self.wcs = wcs.WCS(input_frame = 'detector',
-                     output_frame = sky_cs,
-                     forward_transform = pipeline)
+        self.wcs = wcs.WCS(input_frame='detector',
+                           output_frame=sky_cs,
+                           forward_transform=pipeline)
         nx, ny = (5, 2)
         x = np.linspace(0, 1, nx)
         y = np.linspace(0, 1, ny)
         self.xv, self.yv = np.meshgrid(x, y)
-
 
     def test_forward(self):
         sky_coord = self.wcs(self.xv, self.yv)
@@ -117,9 +117,7 @@ class TestImaging(object):
     def test_units(self):
         assert(self.wcs.unit == [u.degree, u.degree])
 
-
     def test_get_transform(self):
         with pytest.raises(wcs.CoordinateFrameError):
             assert(self.wcs.get_transform('x_translation', 'sky_rotation').submodel_names ==
                    self.wcs.forward_transform[1:].submodel_names)
-

--- a/gwcs/util.py
+++ b/gwcs/util.py
@@ -40,7 +40,7 @@ class ModelDimensionalityError(Exception):
 class RegionError(Exception):
     def __init__(self, message):
         self.message = message
-        super(UnknownRegionError, self).__init__()
+        super(RegionError, self).__init__()
 
 
 class CoordinateFrameError(Exception):

--- a/gwcs/util.py
+++ b/gwcs/util.py
@@ -13,7 +13,7 @@ except ImportError:
     HAS_TIME = False
 #from astropy import coordinates
 
-#these ctype values do not include yzLN and yzLT pairs
+# these ctype values do not include yzLN and yzLT pairs
 sky_pairs = {"equatorial": ["RA--", "DEC-"],
              "ecliptic": ["ELON", "ELAT"],
              "galactic": ["GLON", "GLAT"],
@@ -26,24 +26,28 @@ radesys = ['ICRS', 'FK5', 'FK4', 'FK4-NO-E', 'GAPPT', 'GALACTIC']
 
 
 class UnsupportedTransformError(Exception):
+
     def __init__(self, message):
         self.message = message
         super(UnsupportedTransformError, self).__init__()
 
 
 class ModelDimensionalityError(Exception):
+
     def __init__(self, message):
         self.message = message
         super(ModelDimensionalityError, self).__init__()
 
 
 class RegionError(Exception):
+
     def __init__(self, message):
         self.message = message
         super(RegionError, self).__init__()
 
 
 class CoordinateFrameError(Exception):
+
     def __init__(self, message):
         self.message = message
         super(CoordinateFrameError, self).__init__()
@@ -53,76 +57,76 @@ def get_projcode(ctype):
     # CTYPE here is only the imaging CTYPE keywords
     projcode = ctype[0][5:8].upper()
     if projcode not in projcodes:
-        raise ValueError('Projection code %s, not recognized' %projcode)
+        raise ValueError('Projection code %s, not recognized' % projcode)
     return projcode
 
 
 def read_wcs_from_header(header, mode=None):
-        """
-        Read basic WCS info from the Primary header of the data file.
-        """
-        wcs_info = {}
-        try:
-            wcsaxes = header['WCSAXES']
-        except KeyError:
-            if mode == 'imaging':
-                wcsaxes = 2
-            elif mode == 'spectroscopic':
-                wcsaxes = 3
-                #wcs_info['SPECSYS'] = header['SPECSYS']
-            elif mode == 'ifu':
-                wcsaxes = 3
-            elif mode == 'multislit':
-                wcsaxes = 3
-            else:
-                raise ValueError('Unrecognized mode')
-            # or perhaps do as wcslib
-            # wcsaxes = max(len(dict(**header["ctype*"])), header['NAXES'])
-        wcs_info['WCSAXES'] = wcsaxes
-        #if not present call get_csystem
-        wcs_info['RADESYS'] = header.get('RADESYS', 'ICRS')
-        wcs_info['VAFACTOR'] = header.get('VAFACTOR', 1)
-        wcs_info['NAXIS'] = header.get('NAXIS', 0)
-        # date keyword?
-        wcs_info['DATEOBS'] = header.get('DATE-OBS', 'DATEOBS')
-
-        ctype = []
-        cunit = []
-        crpix = []
-        crval = []
-        cdelt = []
-        for i in range(1, wcsaxes+1):
-            ctype.append(header['CTYPE{0}'.format(i)])
-            cunit.append(header.get('CUNIT{0}'.format(i), None))
-            crpix.append(header.get('CRPIX{0}'.format(i), 0.0))
-            crval.append(header.get('CRVAL{0}'.format(i), 0.0))
-            cdelt.append(header.get('CDELT{0}'.format(i), 1.0))
-
-        if 'CD1_1' in header:
-            wcs_info['has_cd'] = True
+    """
+    Read basic WCS info from the Primary header of the data file.
+    """
+    wcs_info = {}
+    try:
+        wcsaxes = header['WCSAXES']
+    except KeyError:
+        if mode == 'imaging':
+            wcsaxes = 2
+        elif mode == 'spectroscopic':
+            wcsaxes = 3
+            #wcs_info['SPECSYS'] = header['SPECSYS']
+        elif mode == 'ifu':
+            wcsaxes = 3
+        elif mode == 'multislit':
+            wcsaxes = 3
         else:
-            wcs_info['has_cd'] = False
-        pc = np.zeros((wcsaxes, wcsaxes))
-        for i in range(1, wcsaxes+1):
-            for j in range(1, wcsaxes+1):
-                try:
-                    if wcs_info['has_cd']:
-                        pc[i-1, j-1] = header['CD{0}_{1}'.format(i, j)]
-                    else:
-                        pc[i-1, j-1] = header['PC{0}_{1}'.format(i, j)]
-                except KeyError:
-                    if i == j:
-                        pc[i-1, j-1] = 1.
-                    else:
-                        pc[i-1, j-1] = 0.
-        wcs_info['CTYPE'] = ctype
-        wcs_info['CUNIT'] = cunit
-        wcs_info['CRPIX'] = crpix
-        wcs_info['CRVAL'] = crval
-        wcs_info['CDELT'] = cdelt
-        wcs_info['PC'] = pc
+            raise ValueError('Unrecognized mode')
+        # or perhaps do as wcslib
+        # wcsaxes = max(len(dict(**header["ctype*"])), header['NAXES'])
+    wcs_info['WCSAXES'] = wcsaxes
+    # if not present call get_csystem
+    wcs_info['RADESYS'] = header.get('RADESYS', 'ICRS')
+    wcs_info['VAFACTOR'] = header.get('VAFACTOR', 1)
+    wcs_info['NAXIS'] = header.get('NAXIS', 0)
+    # date keyword?
+    wcs_info['DATEOBS'] = header.get('DATE-OBS', 'DATEOBS')
 
-        return wcs_info
+    ctype = []
+    cunit = []
+    crpix = []
+    crval = []
+    cdelt = []
+    for i in range(1, wcsaxes+1):
+        ctype.append(header['CTYPE{0}'.format(i)])
+        cunit.append(header.get('CUNIT{0}'.format(i), None))
+        crpix.append(header.get('CRPIX{0}'.format(i), 0.0))
+        crval.append(header.get('CRVAL{0}'.format(i), 0.0))
+        cdelt.append(header.get('CDELT{0}'.format(i), 1.0))
+
+    if 'CD1_1' in header:
+        wcs_info['has_cd'] = True
+    else:
+        wcs_info['has_cd'] = False
+    pc = np.zeros((wcsaxes, wcsaxes))
+    for i in range(1, wcsaxes+1):
+        for j in range(1, wcsaxes+1):
+            try:
+                if wcs_info['has_cd']:
+                    pc[i-1, j-1] = header['CD{0}_{1}'.format(i, j)]
+                else:
+                    pc[i-1, j-1] = header['PC{0}_{1}'.format(i, j)]
+            except KeyError:
+                if i == j:
+                    pc[i-1, j-1] = 1.
+                else:
+                    pc[i-1, j-1] = 0.
+    wcs_info['CTYPE'] = ctype
+    wcs_info['CUNIT'] = cunit
+    wcs_info['CRPIX'] = crpix
+    wcs_info['CRVAL'] = crval
+    wcs_info['CDELT'] = cdelt
+    wcs_info['PC'] = pc
+
+    return wcs_info
 
 
 def get_axes(wcs_info):
@@ -147,11 +151,13 @@ def get_axes(wcs_info):
     for item in sky_pairs.values():
         if ctype[sky_inmap[0]] == item[0]:
             if ctype[sky_inmap[1]] != item[1]:
-                raise ValueError("Inconsistent ctype for sky coordinates {0} and {1}".format(*ctype))
+                raise ValueError(
+                    "Inconsistent ctype for sky coordinates {0} and {1}".format(*ctype))
             break
         elif ctype[sky_inmap[1]] == item[0]:
             if ctype[sky_inmap[0]] != item[1]:
-                raise ValueError("Inconsistent ctype for sky coordinates {0} and {1}".format(*ctype))
+                raise ValueError(
+                    "Inconsistent ctype for sky coordinates {0} and {1}".format(*ctype))
             sky_inmap = sky_inmap[::-1]
             break
     return sky_inmap, spec_inmap
@@ -166,7 +172,7 @@ def get_sky_wcs_info(wcsinfo):
         sky_wcsinfo[kw] = np.asarray(wcsinfo[kw])[sky_axes].tolist()
     for kw in other_keys:
         sky_wcsinfo[kw] = wcsinfo[kw]
-    pc = np.zeros((2,2))
+    pc = np.zeros((2, 2))
     wpc = wcsinfo['PC']
     pc[0, 0] = wpc[sky_axes[0], sky_axes[0]]
     pc[0, 1] = wpc[sky_axes[0], sky_axes[1]]
@@ -179,7 +185,7 @@ def get_sky_wcs_info(wcsinfo):
 def get_csystem(header=None, radesys=None, equinox=None, dateobs=None):
     ctypesys = "UNKNOWN"
     if header is not None:
-        ctype =  header["CTYPE*"]
+        ctype = header["CTYPE*"]
         radesys = header.get("RADESYS", None)
         equinox = header.get("EQUINOX", None)
         epoch = header.get("EPOCH", None)
@@ -191,12 +197,12 @@ def get_csystem(header=None, radesys=None, equinox=None, dateobs=None):
             assert cs[1] in item[1], "Inconsistent coordinate system type in CTYPE"
             ctypesys = item[0]
     if ctypesys == 'spec':
-        #try to get the rest of the kw that define a spectral system from the header
+        # try to get the rest of the kw that define a spectral system from the header
         return csystems.SpectralCoordSystem(cs, **kwargs)
     if ctypesys not in ['equatorial', 'ecliptic']:
         return coordinates.__getattribute__(sky_systems_map[ctypesys])(0., 0., equinox=equinox,
-                        obstime=dateobs, unit=units)
-        #return ctypesys, radesys, equinox
+                                                                       obstime=dateobs, unit=units)
+        # return ctypesys, radesys, equinox
     else:
         if radesys is None:
             if equinox is None:
@@ -231,7 +237,7 @@ def get_csystem(header=None, radesys=None, equinox=None, dateobs=None):
             dateobs = time.Time(dateobs, scale='utc')
     return ctypesys, radesys, equinox, dateobs
     #units = header.get('CUNIT*', ['deg', 'deg'])
-    #return coordinates.__getattribute__(sky_systems_map[radesys])(0., 0., equinox=equinox,
+    # return coordinates.__getattribute__(sky_systems_map[radesys])(0., 0., equinox=equinox,
     #                obstime=dateobs, unit=units)
 
 
@@ -258,9 +264,9 @@ specsystems = ["WAVE", "FREQ", "ENER", "WAVEN", "AWAV",
                "VRAD", "VOPT", "ZOPT", "BETA", "VELO"]
 
 sky_systems_map = {'ICRS': 'ICRSCoordinates',
-                                    'FK5': 'FK5Coordinates',
-                                    'FK4': 'FK4Coordinates',
-                                    'FK4NOE': 'FK4NoETermCoordinates',
-                                    'GAL': 'GalacticCorrdinates',
-                                    'HOR': 'HorizontalCoordinates'
-                                }
+                   'FK5': 'FK5Coordinates',
+                   'FK4': 'FK4Coordinates',
+                   'FK4NOE': 'FK4NoETermCoordinates',
+                   'GAL': 'GalacticCorrdinates',
+                   'HOR': 'HorizontalCoordinates'
+                   }

--- a/gwcs/wcs.py
+++ b/gwcs/wcs.py
@@ -19,6 +19,7 @@ __all__ = ['WCS']
 
 
 class WCS(object):
+
     """
     Basic WCS class.
 
@@ -35,7 +36,8 @@ class WCS(object):
     name : str
         a name for this WCS
     """
-    def __init__(self, output_frame,  input_frame='detector',
+
+    def __init__(self, output_frame, input_frame='detector',
                  forward_transform=None, name=""):
         self._coord_frames = {}
         self._pipeline = []
@@ -82,10 +84,10 @@ class WCS(object):
         from_name, from_obj = self._get_frame_name(from_frame)
         to_name, to_obj = self._get_frame_name(to_frame)
 
-        #if from_name not in self.available_frames:
-            #raise ValueError("Frame {0} is not in the available frames".format(from_frame))
-        #if to_name not in self.available_frames:
-            #raise ValueError("Frame {0} is not in the available frames".format(to_frame))
+        # if from_name not in self.available_frames:
+        #raise ValueError("Frame {0} is not in the available frames".format(from_frame))
+        # if to_name not in self.available_frames:
+        #raise ValueError("Frame {0} is not in the available frames".format(to_frame))
         try:
             from_ind = self._get_frame_index(from_name)
         except ValueError:
@@ -94,8 +96,8 @@ class WCS(object):
             to_ind = self._get_frame_index(to_name)
         except ValueError:
             raise CoordinateFrameError("Frame {0} is not in the available frames".format(to_name))
-        transforms = np.array(self._pipeline[from_ind : to_ind])[:,1].tolist()
-        return functools.reduce(lambda x, y: x | y , transforms)
+        transforms = np.array(self._pipeline[from_ind: to_ind])[:, 1].tolist()
+        return functools.reduce(lambda x, y: x | y, transforms)
 
     def set_transform(self, from_frame, to_frame, transform):
         """
@@ -114,9 +116,11 @@ class WCS(object):
         to_name, to_obj = self._get_frame_name(to_frame)
         if not self._pipeline:
             if from_name != self._input_frame:
-                raise CoordinateFrameError("Expected 'from_frame' to be {0}".format(self._input_frame))
+                raise CoordinateFrameError(
+                    "Expected 'from_frame' to be {0}".format(self._input_frame))
             if to_frame != self._output_frame:
-                raise CoordinateFrameError("Expected 'to_frame' to be {0}".format(self._output_frame))
+                raise CoordinateFrameError(
+                    "Expected 'to_frame' to be {0}".format(self._output_frame))
         try:
             from_ind = self._get_frame_index(from_name)
         except ValueError:
@@ -162,7 +166,7 @@ class WCS(object):
         """
         Return the index in the pipeline where this frame is locate.
         """
-        return np.asarray(self._pipeline)[:,0].tolist().index(frame)
+        return np.asarray(self._pipeline)[:, 0].tolist().index(frame)
 
     def _get_frame_name(self, frame):
         """
@@ -187,7 +191,6 @@ class WCS(object):
             name = frame.name
             frame_obj = frame
         return name, frame_obj
-
 
     def __call__(self, *args):
         """
@@ -329,22 +332,21 @@ class WCS(object):
         coord : (4, 2) array of (*x*, *y*) coordinates.
             The order is counter-clockwise starting with the bottom left corner.
         """
-        naxis1, naxis2 = axes # extend this to more than 2 axes
+        naxis1, naxis2 = axes  # extend this to more than 2 axes
         if center == True:
             corners = np.array([[1, 1],
                                 [1, naxis2],
                                 [naxis1, naxis2],
-                                [naxis1, 1]], dtype = np.float64)
+                                [naxis1, 1]], dtype=np.float64)
         else:
             corners = np.array([[0.5, 0.5],
                                 [0.5, naxis2 + 0.5],
                                 [naxis1 + 0.5, naxis2 + 0.5],
-                                [naxis1 + 0.5, 0.5]], dtype = np.float64)
-        result =  self.__call__(corners[:,0], corners[:,1])
+                                [naxis1 + 0.5, 0.5]], dtype=np.float64)
+        result = self.__call__(corners[:, 0], corners[:, 1])
         return np.asarray(result).T
         #result = np.vstack(self.__call__(corners[:,0], corners[:,1])).T
-        #try:
-            #return self.output_coordinate_system.world_coordinates(result[:,0], result[:,1])
-        #except:
-            #return result
-
+        # try:
+        # return self.output_coordinate_system.world_coordinates(result[:,0], result[:,1])
+        # except:
+        # return result


### PR DESCRIPTION
This PR separates the mask used in `RegionsSelector` into a separate model, subclass of `modeling.Model`. This allows inverse to be assigned to it and used with `RegionsSelector.inverse`.
Also some refactoring of the Selector model.