### PR TITLE
fix label_mappers

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,16 @@
 0.6 (unreleased)
 ----------------
 
+API_Changes
+^^^^^^^^^^^
+- Added `atol` argument to `LabelMapperDict`, representing the absolute tolerance [#29]
+
+Bug Fixes
+^^^^^^^^^
+- Fixed a bug in `LabelMapperDict` where a wrong index was used.[#29]
+- Changed the order of the inputs when `LabelMapperArray` is evaluated as
+  the inputs are supposed to be image coordinates. [#29]
+
 0.5 (2015-12-28)
 ----------------
 


### PR DESCRIPTION
Added atol argument to LabelMapperDict - passed to np.allclose().

 Reversed the order of inputs in LabelMapperArray, as the input coordinates are image coordinates in (slow-, fast-) changing axis.