### PR TITLE
Infrastructure update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,6 @@ env:
     matrix:
         - SETUP_CMD='egg_info'
         - SETUP_CMD='test'
-        - ASTROPY_VERSION=stable SETUP_CMD='test'
 
 matrix:
     include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,17 @@
 language: python
 
+# Setting sudo to false opts in to Travis-CI container-based builds.
+sudo: false
+
+# The apt packages below are needed for sphinx builds, which can no longer
+# be installed with sudo apt-get.
+addons:
+    apt:
+        packages:
+            - graphviz
+            - texlive-latex-extra
+            - dvipng
+
 python:
     - 2.7
     - 3.4
@@ -68,12 +80,6 @@ before_install:
     - conda config --set always_yes yes --set changeps1 no
     - conda update -q conda
     - conda info -a
-
-    # UPDATE APT-GET LISTINGS
-    - sudo apt-get update
-
-    # DOCUMENTATION DEPENDENCIES
-    - if [[ $SETUP_CMD == build_sphinx* ]]; then sudo apt-get install graphviz texlive-latex-extra dvipng; fi
 
 install:
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ env:
 matrix:
     include:
 
-        # Do a coverage test in Python 2. 
+        # Do a coverage test in Python 2.
         - python: 2.7
           env: SETUP_CMD='test --coverage'
 
@@ -59,11 +59,15 @@ before_install:
     # Use utf8 encoding. Should be default, but this is insurance against
     # future changes
     - export PYTHONIOENCODING=UTF8
-    - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
-    - chmod +x miniconda.sh
-    - ./miniconda.sh -b
-    - export PATH=/home/travis/miniconda/bin:$PATH
-    - conda update --yes conda
+
+    # http://conda.pydata.org/docs/travis.html#the-travis-yml-file
+    - wget https://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh;
+    - bash miniconda.sh -b -p $HOME/miniconda
+    - export PATH="$HOME/miniconda/bin:$PATH"
+    - hash -r
+    - conda config --set always_yes yes --set changeps1 no
+    - conda update -q conda
+    - conda info -a
 
     # UPDATE APT-GET LISTINGS
     - sudo apt-get update

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ addons:
 python:
     - 2.7
     - 3.4
-    # This is just for "egg_info".  All other builds are explicitly given in the matrix
+
 env:
     global:
         # The following versions are the 'default' for tests, unless
@@ -23,10 +23,12 @@ env:
         # to repeat them for all configurations.
         - NUMPY_VERSION=1.9
         - ASTROPY_VERSION=development
-        - CONDA_INSTALL='conda install -c astropy-ci-extras --yes'
-        - PIP_INSTALL='pip install'
+        - CONDA_DEPENDENCIES=''
+        - PIP_DEPENDENCIES='git+https://github.com/spacetelescope/pyasdf.git#egg=pyasdf'
     matrix:
         - SETUP_CMD='egg_info'
+        - SETUP_CMD='test'
+        - ASTROPY_VERSION=stable SETUP_CMD='test'
 
 matrix:
     include:
@@ -40,78 +42,9 @@ matrix:
         - python: 2.7
           env: SETUP_CMD='build_sphinx -w'
 
-        # Try Astropy development version
-        - python: 2.7
-          env: ASTROPY_VERSION=development SETUP_CMD='test'
-        - python: 3.3
-          env: ASTROPY_VERSION=development SETUP_CMD='test'
-
-        # Try all python versions with the latest numpy
-        - python: 2.7
-          env: SETUP_CMD='test'
-        #- python: 3.2
-        #  env: SETUP_CMD='test'
-        #- python: 3.3
-        #  env: SETUP_CMD='test'
-        - python: 3.4
-          env: SETUP_CMD='test'
-
-        # Try older numpy versions
-        #- python: 3.2
-        #  env: NUMPY_VERSION=1.6 SETUP_CMD='test'
-        #- python: 2.7
-        #  env: NUMPY_VERSION=1.7 SETUP_CMD='test'
-        #- python: 2.7
-        #  env: NUMPY_VERSION=1.6 SETUP_CMD='test'
-        #- python: 2.7
-        #  env: NUMPY_VERSION=1.5 SETUP_CMD='test'
-
-before_install:
-
-    # Use utf8 encoding. Should be default, but this is insurance against
-    # future changes
-    - export PYTHONIOENCODING=UTF8
-
-    # http://conda.pydata.org/docs/travis.html#the-travis-yml-file
-    - wget https://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh;
-    - bash miniconda.sh -b -p $HOME/miniconda
-    - export PATH="$HOME/miniconda/bin:$PATH"
-    - hash -r
-    - conda config --set always_yes yes --set changeps1 no
-    - conda update -q conda
-    - conda info -a
-
 install:
-
-    # CONDA
-    - conda create --yes -n test -c astropy-ci-extras python=$TRAVIS_PYTHON_VERSION
-    - source activate test
-
-    # CORE DEPENDENCIES
-    - if [[ $SETUP_CMD != egg_info ]]; then $CONDA_INSTALL numpy=$NUMPY_VERSION pytest pip Cython jinja2; fi
-    - if [[ $SETUP_CMD != egg_info ]]; then $PIP_INSTALL pytest-xdist; fi
-    - if [[ $SETUP_CMD != egg_info ]]; then $PIP_INSTALL git+https://github.com/spacetelescope/pyasdf.git#egg=pyasdf; fi
-
-    # ASTROPY
-    - if [[ $SETUP_CMD != egg_info ]] && [[ $ASTROPY_VERSION == development ]]; then $PIP_INSTALL git+http://github.com/astropy/astropy.git#egg=astropy; fi
-    - if [[ $SETUP_CMD != egg_info ]] && [[ $ASTROPY_VERSION == stable ]]; then $CONDA_INSTALL numpy=$NUMPY_VERSION astropy; fi
-
-    # OPTIONAL DEPENDENCIES
-    # Here you can add any dependencies your package may have. You can use
-    # conda for packages available through conda, or pip for any other
-    # packages. You should leave the `numpy=$NUMPY_VERSION` in the `conda`
-    # install since this ensures Numpy does not get automatically upgraded.
-    - if [[ $SETUP_CMD != egg_info ]]; then $CONDA_INSTALL numpy=$NUMPY_VERSION ; fi
-    #- if [[ $SETUP_CMD != egg_info ]]; then $PIP_INSTALL ...; fi
-
-    # DOCUMENTATION DEPENDENCIES
-    # build_sphinx needs sphinx and matplotlib (for plot_directive). Note that
-    # this matplotlib will *not* work with py 3.x, but our sphinx build is
-    # currently 2.7, so that's fine
-    - if [[ $SETUP_CMD == build_sphinx* ]]; then $CONDA_INSTALL numpy=$NUMPY_VERSION Sphinx matplotlib; fi
-
-    # COVERAGE DEPENDENCIES
-    - if [[ $SETUP_CMD == 'test --coverage' ]]; then $PIP_INSTALL coverage coveralls; fi
+    - git clone git://github.com/astropy/ci-helpers.git
+    - source ci-helpers/travis/setup_conda_$TRAVIS_OS_NAME.sh
 
 script:
    - python setup.py $SETUP_CMD

--- a/ah_bootstrap.py
+++ b/ah_bootstrap.py
@@ -409,7 +409,7 @@ class _Bootstrapper(object):
     def get_index_dist(self):
         if not self.download:
             log.warn('Downloading {0!r} disabled.'.format(DIST_NAME))
-            return False
+            return None
 
         log.warn(
             "Downloading {0!r}; run setup.py with the --offline option to "

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -29,7 +29,7 @@ Installation
 
 - `numpy <http://www.numpy.org/>`__ 1.6 or later
 
-- `astropy <http://www.astropy.org/>`__ 1.0 or later
+- `astropy <http://www.astropy.org/>`__ 1.1 or later
 
 - `pyasdf <http://pyasdf.readthedocs.org/en/latest/>`__
 

--- a/gwcs/conftest.py
+++ b/gwcs/conftest.py
@@ -14,7 +14,7 @@ try:
     PYTEST_HEADER_MODULES['Astropy'] = 'astropy'
     PYTEST_HEADER_MODULES['pyasdf'] = 'pyasdf'
     del PYTEST_HEADER_MODULES['h5py']
-except NameError:  # needed to support Astropy < 1.0
+except (NameError, KeyError):
     pass
 
 # This is to figure out the affiliated package version, rather than

--- a/gwcs/conftest.py
+++ b/gwcs/conftest.py
@@ -1,18 +1,28 @@
+import os
+
 # this contains imports plugins that configure py.test for astropy tests.
 # by importing them here in conftest.py they are discoverable by py.test
 # no matter how it is invoked within the source tree.
 
 from astropy.tests.pytest_plugins import *
 
-## Uncomment the following line to treat all DeprecationWarnings as
-## exceptions
+# Uncomment the following line to treat all DeprecationWarnings as
+# exceptions
 enable_deprecations_as_exceptions()
 
-## Uncomment and customize the following lines to add/remove entries
-## from the list of packages for which version numbers are displayed
-## when running the tests
-# try:
-#     PYTEST_HEADER_MODULES['scikit-image'] = 'skimage'
-#     del PYTEST_HEADER_MODULES['h5py']
-# except NameError:  # needed to support Astropy < 1.0
-#     pass
+try:
+    PYTEST_HEADER_MODULES['Astropy'] = 'astropy'
+    PYTEST_HEADER_MODULES['pyasdf'] = 'pyasdf'
+    del PYTEST_HEADER_MODULES['h5py']
+except NameError:  # needed to support Astropy < 1.0
+    pass
+
+# This is to figure out the affiliated package version, rather than
+# using Astropy's
+from . import version
+
+try:
+    packagename = os.path.basename(os.path.dirname(__file__))
+    TESTED_VERSIONS[packagename] = version.version
+except NameError:   # Needed to support Astropy <= 1.0.0
+    pass


### PR DESCRIPTION
Including:

  -  fix miniconda prefix (that causes travis failures at the moment)
  -  update helpers to 1.0.5
  -  opt in to container based travis
  -  customize test header