### PR TITLE
Generalize selector classes

### DIFF
--- a/gwcs/selector.py
+++ b/gwcs/selector.py
@@ -1,7 +1,27 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+The classes in this module create discontinuous transforms.
+The main class is `RegionsSelector`. It maps regions to transforms.
+Regions are well defined spaces in the same frame as the inputs to
+RegionsSelector. They are assigned unique labels (int or str).
+
+The module also defines classes which map inputs to regions.
+An in stance of one of the LabelMapper classes is passed as a parameter to RegionsSelector.
+Its purpose is to return the labels of the  regions within which
+all inputs are located. This labels are used by RegionsSelector to
+pick the corresponding transform. Finally, RegionsSelector
+evaluates the transforms with their corresponding inputs.
+
+The base class _LabelMapper can be subclassed to create other
+label mappers. The inputs to RegionsSelector are passed to the
+LabelMapper instance which must return a label.
+
+
+"""
 from __future__ import absolute_import, division, unicode_literals, print_function
 
 import copy
+import numbers
 import numpy as np
 import warnings
 
@@ -13,7 +33,29 @@ from . import region
 from .utils import RegionError
 
 
-__all__ = ['SelectorMask', 'RegionsSelector']
+__all__ = ['LabelMapperArray', 'LabelMapperDict', 'LabelMapperRange', 'RegionsSelector']
+
+
+def get_unique_regions(regions):
+    if isinstance(regions, np.ndarray):
+        unique_regions = np.unique(regions).tolist()
+
+        try:
+            unique_regions.remove(0)
+            unique_regions.remove('')
+        except ValueError:
+            pass
+        try:
+            unique_regions.remove("")
+        except ValueError:
+            pass
+    elif isinstance(regions, dict):
+        unique_regions = []
+        for key in regions.keys():
+            unique_regions.append(regions[key](key))
+    else:
+        raise TypeError("Unable to get unique regions.")
+    return unique_regions
 
 
 def _toindex(value):
@@ -38,69 +80,115 @@ def _toindex(value):
     return indx
 
 
-class SelectorMask(Model):
-
+class _LabelMapper(Model):
     """
-    A mask model to be used with the `~gwcs.selector.RegionsSelector` transform.
+    Maps location to a label.
 
-    For an IFU observation, the values of the mask
-    correspond to the region (slice)  label.
+    Labels are strings or numbers which uniquely identify a location.
+    For example, labels may represent slices of an IFU or names of spherical polygons.
 
     Parameters
     ----------
-    mask : ndarray
+    mapper : object
+        A python structure which represents the labels.
+        Look at subclasses for examples.
+    no_label : str or int
+        "" or 0
+        A return value for a location which has no corresponding label.
+    inputs_mapping : `~astropy.modeling.mappings.Mapping`
+        An optional Mapping model to be prepended to the LabelMapper
+        with the purpose to filter the inputs or change their order.
+    """
+    def __init__(self, mapper, no_label, inputs_mapping=None):
+        self._no_label = no_label
+        self._inputs_mapping = inputs_mapping
+        self._mapper = mapper
+        super(_LabelMapper, self).__init__()
+
+    @property
+    def mapper(self):
+        return self._mapper
+
+    @property
+    def inputs_mapping(self):
+        return self._inputs_mapping
+
+    @property
+    def no_label(self):
+        return self._no_label
+
+    def get_labels(self):
+        """
+        Return the labels in the mapper.
+        """
+        raise NotImplementedError("Subclasses should impement this.")
+
+
+class LabelMapperArray(_LabelMapper):
+
+    """
+    Maps array locations to labels.
+
+    Parameters
+    ----------
+    mapper : ndarray
         An array of integers or strings where the values
-        correspond to a transform label in `~gwcs.selector.RegionsSelector` model.
-        If a transform is not defined the value shoul dbe set to 0 or " ".
+        correspond to a label in `~gwcs.selector.RegionsSelector` model.
+        If a transform is not defined the value should be set to 0 or " ".
+    inputs_mapping : `~astropy.modeling.mappings.Mapping`
+        An optional Mapping model to be prepended to the LabelMapper
+        with the purpose to filter the inputs or change their order.
+
+    Use case:
+    For an IFU observation, the array represents the detector and its
+    values correspond to the IFU slice  label.
+
     """
 
     inputs = ('x', 'y')
-    outputs = ('z')
+    outputs = ('label',)
 
     linear = False
     fittable = False
 
-    def __init__(self, mask):
-        if mask.dtype.type is not np.unicode_:
-            self._mask = np.asanyarray(mask, dtype=np.int)
+    def __init__(self, mapper, inputs_mapping=None):
+        if mapper.dtype.type is not np.unicode_:
+            mapper = np.asanyarray(mapper, dtype=np.int)
+            _no_label = 0
         else:
-            self._mask = mask
-        if mask.dtype.type is np.string_:
-            self._no_transform_value = ""
+            _no_label = ""
+
+        super(LabelMapperArray, self).__init__(mapper, _no_label)
+
+    def get_labels(self):
+        labels = list(np.unique(self._mapper))
+
+        if isinstance(labels[0], numbers.Number):
+            if 0 in labels:
+                labels.remove(0)
         else:
-            self._no_transform_value = 0
-        super(SelectorMask, self).__init__()
+            if "" in labels:
+                labels.remove("")
+        return labels
 
-    @property
-    def mask(self):
-        return self._mask
-
-    @property
-    def no_transform_value(self):
-        return self._no_transform_value
-
-    def evaluate(self, x, y):
-
-        indx = _toindex(x)
-        indy = _toindex(y)
-        return self.mask[indx, indy]
+    def evaluate(self, *args):
+        args = [_toindex(a) for a in args]
+        return self._mapper[args]
 
     @classmethod
-    def from_vertices(cls, mask_shape, regions):
+    def from_vertices(cls, shape, regions):
         """
-        Create a `~gwcs.selector.SelectorMask` from
-        polygon vertices read in from a json file.
+        Create a `~gwcs.selector.LabelMapperArray` from
+        polygon vertices stores in a dict.
 
         Parameters
         ----------
-        mask_shape : tuple
-            shape of mask array
+        shape : tuple
+            shape of mapper array
         regions: dict
             {region_label : list_of_polygon_vertices}
-
             The keys in this dictionary should match the region labels
             in `~gwcs.selector.RegionsSelector`.
-
             The list of vertices is ordered in such a way that when traversed in a
             counterclockwise direction, the enclosed area is the polygon.
             The last vertex must coincide with the first vertex, minimum
@@ -108,16 +196,25 @@ class SelectorMask(Model):
 
         Returns
         -------
-        mask : `~gwcs.selector.SelectorMask`
-            Mask to be used with `~gwcs.selector.SelectorModel`.
+        mapper : `~gwcs.selector.LabelMapperArray`
+            This models is used with `~gwcs.selector.RegionsSelector`.
+            A model which takes the same inputs as `~gwcs.selector.RegionsSelector`
+            and returns a label.
+
+
 
         Examples
-        -------_
-        mask = region.create_regions_mask_from_json((300,300), 'regions.json',
-        'region_schema.json')
+        --------
+        regions = {1: [[795, 970], [2047, 970], [2047, 999], [795, 999], [795, 970]],
+                   2: [[844, 1067], [2047, 1067], [2047, 1113], [844, 1113], [844, 1067]],
+                   3: [[654, 1029], [2047, 1029], [2047, 1078], [654, 1078], [654, 1029]],
+                   4: [[772, 990], [2047, 990], [2047, 1042], [772, 1042], [772, 990]]
+                  }
+        mapper = selector.LabelMapperArray.from_vertices((2400, 2400), regions)
+
         """
         labels = np.array(list(regions.keys()))
-        mask = np.zeros(mask_shape, dtype=labels.dtype)
+        mask = np.zeros(shape, dtype=labels.dtype)
 
         for rid, vert in regions.items():
             pol = region.Polygon(rid, vert)
@@ -126,11 +223,171 @@ class SelectorMask(Model):
         return cls(mask)
 
 
+class LabelMapperDict(_LabelMapper):
+
+    """
+    Maps a number to a transform. The transforms take as input the key
+    and return a label.
+
+    Use case: inverse transforms of an IFU.
+    For an IFU observation, the keys are constant angles (corresponding to a slice)
+    and values are transforms which return a slice label.
+
+    Parameters
+    ----------
+    inputs : tuple of str
+        Names for the inputs, e.g. ('alpha', 'beta', lam')
+    mapper : dict
+        Maps key values to transforms.
+    inputs_mapping : `~astropy.modeling.mappings.Mapping`
+        An optional Mapping model to be prepended to the LabelMapper
+        with the purpose to filter the inputs or change their order.
+    """
+    standard_broadcasting = False
+    outputs = ('labels',)
+
+    linear = False
+    fittable = False
+
+    def __init__(self, inputs, mapper, inputs_mapping=None):
+        self.inputs = inputs
+        # try to determine if slices are numbers of strings
+        if isinstance(mapper[list(mapper.keys())[0]](*np.arange(len(inputs))), numbers.Number):
+            _no_label = 0
+        else:
+            _no_label = ""
+        super(LabelMapperDict, self).__init__(mapper, _no_label, inputs_mapping)
+
+    def get_labels(self):
+        labels = [self._mapper[key](key) for key in self._mapper.keys()]
+        return labels
+
+    def evaluate(self, *args):
+        shape = args[0].shape
+        args = [a.flatten() for a in args]
+        if self.inputs_mapping is not None:
+            keys = self._inputs_mapping.evaluate(*args)
+        else:
+            keys = args
+        res = np.empty(shape, dtype=type(self._no_label))
+        unique = np.unique(keys)
+        for key in unique:
+            ind = (keys == key)
+            inputs = [a[ind] for a in args]
+            mapper_keys = list(self.mapper.keys())
+            key_ind = np.nonzero([np.allclose(key, mk) for mk in mapper_keys])[0]
+            if key_ind.size > 1:
+                raise ValueError("More than one key found.")
+            elif key_ind.size == 0:
+                res[ind] = self._no_label
+            else:
+                res[ind] = self.mapper[key](*inputs)
+        res.shape = shape
+        return res
+
+
+class LabelMapperRange(_LabelMapper):
+
+    """
+    The structure this class uses maps a range of values to a transform.
+    Given an in put value it checks which range the value falls in and returns
+    the corresponding transform. When evaluated the transform returns a label.
+
+    This class is to be used as an argument to `~gwcs.selector.RegionsSelector`.
+    All inputs passed to `~gwcs.selector.RegionsSelector` are passed to
+    this class. ``inputs_mapping`` is used to filter which input is to be used
+    to determine the range. Transforms may use an instance of `~astropy.modeling.models.Mapping`
+    and/or `~astropy.modeling.models.Identity` to filter or change the order of their inputs.
+
+    Example: Pick a transform based on wavelength range.
+    For an IFU observation, the keys are (lambda_min, lambda_max) pairs
+    and values are transforms which return a label corresponding to a slice.
+    This label is used by `~gwcs.selector.RegionsSelector` to evaluate the transform
+    corresponding to this slice.
+
+
+    Parameters
+    ----------
+    inputs : tuple of str
+        Names for the inputs, e.g. ('alpha', 'beta', 'lambda')
+    mapper : dict
+        Maps key values to transforms.
+    inputs_mapping : `~astropy.modeling.mappings.Mapping`
+        An optional Mapping model to be prepended to the LabelMapper
+        with the purpose to filter the inputs or change their order.
+    """
+    standard_broadcasting = False
+    outputs = ('labels',)
+
+    linear = False
+    fittable = False
+
+    def __init__(self, inputs, mapper, inputs_mapping=None):
+        self.inputs = inputs
+        # try to determine if slices are numbers of strings
+        #if isinstance(mapper[list(mapper.keys())[0]](*np.arange(len(inputs))), numbers.Number):
+        _no_label = 0
+        #else:
+        #    _no_label = ""
+        super(LabelMapperRange, self).__init__(mapper, _no_label, inputs_mapping)
+
+    def get_labels(self):
+        labels = [self._mapper[key](key) for key in self._mapper.keys()]
+        return labels
+
+    # move this to utils?
+    def _find_range(self, value_range, value):
+        """
+        Returns the index of the range which holds value.
+
+        Parameters
+        ----------
+        value_range : np.ndarray
+            an (2, 2) array of non-overlapping (min, max) values
+        value : number
+            The value to
+        """
+        a, b = value_range[:,0], value_range[:,1]
+        ind = np.logical_and(value > a, value < b).nonzero()[0]
+        if ind.size > 1:
+            raise ValueError("There are overlapping ranges.")
+        elif ind.size == 0:
+            return None
+        else:
+            return ind.item()
+
+    def evaluate(self, *args):
+        shape = args[0].shape
+        args = [a.flatten() for a in args]
+        if self.inputs_mapping is not None:
+            keys = self._inputs_mapping.evaluate(*args)
+        else:
+            keys = args
+        res = np.empty(shape, dtype=type(self._no_label)) # this creates a S1 type array
+        unique = np.unique(keys)
+        value_range = np.array(self.mapper.keys())
+        for key in unique:
+            ind = (keys == key)#[0]
+            print('ind', ind)
+            print('a', a)
+            print('args', args)
+            inputs = [a[ind] for a in args]
+            range_ind = self._find_range(value_range, key)
+            #filter out values which are not within any region
+            if range_ind is not None:
+                transform = self.mapper[list(self.mapper.keys())[range_ind]]
+                res[ind] = transform(*inputs)
+            else:
+                res[ind] = self._no_label
+            res.shape = shape
+        return res
+
+
 class RegionsSelector(Model):
 
     """
-    A model which maps regions to their corresponding transforms.
-    It evaluates the model matching inputs to the correct region/transform.
+    A model which maps locations to their corresponding transforms.
+    It uses an instance of `_LabelMapper` to map inputs to the correct region.
 
     Parameters
     ----------
@@ -140,70 +397,35 @@ class RegionsSelector(Model):
         Names of the outputs.
     selector : dict
         Mapping of region labels to transforms.
-        Labels can be of type int or str, transforms are of type `~astropy.modeling.core.Model`
-    mask : `~gwcs.selector.SelectorMask`
-        Mask with region labels.
+        Labels can be of type int or str, transforms are of type `~astropy.modeling.core.Model`.
+    label_mapper : a subclass of `~gwcs.selector._LabelMapper`
+        A model which maps locations to region labels.
     undefined_transform_value : float, np.nan (default)
         Value to be returned if there's no transform defined for the inputs.
     """
+    standard_broadcasting = False
     _param_names = ()
 
     linear = False
     fittable = False
 
-    def __init__(self, inputs, outputs, selector, mask, undefined_transform_value=np.nan):
+    def __init__(self, inputs, outputs, selector, label_mapper, undefined_transform_value=np.nan, mapping=None):
+        self._mapping = mapping
         self._inputs = inputs
         self._outputs = outputs
-        self.mask = mask.copy()
+        self.label_mapper = label_mapper
         self._undefined_transform_value = undefined_transform_value
-        self._selector = copy.deepcopy(selector)
+        self._selector = selector #copy.deepcopy(selector)
 
         if " " in selector.keys() or 0 in selector.keys():
             raise ValueError('"0" and " " are not allowed as keys.')
 
         super(RegionsSelector, self).__init__(n_models=1)
         # make sure that keys in mapping match labels in mask
-        labels_mask = self.labels_from_mask(mask.mask)
-        if not np.in1d(labels_mask, list(self._selector.keys()), assume_unique=True).all() or \
-           not np.in1d(list(self._selector.keys()), labels_mask, assume_unique=True).all():
-            raise ValueError("Labels don't match regions_mask.")
-
-    @staticmethod
-    def labels_from_mask(regions_mask):
-        """
-        Parameters
-        ----------
-        regions_mask : ndarray
-            An array where regions are indicated by int or str labels.
-            " " and 0 indicate a pixel on the detector which is not within any region.
-            Evaluating the model in these locations returns NaN or
-            ``undefined_transform_value`` if provided.
-        """
-        labels = np.unique(regions_mask).tolist()
-        try:
-            labels.remove(0)
-        except ValueError:
-            pass
-        try:
-            labels.remove('')
-        except ValueError:
-            pass
-        return labels
-
-    @staticmethod
-    def get_unique_regions(mask):
-        unique_regions = np.unique(mask).tolist()
-
-        try:
-            unique_regions.remove(0)
-            unique_regions.remove('')
-        except ValueError:
-            pass
-        try:
-            unique_regions.remove("")
-        except ValueError:
-            pass
-        return unique_regions
+        #labels = label_mapper.get_labels()
+        #if not np.in1d(labels, list(self._selector.keys()), assume_unique=True).all() or \
+           #not np.in1d(list(self._selector.keys()), labels, assume_unique=True).all():
+            #raise ValueError("Selector labels don't match labels in mapper.")
 
     def set_input(self, rid):
         """
@@ -213,71 +435,38 @@ class RegionsSelector(Model):
             return self._selector[rid](x, y)
         return _eval_input
 
-    def evaluate(self, x, y):
+    def evaluate(self, *args):
         """
         Parameters
         ----------
-        x : float or ndarray
-            Input pixel coordinate.
-        y : float or ndarray
-            Input pixel coordinate.
+        args : float or ndarray
+            Input pixel coordinate, one input for each dimension.
+
         """
         # Get the region labels corresponding to these inputs
-        indx = _toindex(x)
-        indy = _toindex(y)
-        rids = self.mask(indx, indy).flatten()
+        rids = self.label_mapper(*args).flatten()
         # Raise an error if all pixels are outside regions
-        if (rids == self.mask.no_transform_value).all():
+        if (rids == self.label_mapper.no_label).all():
             raise RegionError("The input positions are not inside any region.")
 
-        # Create output arrays and set any pixels not withing regions to
+        # Create output arrays and set any pixels not within regions to
         # "undefined_transform_value"
-        no_trans_ind = (rids == self.mask.no_transform_value).nonzero()
+        no_trans_ind = (rids == self.label_mapper.no_label).nonzero()
         outputs = [np.empty(rids.shape) for n in range(self.n_outputs)]
         for out in outputs:
             out[no_trans_ind] = self.undefined_transform_value
 
         # Compute the transformations
-        x = x.flatten()
-        y = y.flatten()
-        uniq = self.get_unique_regions(rids)
+        args = [a.flatten() for a in args]
+        uniq = get_unique_regions(rids)
+
         for rid in uniq:
             ind = (rids == rid)
-            result = self._selector[rid](x[ind], y[ind])
+            inputs = [a[ind] for a in args]
+            result = self._selector[rid](*inputs)
             for j in range(self.n_outputs):
                 outputs[j][ind] = result[j]
         return outputs
-
-    def __call__(self, *inputs, **kwargs):
-        """
-        Evaluate this model using the given input(s) and the parameter values
-        that were specified when the model was instantiated.
-        """
-        import itertools
-
-        parameters = self._param_sets(raw=True)
-        evaluate = self.evaluate
-        inputs, format_info = self.prepare_inputs(*inputs, **kwargs)
-        outputs = evaluate(*itertools.chain(inputs, parameters))
-
-        if self.n_outputs == 1:
-            outputs = (outputs,)
-        return self.prepare_outputs(format_info, *outputs, **kwargs)
-
-    def inverse(self):
-        """
-        The inverse exists if all transforms have an inverse
-        and the mask has an inverse.
-        """
-        selector_inverse = copy.deepcopy(self._selector)
-        for tr in selector_inverse:
-            selector_inverse[tr] = selector_inverse[tr].inverse
-        try:
-            mask = self.mask.inverse
-        except NotImplementedError:
-            raise
-        return self.__class__(self.outputs, self.inputs, selector_inverse,
-                              mask, self.undefined_transform_value)
 
     @property
     def undefined_transform_value(self):

--- a/gwcs/selector.py
+++ b/gwcs/selector.py
@@ -117,12 +117,6 @@ class _LabelMapper(Model):
     def no_label(self):
         return self._no_label
 
-    def get_labels(self):
-        """
-        Return the labels in the mapper.
-        """
-        raise NotImplementedError("Subclasses should impement this.")
-
 
 class LabelMapperArray(_LabelMapper):
 
@@ -159,17 +153,6 @@ class LabelMapperArray(_LabelMapper):
             _no_label = ""
 
         super(LabelMapperArray, self).__init__(mapper, _no_label)
-
-    def get_labels(self):
-        labels = list(np.unique(self._mapper))
-
-        if isinstance(labels[0], numbers.Number):
-            if 0 in labels:
-                labels.remove(0)
-        else:
-            if "" in labels:
-                labels.remove("")
-        return labels
 
     def evaluate(self, *args):
         args = [_toindex(a) for a in args]
@@ -258,10 +241,6 @@ class LabelMapperDict(_LabelMapper):
             _no_label = ""
         super(LabelMapperDict, self).__init__(mapper, _no_label, inputs_mapping)
 
-    def get_labels(self):
-        labels = [self._mapper[key](key) for key in self._mapper.keys()]
-        return labels
-
     def evaluate(self, *args):
         shape = args[0].shape
         args = [a.flatten() for a in args]
@@ -330,10 +309,6 @@ class LabelMapperRange(_LabelMapper):
         #else:
         #    _no_label = ""
         super(LabelMapperRange, self).__init__(mapper, _no_label, inputs_mapping)
-
-    def get_labels(self):
-        labels = [self._mapper[key](key) for key in self._mapper.keys()]
-        return labels
 
     # move this to utils?
     def _find_range(self, value_range, value):

--- a/gwcs/selector.py
+++ b/gwcs/selector.py
@@ -6,11 +6,11 @@ Regions are well defined spaces in the same frame as the inputs to
 RegionsSelector. They are assigned unique labels (int or str).
 
 The module also defines classes which map inputs to regions.
-An in stance of one of the LabelMapper classes is passed as a parameter to RegionsSelector.
+An instance of one of the LabelMapper classes is passed as a parameter to RegionsSelector.
 Its purpose is to return the labels of the  regions within which
-all inputs are located. This labels are used by RegionsSelector to
-pick the corresponding transform. Finally, RegionsSelector
-evaluates the transforms with their corresponding inputs.
+each input is located. The labels are used by RegionsSelector to
+pick the corresponding transforms. Finally, RegionsSelector
+evaluates the transforms using the matchin inputs.
 
 The base class _LabelMapper can be subclassed to create other
 label mappers. The inputs to RegionsSelector are passed to the

--- a/gwcs/selector.py
+++ b/gwcs/selector.py
@@ -187,16 +187,14 @@ class LabelMapperArray(_LabelMapper):
             A model which takes the same inputs as `~gwcs.selector.RegionsSelector`
             and returns a label.
 
-
-
         Examples
         --------
-        regions = {1: [[795, 970], [2047, 970], [2047, 999], [795, 999], [795, 970]],
-                   2: [[844, 1067], [2047, 1067], [2047, 1113], [844, 1113], [844, 1067]],
-                   3: [[654, 1029], [2047, 1029], [2047, 1078], [654, 1078], [654, 1029]],
-                   4: [[772, 990], [2047, 990], [2047, 1042], [772, 1042], [772, 990]]
-                  }
-        mapper = selector.LabelMapperArray.from_vertices((2400, 2400), regions)
+        >>> regions = {1: [[795, 970], [2047, 970], [2047, 999], [795, 999], [795, 970]],
+                       2: [[844, 1067], [2047, 1067], [2047, 1113], [844, 1113], [844, 1067]],
+                       3: [[654, 1029], [2047, 1029], [2047, 1078], [654, 1078], [654, 1029]],
+                       4: [[772, 990], [2047, 990], [2047, 1042], [772, 1042], [772, 990]]
+                      }
+        >>> mapper = selector.LabelMapperArray.from_vertices((2400, 2400), regions)
 
         """
         labels = np.array(list(regions.keys()))
@@ -341,7 +339,7 @@ class LabelMapperRange(_LabelMapper):
             keys = args
         res = np.empty(shape)
         unique = np.unique(keys)
-        value_range = np.array(self.mapper.keys())
+        value_range = np.array(list(self.mapper.keys()))
         for key in unique:
             ind = (keys == key)
             inputs = [a[ind] for a in args]

--- a/gwcs/selector.py
+++ b/gwcs/selector.py
@@ -117,6 +117,9 @@ class _LabelMapper(Model):
     def no_label(self):
         return self._no_label
 
+    def evaluate(self, *args):
+        raise NotImplementedError("Subclasses should implement this method.")
+
 
 class LabelMapperArray(_LabelMapper):
 

--- a/gwcs/tests/test_region.py
+++ b/gwcs/tests/test_region.py
@@ -6,7 +6,8 @@ from __future__ import absolute_import, division, unicode_literals, print_functi
 
 import numpy as np
 from numpy.testing import utils
-
+from astropy.modeling import models
+from astropy.tests.helper import pytest
 from .. import region, selector
 
 
@@ -23,7 +24,7 @@ def test_LabelMapperArray_from_vertices_int():
     assert(np.sort(labels) == np.sort(mask_labels)).all()
 
 
-def test_SelectorMask_from_vertices_string():
+def test_LabelMapperArray_from_vertices_string():
     regions = {'S1600A1': [[795, 970], [2047, 970], [2047, 999], [795, 999], [795, 970]],
                'S200A1': [[844, 1067], [2047, 1067], [2047, 1113], [844, 1113], [844, 1067]],
                'S200A2': [[654, 1029], [2047, 1029], [2047, 1078], [654, 1078], [654, 1029]],
@@ -78,3 +79,63 @@ def test_create_mask_two_polygons():
     mask = selector.LabelMapperArray.from_vertices((301, 301), vertices)
     pol2 = two_polygons()
     utils.assert_equal(mask.mapper, pol2)
+
+
+def create_range_mapper():
+    m = []
+    for i in np.arange(9) *.1:
+        c0_0, c1_0, c0_1, c1_1 = np.ones((4,)) * i
+        m.append(models.Polynomial2D(2, c0_0=c0_0,
+                                     c1_0=c1_0, c0_1=c0_1, c1_1=c1_1))
+    keys = np.array([[  4.88,   5.77],
+                     [  5.64,   6.67],
+                     [  6.5 ,   7.7 ],
+                     [  7.47,   8.83],
+                     [  8.63,  10.19],
+                     [  9.96,  11.77],
+                     [ 11.49,  13.55],
+                     [ 13.28,  15.66],
+                     [ 15.34,  18.09]])
+
+    rmapper = {}
+    for k, v in zip(keys, m):
+        rmapper[tuple(k)] = v
+
+    sel = selector.LabelMapperRange(('x', 'y'), rmapper,
+                                   inputs_mapping=models.Mapping((0,), n_inputs=2))
+    return sel
+
+
+def test_LabelMapperDict():
+    m = []
+    for i in np.arange(5) *.1:
+        c0_0, c1_0, c0_1, c1_1 = np.ones((4,)) * i
+        m.append(models.Polynomial2D(2, c0_0=c0_0,
+                                     c1_0=c1_0, c0_1=c0_1, c1_1=c1_1))
+    keys = [ -1.95805483e+00,  -1.67833272e+00,  -1.39861060e+00,
+             -1.11888848e+00,  -8.39166358e-01]
+
+    dmapper = {}
+    for k, v in zip(keys, m):
+        dmapper[k] = v
+
+    sel = selector.LabelMapperDict(('x', 'y'), dmapper,
+                                   inputs_mapping=models.Mapping((0,), n_inputs=2))
+    assert(sel(-1.9580, 2) == dmapper[-1.95805483](-1.95805483, 2))
+
+
+def test_LabelMapperRange():
+    sel = create_range_mapper()
+    assert(sel(6, 2) == 2.1)
+
+
+def test_outside_range():
+    """
+    Overlapping ranges should raise an error.
+    """
+    sel = create_range_mapper()
+    key = sel.mapper.keys()[0]
+    newkey = (key[0], key[1]+5)
+    sel.mapper[newkey] = sel.mapper[key]
+    with pytest.raises(ValueError):
+        sel(key[0] + .5, 3)

--- a/gwcs/tests/test_region.py
+++ b/gwcs/tests/test_region.py
@@ -10,16 +10,16 @@ from numpy.testing import utils
 from .. import region, selector
 
 
-def test_SelectorMask_from_vertices_int():
+def test_LabelMapperArray_from_vertices_int():
     regions = {1: [[795, 970], [2047, 970], [2047, 999], [795, 999], [795, 970]],
                2: [[844, 1067], [2047, 1067], [2047, 1113], [844, 1113], [844, 1067]],
                3: [[654, 1029], [2047, 1029], [2047, 1078], [654, 1078], [654, 1029]],
                4: [[772, 990], [2047, 990], [2047, 1042], [772, 1042], [772, 990]]
                }
-    mask = selector.SelectorMask.from_vertices((2400, 2400), regions)
+    mask = selector.LabelMapperArray.from_vertices((2400, 2400), regions)
     labels = list(regions.keys())
     labels.append(0)
-    mask_labels = np.unique(mask.mask).tolist()
+    mask_labels = np.unique(mask.mapper).tolist()
     assert(np.sort(labels) == np.sort(mask_labels)).all()
 
 
@@ -29,10 +29,10 @@ def test_SelectorMask_from_vertices_string():
                'S200A2': [[654, 1029], [2047, 1029], [2047, 1078], [654, 1078], [654, 1029]],
                'S400A1': [[772, 990], [2047, 990], [2047, 1042], [772, 1042], [772, 990]]
                }
-    mask = selector.SelectorMask.from_vertices((1400, 1400), regions)
+    mask = selector.LabelMapperArray.from_vertices((1400, 1400), regions)
     labels = list(regions.keys())
     labels.append('')
-    mask_labels = np.unique(mask.mask).tolist()
+    mask_labels = np.unique(mask.mapper).tolist()
     assert(np.sort(labels) == np.sort(mask_labels)).all()
 
 
@@ -75,6 +75,6 @@ def test_polygon1():
 def test_create_mask_two_polygons():
     vertices = {1: [[2, 1], [3, 5], [6, 6], [3, 8], [0, 4], [2, 1]],
                 2: [[10, 0], [30, 0], [30, 30], [10, 30], [10, 0]]}
-    mask = selector.SelectorMask.from_vertices((301, 301), vertices)
+    mask = selector.LabelMapperArray.from_vertices((301, 301), vertices)
     pol2 = two_polygons()
-    utils.assert_equal(mask.mask, pol2)
+    utils.assert_equal(mask.mapper, pol2)

--- a/gwcs/tests/test_region.py
+++ b/gwcs/tests/test_region.py
@@ -134,7 +134,7 @@ def test_outside_range():
     Overlapping ranges should raise an error.
     """
     sel = create_range_mapper()
-    key = sel.mapper.keys()[0]
+    key = list(sel.mapper.keys())[0]
     newkey = (key[0], key[1]+5)
     sel.mapper[newkey] = sel.mapper[key]
     with pytest.raises(ValueError):


### PR DESCRIPTION
The `RegionsSelector` class maps region labels to transforms. One of its parameters is a model which maps inputs to region labels and hands the labels to `RegionsSelector`. This model (previously called `SelectorMask`) worked only with arrays. 

The old name was not very descriptive. This model takes the same inputs as RegionsSelector and returns matching labels so I changed the name to `LabelMapperArray` (I'm open to other suggestions).

Two other common cases are implemented here.
 `LabelMapperDict` is represented by a dict with {number: transform} pairs. The model takes the same inputs as RegionsSelector and uses one of the inputs to match a key in the dictionary. It returns the result of evaluating the transform which must be a label.

 Similarly `LabelMapperRange` is represented by a dict {(a_min, a_max) : transform} pairs where each key represents a range of numbers. The model takes the same inputs as RegionsSelector and uses one of the inputs to find the range it falls into. It evaluates the corresponding transform and returns a label. The keys must represent non-overlapping ranges.

Any comments? @perrygreenfield @mdboom @embray 

I will include the corresponding schema and readers/writers in a separate PR.