### PR TITLE
Wcs from pointing

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,14 +1,18 @@
 0.6 (unreleased)
 ----------------
 
+New Features
+^^^^^^^^^^^^
+- Added ``wcs_from_fiducial`` function to wcstools. [#34]
+
 API_Changes
 ^^^^^^^^^^^
-- Added `atol` argument to `LabelMapperDict`, representing the absolute tolerance [#29]
+- Added ``atol`` argument to ``LabelMapperDict``, representing the absolute tolerance [#29]
 
 Bug Fixes
 ^^^^^^^^^
-- Fixed a bug in `LabelMapperDict` where a wrong index was used.[#29]
-- Changed the order of the inputs when `LabelMapperArray` is evaluated as
+- Fixed a bug in ``LabelMapperDict`` where a wrong index was used.[#29]
+- Changed the order of the inputs when ``LabelMapperArray`` is evaluated as
   the inputs are supposed to be image coordinates. [#29]
 
 0.5.1 (2016-02-01)

--- a/docs/gwcs/wcstools.rst
+++ b/docs/gwcs/wcstools.rst
@@ -3,6 +3,7 @@ WCS User Tools
 
 
 The `~gwcs.wcstools` module contains functions of general usability related to WCS.
+
 `~gwcs.wcstools.wcs_from_fiducial` is a function which given a fiducial in some coordinate system,
 returns a WCS object.
 
@@ -11,13 +12,13 @@ returns a WCS object.
   >>> from astropy import units as u
   >>> from astropy.modeling import models
 
-To create a WCS from a pointing on the sky, as a minimm pass a sky coordinate and a projection to the function.
-  >>> fiducial = coord.SkyCoord(5.46*u.deg, -72.2*u.deg, frame='icrs')
+To create a WCS from a pointing on the sky, as a minimum pass a sky coordinate and a projection to the function.
+  >>> fiducial = coord.SkyCoord(5.46 * u.deg, -72.2 * u.deg, frame='icrs')
   >>> tan = models.Pix2Sky_TAN()
 
 Any additional transforms are prepended to the projection and sky rotation.
 
-  >>> trans = models, Shift(-1024) & models.Shift(2048) | models.Scale(.05) & models.Scale(.05)
+  >>> trans = models.Shift(-1024) & models.Shift(2048) | models.Scale(.05) & models.Scale(.05)
   >>> w = wcs_from_fiducial(fiducial, projection=tan, transform=trans)
   >>> w(1024, 2048)
       (5.46, -72.2)

--- a/docs/gwcs/wcstools.rst
+++ b/docs/gwcs/wcstools.rst
@@ -1,0 +1,24 @@
+WCS User Tools
+==============
+
+
+The `~gwcs.wcstools` module contains functions of general usability related to WCS.
+`~gwcs.wcstools.wcs_from_fiducial` is a function which given a fiducial in some coordinate system,
+returns a WCS object.
+
+  >>> from gwcs.wcstools import wcs_from_fiducial
+  >>> from astropy import coordinates as coord
+  >>> from astropy import units as u
+  >>> from astropy.modeling import models
+
+To create a WCS from a pointing on the sky, as a minimm pass a sky coordinate and a projection to the function.
+  >>> fiducial = coord.SkyCoord(5.46*u.deg, -72.2*u.deg, frame='icrs')
+  >>> tan = models.Pix2Sky_TAN()
+
+Any additional transforms are prepended to the projection and sky rotation.
+
+  >>> trans = models, Shift(-1024) & models.Shift(2048) | models.Scale(.05) & models.Scale(.05)
+  >>> w = wcs_from_fiducial(fiducial, projection=tan, transform=trans)
+  >>> w(1024, 2048)
+      (5.46, -72.2)
+

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -99,7 +99,7 @@ Using `gwcs`
 
   gwcs/create_wcs
   gwcs/selector_model.rst
-
+  gwcs/wcstools.rst
 
 
 See also
@@ -123,3 +123,4 @@ Reference/API
 .. automodapi:: gwcs.wcs
 .. automodapi:: gwcs.coordinate_frames
 .. automodapi:: gwcs.selector
+.. automodapi:: gwcs.wcstools

--- a/gwcs/__init__.py
+++ b/gwcs/__init__.py
@@ -17,5 +17,6 @@ from ._astropy_init import *
 # For egg_info test builds to pass, put package imports here.
 if not _ASTROPY_SETUP_:
     from .wcs import *
+    from .wcstools import *
     from .coordinate_frames import *
     from .selector import *

--- a/gwcs/coordinate_frames.py
+++ b/gwcs/coordinate_frames.py
@@ -118,7 +118,7 @@ class CoordinateFrame(object):
     @name.setter
     def name(self, val):
         """ A custom name of this frame."""
-        self._name = name
+        self._name = val
 
     @property
     def naxes(self):

--- a/gwcs/coordinate_frames.py
+++ b/gwcs/coordinate_frames.py
@@ -52,12 +52,11 @@ class CoordinateFrame(object):
         Reference to the WCS object to which this frame belongs.
     """
 
-    def __init__(self, naxes, axes_type, axes_order, fiducial=None, reference_frame=None,
+    def __init__(self, naxes, axes_type, axes_order, reference_frame=None,
                  reference_position=None, unit=None, axes_names=None,
                  name=None, wcsobj=None):
         self._naxes = naxes
         self._axes_order = tuple(axes_order)
-        self._fiducial = fiducial
         if isinstance(axes_type, six.string_types):
             self._axes_type = (axes_type,)
         else:
@@ -151,14 +150,6 @@ class CoordinateFrame(object):
             return self._reference_position
         except AttributeError:
             return None
-
-    @property
-    def fiducial(self):
-        return self._fiducial
-
-    @fiducial.property
-    def fiducial(self, val):
-        self._fiducial = val
 
     def input_axes(self, start_frame=None):
         """
@@ -466,7 +457,7 @@ class Frame2D(CoordinateFrame):
     def __init__(self, axes_order=(0, 1), unit=(u.pix, u.pix), axes_names=('x', 'y'),
                  name=None, wcsobj=None):
 
-        super(Frame2D, self).__init__(2, "SPATIAL", axes_order, name=name,
+        super(Frame2D, self).__init__(2, ["SPATIAL", "SPATIAL"], axes_order, name=name,
                                       axes_names=axes_names,unit=unit, wcsobj=None)
 
     def coordinates(self, *args):

--- a/gwcs/coordinate_frames.py
+++ b/gwcs/coordinate_frames.py
@@ -420,7 +420,7 @@ class CompositeFrame(CoordinateFrame):
 
     def coordinates(self, *args):
         """
-        Return the output of the forwrd_transform as quantities.
+        Return the output of ``forward_transform`` as quantities.
 
         Parameters
         ----------

--- a/gwcs/coordinate_frames.py
+++ b/gwcs/coordinate_frames.py
@@ -458,7 +458,7 @@ class Frame2D(CoordinateFrame):
                  name=None, wcsobj=None):
 
         super(Frame2D, self).__init__(2, ["SPATIAL", "SPATIAL"], axes_order, name=name,
-                                      axes_names=axes_names,unit=unit, wcsobj=None)
+                                      axes_names=axes_names, unit=unit, wcsobj=None)
 
     def coordinates(self, *args):
         args = self._wcsobj.get_transform(self._wcsobj.input_frame, self)(*args)

--- a/gwcs/coordinate_frames.py
+++ b/gwcs/coordinate_frames.py
@@ -52,11 +52,12 @@ class CoordinateFrame(object):
         Reference to the WCS object to which this frame belongs.
     """
 
-    def __init__(self, naxes, axes_type, axes_order, reference_frame=None,
+    def __init__(self, naxes, axes_type, axes_order, fiducial=None, reference_frame=None,
                  reference_position=None, unit=None, axes_names=None,
                  name=None, wcsobj=None):
         self._naxes = naxes
         self._axes_order = tuple(axes_order)
+        self._fiducial = fiducial
         if isinstance(axes_type, six.string_types):
             self._axes_type = (axes_type,)
         else:
@@ -150,6 +151,14 @@ class CoordinateFrame(object):
             return self._reference_position
         except AttributeError:
             return None
+
+    @property
+    def fiducial(self):
+        return self._fiducial
+
+    @fiducial.property
+    def fiducial(self, val):
+        self._fiducial = val
 
     def input_axes(self, start_frame=None):
         """

--- a/gwcs/tests/test_wcs.py
+++ b/gwcs/tests/test_wcs.py
@@ -10,10 +10,9 @@ from astropy import units as u
 from astropy.tests.helper import pytest
 from astropy.utils.data import get_pkg_data_filename
 from astropy import wcs as astwcs
-from astropy import coordinates as coords
-from astropy import units as u
 
 from .. import wcs
+from ..wcstools import *
 from .. import coordinate_frames as cf
 from ..utils import ModelDimensionalityError, CoordinateFrameError
 
@@ -114,48 +113,34 @@ def test_get_transform():
 
 
 def test_from_fiducial_sky():
-    sky = coords.SkyCoord(1.63 * u.radian, -72.4 * u.deg, frame='fk5')
+    sky = coord.SkyCoord(1.63 * u.radian, -72.4 * u.deg, frame='fk5')
     tan = models.Pix2Sky_TAN()
-    w = wcs.WCS.from_fiducial(sky, projection=tan)
-    assert isinstance(w.CelestialFrame.reference_frame, coords.FK5)
+    w = wcs_from_fiducial(sky, projection=tan)
+    assert isinstance(w.CelestialFrame.reference_frame, coord.FK5)
     assert_allclose(w(.1, .1), (93.7210280925364, -72.29972666307474))
 
 
 def test_from_fiducial_composite():
-    sky = coords.SkyCoord(1.63 * u.radian, -72.4 * u.deg, frame='fk5')
+    sky = coord.SkyCoord(1.63 * u.radian, -72.4 * u.deg, frame='fk5')
     tan = models.Pix2Sky_TAN()
     spec = cf.SpectralFrame(unit=(u.micron,))
     celestial = cf.CelestialFrame(reference_frame=sky.frame, unit=(sky.spherical.lon.unit,
                                   sky.spherical.lat.unit))
     coord_frame = cf.CompositeFrame([spec, celestial], name='cube_frame')
-    w = wcs.WCS.from_fiducial([.5 * u.micron, sky], coord_frame, projection=tan)
-    assert isinstance(w.cube_frame.frames[1].reference_frame, coords.FK5)
+    w = wcs_from_fiducial([.5 * u.micron, sky], coord_frame, projection=tan)
+    assert isinstance(w.cube_frame.frames[1].reference_frame, coord.FK5)
     assert_allclose(w(1, 1, 1), (1.5, 96.52373368309931, -71.37420187296995))
     trans = models.Shift(10) & models.Scale(2) & models.Shift(-1)
-    w = wcs.WCS.from_fiducial([.5 * u.micron, sky], coord_frame, projection=tan,
+    w = wcs_from_fiducial([.5 * u.micron, sky], coord_frame, projection=tan,
                               transform=trans)
     assert_allclose(w(1, 1, 1), (11.5, 99.97738475762152, -72.29039139739766))
 
 
 def test_from_fiducial_frame2d():
     fiducial = (34.5, 12.3)
-    w = wcs.WCS.from_fiducial(fiducial, coordinate_frame=cf.Frame2D())
-    assert(w.output_frame == 'Frame2D')
+    w = wcs_from_fiducial(fiducial, coordinate_frame=cf.Frame2D())
+    assert (w.output_frame =='Frame2D')
     assert_allclose(w(1, 1), (35.5, 13.3))
-
-
-def test_from_fiducial_domain():
-    domain = [{u'includes_lower': True,
-               u'includes_upper': False,
-               u'lower': 0,
-               u'upper': 129},
-              {u'includes_lower': True,
-               u'includes_upper': False,
-               u'lower': 0,
-               u'upper': 127}]
-    w = wcs.WCS.from_fiducial((34.5, 12.3), coordinate_frame=cf.Frame2D(), domain=domain)
-    with pytest.raises(ValueError):
-        w = wcs.WCS.from_fiducial((34.5, 12.3), coordinate_frame=cf.Frame2D(), domain=domain[0])
 
 
 class TestImaging(object):

--- a/gwcs/tests/test_wcs.py
+++ b/gwcs/tests/test_wcs.py
@@ -137,6 +137,27 @@ def test_from_fiducial_composite():
     assert_allclose(w(1, 1, 1), (11.5, 99.97738475762152, -72.29039139739766))
 
 
+def test_from_fiducial_frame2d():
+    fiducial = (34.5, 12.3)
+    w = wcs.WCS.from_fiducial(fiducial, coordinate_frame=cf.Frame2D())
+    assert(w.output_frame == 'Frame2D')
+    assert_allclose(w(1, 1), (35.5, 13.3))
+
+
+def test_from_fiducial_domain():
+    domain = [{u'includes_lower': True,
+               u'includes_upper': False,
+               u'lower': 0,
+               u'upper': 129},
+              {u'includes_lower': True,
+               u'includes_upper': False,
+               u'lower': 0,
+               u'upper': 127}]
+    w = wcs.WCS.from_fiducial((34.5, 12.3), coordinate_frame=cf.Frame2D(), domain=domain)
+    with pytest.raises(ValueError):
+        w = wcs.WCS.from_fiducial((34.5, 12.3), coordinate_frame=cf.Frame2D(), domain=domain[0])
+
+
 class TestImaging(object):
 
     def setup_class(self):

--- a/gwcs/utils.py
+++ b/gwcs/utils.py
@@ -10,7 +10,7 @@ import numpy as np
 from astropy.modeling import projections
 from astropy.modeling import models as astmodels
 from astropy.modeling.models import Mapping
-from astropy.modeling import core
+from astropy.modeling import core, projections
 from astropy.io import fits
 import functools
 
@@ -63,18 +63,6 @@ class CoordinateFrameError(Exception):
 
     def __init__(self, message):
         super(CoordinateFrameError, self).__init__(message)
-
-
-def wcs_from_footprints(wcslist, refwcs=None, transform=None, domain=None):
-    from astropy.utils.misc import isiterable
-    from gwcs import WCS
-
-    if not isiterable(wcslist):
-        raise ValueError("Expected 'wcslist' to be an iterable of WCS objects.")
-    if not all([isinstance(w, gwcs.WCS) for w in wcslist]):
-        raise TypeError("All items in wcslist are expected to be instances of gwcs.WCS.")
-    if refwcs is None:
-        refwcs = wcslist[0]
 
 
 def _compute_lon_pole(skycoord, projection):

--- a/gwcs/utils.py
+++ b/gwcs/utils.py
@@ -70,7 +70,7 @@ def _compute_lon_pole(skycoord, projection):
     Compute the longitude of the celestial pole of a standard frame in the
     native frame.
 
-    This angle then can be used as one of the Euler angles (the other two being skyccord)
+    This angle then can be used as one of the Euler angles (the other two being skycoord)
     to rotate the native frame into the standard frame ``skycoord.frame``.
 
     Parameters

--- a/gwcs/utils.py
+++ b/gwcs/utils.py
@@ -6,21 +6,21 @@ Utility function for WCS
 from __future__ import absolute_import, division, unicode_literals, print_function
 
 import re
+import functools
 import numpy as np
 from astropy.modeling import projections
 from astropy.modeling import models as astmodels
 from astropy.modeling.models import Mapping
 from astropy.modeling import core, projections
 from astropy.io import fits
-import functools
+from astropy import coordinates as coords
+from astropy.utils.misc import isiterable
 
 try:
     from astropy import time
     HAS_TIME = True
 except ImportError:
     HAS_TIME = False
-from astropy import coordinates
-from astropy import coordinates as coord
 
 
 # these ctype values do not include yzLN and yzLT pairs
@@ -65,12 +65,36 @@ class CoordinateFrameError(Exception):
         super(CoordinateFrameError, self).__init__(message)
 
 
+def _toindex(value):
+    """
+    Convert value to an int or an int array.
+
+    Input coordinates converted to integers
+    corresponding to the center of the pixel.
+    The convention is that the center of the pixel is
+    (0, 0), while the lower left corner is (-0.5, -0.5).
+    The outputs are used to index the mask.
+
+    Examples
+    --------
+    >>> _toindex(np.array([-0.5, 0.49999]))
+    array([0, 0])
+    >>> _toindex(np.array([0.5, 1.49999]))
+    array([1, 1])
+    >>> _toindex(np.array([1.5, 2.49999]))
+    array([2, 2])
+    """
+    indx = np.empty(value.shape, dtype=np.int32)
+    indx = np.floor(value + 0.5, out=indx)
+    return indx
+
+
 def _compute_lon_pole(skycoord, projection):
     """
     Compute the longitude of the celestial pole of a standard frame in the
     native frame.
 
-    This angle then can be used as one of the Euler angles (the other two being skycoord)
+    This angle then can be used as one of the Euler angles (the other two being skyccord)
     to rotate the native frame into the standard frame ``skycoord.frame``.
 
     Parameters
@@ -88,7 +112,10 @@ def _compute_lon_pole(skycoord, projection):
     TODO: Implement all projections
         Currently this only supports Zenithal projection.
     """
-    lat = skycoord.spherical.lat
+    if isinstance(skycoord, coords.SkyCoord):
+        lat = skycoord.spherical.lat
+    else:
+        lat = skycoord[1]
     if isinstance(projection, projections.Zenithal):
         if lat < 0:
             lon_pole = 180
@@ -231,12 +258,12 @@ def get_axes(header):
 specsystems = ["WAVE", "FREQ", "ENER", "WAVEN", "AWAV",
                "VRAD", "VOPT", "ZOPT", "BETA", "VELO"]
 
-sky_systems_map = {'ICRS': coord.ICRS,
-                   'FK5': coord.FK5,
-                   'FK4': coord.FK4,
-                   'FK4NOE': coord.FK4NoETerms,
-                   'GAL': coord.Galactic,
-                   'HOR': coord.AltAz
+sky_systems_map = {'ICRS': coords.ICRS,
+                   'FK5': coords.FK5,
+                   'FK4': coords.FK4,
+                   'FK4NOE': coords.FK4NoETerms,
+                   'GAL': coords.Galactic,
+                   'HOR': coords.AltAz
                    }
 
 

--- a/gwcs/utils.py
+++ b/gwcs/utils.py
@@ -65,12 +65,24 @@ class CoordinateFrameError(Exception):
         super(CoordinateFrameError, self).__init__(message)
 
 
+def wcs_from_footprints(wcslist, refwcs=None, transform=None, domain=None):
+    from astropy.utils.misc import isiterable
+    from gwcs import WCS
+
+    if not isiterable(wcslist):
+        raise ValueError("Expected 'wcslist' to be an iterable of WCS objects.")
+    if not all([isinstance(w, gwcs.WCS) for w in wcslist]):
+        raise TypeError("All items in wcslist are expected to be instances of gwcs.WCS.")
+    if refwcs is None:
+        refwcs = wcslist[0]
+
+
 def _compute_lon_pole(skycoord, projection):
     """
     Compute the longitude of the celestial pole of a standard frame in the
     native frame.
 
-    This angle then canbe used as one of the Euler angles (the other two being skyccord)
+    This angle then can be used as one of the Euler angles (the other two being skyccord)
     to rotate the native frame into the standard frame ``skycoord.frame``.
 
     Parameters
@@ -95,7 +107,7 @@ def _compute_lon_pole(skycoord, projection):
         else:
             lon_pole = 0
     else:
-        raise UnsupportedProjectionError("Projection {0} is not supported yet.".format(projection))
+        raise UnsupportedProjectionError("Projection {0} is not supported.".format(projection))
     return lon_pole
 
 

--- a/gwcs/utils.py
+++ b/gwcs/utils.py
@@ -65,6 +65,40 @@ class CoordinateFrameError(Exception):
         super(CoordinateFrameError, self).__init__(message)
 
 
+def _compute_lon_pole(skycoord, projection):
+    """
+    Compute the longitude of the celestial pole of a standard frame in the
+    native frame.
+
+    This angle then canbe used as one of the Euler angles (the other two being skyccord)
+    to rotate the native frame into the standard frame ``skycoord.frame``.
+
+    Parameters
+    ----------
+    skycoord : `astropy.coordinates.SkyCoord`
+        The fiducial point of the native coordinate system.
+    projection : `astropy.modeling.projections.Projection`
+        A Projection instance.
+
+    Returns
+    -------
+    lon_pole : float
+        Longitude in the units of skycoord.spherical
+
+    TODO: Implement all projections
+        Currently this only supports Zenithal projection.
+    """
+    lat = skycoord.spherical.lat
+    if isinstance(projection, projections.Zenithal):
+        if lat < 0:
+            lon_pole = 180
+        else:
+            lon_pole = 0
+    else:
+        raise UnsupportedProjectionError("Projection {0} is not supported yet.".format(projection))
+    return lon_pole
+
+
 def get_projcode(ctype):
     # CTYPE here is only the imaging CTYPE keywords
     projcode = ctype[0][5:8].upper()

--- a/gwcs/wcs.py
+++ b/gwcs/wcs.py
@@ -5,19 +5,12 @@ import copy
 import functools
 import numpy as np
 from astropy.extern import six
-from astropy.io import fits
-from astropy import coordinates as coords
-from astropy.modeling import models
 from astropy.modeling.core import Model
-from astropy.modeling import projections
-from astropy import units as u
-from astropy.utils import isiterable
 
 from . import coordinate_frames
-from .utils import (ModelDimensionalityError, CoordinateFrameError, UnsupportedProjectionError,
-                    UnsupportedTransformError)
-from .utils import _compute_lon_pole
-
+from .utils import (ModelDimensionalityError, CoordinateFrameError)
+from .utils import _toindex
+from . import utils
 
 __all__ = ['WCS']
 
@@ -416,101 +409,3 @@ class WCS(object):
         # return self.output_coordinate_system.world_coordinates(result[:,0], result[:,1])
         # except:
         # return result
-
-    @classmethod
-    def from_fiducial(cls, fiducial, coordinate_frame=None, projection=None,
-                      transform=None, name='', domain=None):
-        """
-        Create a WCS object from a fiducial point in a coordinate frame.
-
-        If an additional transform is supplied it is prepended to the projection.
-
-        Parameters
-        ----------
-        fiducial : `~astropy.coordinates.SkyCoord` or tuple of float
-            One of:
-                A location on the sky in some standard coordinate system.
-                A Quantity with spectral units.
-                A list of the above.
-        coordinate_frame : ~gwcs.coordinate_frames.CoordinateFrame`
-            The output coordinate frame.
-            If fiducial is not an instance of `~astropy.coordinates.SkyCoord`,
-            ``coordinate_frame`` is required.
-        projection : `~astropy.modeling.projections.Projection`
-            Projection instance - required if there is a celestial component in
-            the fiducial.
-        transform : `~astropy.modeling.Model`, optional
-            An optional tranform to be prepended to the transform constructed by
-            the fiducial point. The number of outputs of this transform must equal
-            the number of axes in the coordinate frame.
-        name : str, optional
-            Name of this WCS.
-        domain : list of dicts, optional
-            Domain of this WCS. The format is a list of dictionaries for each
-            axis in the input frame
-            [{'lower': lowx, 'upper': highx, 'includes_lower': bool, 'includes_upper': bool}]
-       """
-        if transform is not None:
-            if not isinstance(transform, Model):
-                raise UnsupportedTransformError("Expected transform to be an instance",
-                                                "of astropy.modeling.Model")
-            transform_outputs = transform.n_outputs
-
-        def _verify_projection(projection):
-            if projection is None:
-                raise ValueError("Celestial coordinate frame requires a projection to be specified.")
-            if not isinstance(projection, projections.Projection):
-                raise UnsupportedProjectionError(projection)
-
-        def _sky_transform(skycoord, projection):
-            """
-            A sky transform is a projection, followed by a rotation on the sky.
-            """
-            _verify_projection(projection)
-            lon_pole = _compute_lon_pole(skycoord, projection)
-            sky_rotation = models.RotateNative2Celestial(skycoord.spherical.lon,
-                                                         skycoord.spherical.lat,
-                                                         lon_pole)
-            return projection | sky_rotation
-
-        def _spectral_transform(fiducial):
-            """
-            A spectral transform is a shift by the fiducial.
-            """
-            return models.Shift(fiducial)
-
-        if isinstance(fiducial, coords.SkyCoord):
-            coordinate_frame = coordinate_frames.CelestialFrame(reference_frame=fiducial.frame,
-                                                                unit=(fiducial.spherical.lon.unit,
-                                                                      fiducial.spherical.lat.unit))
-            fiducial_transform = _sky_transform(fiducial, projection)
-        elif isinstance(coordinate_frame, coordinate_frames.CompositeFrame):
-            trans_from_fiducial = []
-            for item in coordinate_frame.frames:
-                ind = coordinate_frame.frames.index(item)
-                if isinstance(item, coordinate_frames.CelestialFrame):
-                    model = _sky_transform(fiducial[ind], projection)
-                elif isinstance(item, coordinate_frames.SpectralFrame):
-                    model = _spectral_transform(fiducial[ind])
-                elif isinstance(item, coordinate_frames.Frame2D):
-                    model = _frame2d_transform(fiducial)
-                else:
-                    raise TypeError("Coordinate frame {0} is not supported".format(item))
-                trans_from_fiducial.append(model)
-            fiducial_transform = functools.reduce(lambda x, y: x & y,
-                                                  [tr for tr in trans_from_fiducial])
-        elif isiterable(fiducial) and not isiterable(coordinate_frame):
-            # The case of one coordinate frame with more than 1 axes.
-            fiducial_transform = functools.reduce(lambda x, y: x & y,
-                                                  [models.Shift(val) for val in fiducial])
-        if transform is not None:
-            forward_transform = transform | fiducial_transform
-        else:
-            forward_transform = fiducial_transform
-        if domain is not None:
-            if len(domain) != forward_transform.n_outputs:
-                raise ValueError("Expected the number of items in 'domain' to be equal to the "
-                                 "number of outputs of the forawrd transform.")
-            forward_transform.meta['domain'] = domain
-        return cls(output_frame=coordinate_frame, forward_transform=forward_transform,
-                   name=name)

--- a/gwcs/wcs.py
+++ b/gwcs/wcs.py
@@ -439,16 +439,16 @@ class WCS(object):
         projection : `~astropy.modeling.projections.Projection`
             Projection instance - required if there is a celestial component in
             the fiducial.
-        transform : `~astropy.modeling.Model` (optional)
+        transform : `~astropy.modeling.Model`, optional
             An optional tranform to be prepended to the transform constructed by
             the fiducial point. The number of outputs of this transform must equal
             the number of axes in the coordinate frame.
-        name : str
+        name : str, optional
             Name of this WCS.
-        domain : list of dicts
+        domain : list of dicts, optional
             Domain of this WCS. The format is a list of dictionaries for each
             axis in the output frame [{'lower': lowx, 'upper': highx,
-                                      'includes_lower': bool, 'includes_upper': bool}]
+                                       'includes_lower': bool, 'includes_upper': bool}]
        """
         if transform is not None:
             if not isinstance(transform, Model):

--- a/gwcs/wcs.py
+++ b/gwcs/wcs.py
@@ -434,8 +434,8 @@ class WCS(object):
                 A list of the above.
         coordinate_frame : ~gwcs.coordinate_frames.CoordinateFrame`
             The output coordinate frame.
-            If fiducial is not an instance of `~astropy.coordinates.SkyCoord` it
-            should be specified here.
+            If fiducial is not an instance of `~astropy.coordinates.SkyCoord`,
+            ``coordinate_frame`` is required.
         projection : `~astropy.modeling.projections.Projection`
             Projection instance - required if there is a celestial component in
             the fiducial.
@@ -447,7 +447,8 @@ class WCS(object):
             Name of this WCS.
         domain : list of dicts
             Domain of this WCS. The format is a list of dictionaries for each
-            axis in the output frame [{'low': lowx, 'high': highx}]
+            axis in the output frame [{'lower': lowx, 'upper': highx,
+                                      'includes_lower': bool, 'includes_upper': bool}]
        """
         if transform is not None:
             if not isinstance(transform, Model):

--- a/gwcs/wcs.py
+++ b/gwcs/wcs.py
@@ -444,8 +444,9 @@ class WCS(object):
         if not isinstance(skycoord, coord.SkyCoord):
             raise ValueError("Expected skycoord to be an instance of astropy.coordinates.SkyCoord.")
         coord_frame = coordinate_frames.CelestialFrame(reference_frame=skycoord.frame,
-                    unit=(skycoord.spherical.lon.unit, skycoord.spherical.lat.unit),
-                    name=name, axes_order=axes_order)
+                                                       unit=(skycoord.spherical.lon.unit,
+                                                             skycoord.spherical.lat.unit),
+                                                       name=name, axes_order=axes_order)
         lon_pole = _compute_lon_pole(skycoord, projection)
         skyrot = astmodels.RotateNative2Celestial(skycoord.spherical.lon,
                                                   skycoord.spherical.lat, lon_pole)

--- a/gwcs/wcs.py
+++ b/gwcs/wcs.py
@@ -447,8 +447,8 @@ class WCS(object):
             Name of this WCS.
         domain : list of dicts, optional
             Domain of this WCS. The format is a list of dictionaries for each
-            axis in the output frame [{'lower': lowx, 'upper': highx,
-                                       'includes_lower': bool, 'includes_upper': bool}]
+            axis in the input frame
+            [{'lower': lowx, 'upper': highx, 'includes_lower': bool, 'includes_upper': bool}]
        """
         if transform is not None:
             if not isinstance(transform, Model):

--- a/gwcs/wcstools.py
+++ b/gwcs/wcstools.py
@@ -1,0 +1,126 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import, division, unicode_literals, print_function
+"""
+User oriented WCS tools.
+"""
+import functools
+from astropy.modeling.core import Model
+from astropy.modeling import projections
+from astropy.modeling import models
+from astropy import coordinates as coord
+
+from .wcs import WCS
+from . import coordinate_frames
+from .utils import UnsupportedTransformError, UnsupportedProjectionError
+from .utils import _compute_lon_pole
+
+
+__all__ = ['wcs_from_fiducial']
+
+
+def wcs_from_fiducial(fiducial, coordinate_frame=None, projection=None,
+                      transform=None, name='', domain=None):
+    """
+    Create a WCS object from a fiducial point in a coordinate frame.
+
+    If an additional transform is supplied it is prepended to the projection.
+
+    Parameters
+    ----------
+    fiducial : `~astropy.coordinates.SkyCoord` or tuple of float
+        One of:
+            A location on the sky in some standard coordinate system.
+            A Quantity with spectral units.
+            A list of the above.
+    coordinate_frame : ~gwcs.coordinate_frames.CoordinateFrame`
+        The output coordinate frame.
+        If fiducial is not an instance of `~astropy.coordinates.SkyCoord`,
+        ``coordinate_frame`` is required.
+    projection : `~astropy.modeling.projections.Projection`
+        Projection instance - required if there is a celestial component in
+        the fiducial.
+    transform : `~astropy.modeling.Model` (optional)
+        An optional tranform to be prepended to the transform constructed by
+        the fiducial point. The number of outputs of this transform must equal
+        the number of axes in the coordinate frame.
+    name : str
+        Name of this WCS.
+    domain : list of dicts
+        Domain of this WCS. The format is a list of dictionaries for each
+        axis in the input frame
+        [{'lower': lowx, 'upper': highx, 'includes_lower': bool, 'includes_upper': bool}]
+    """
+    if transform is not None:
+        if not isinstance(transform, Model):
+            raise UnsupportedTransformError("Expected transform to be an instance"
+                                            "of astropy.modeling.Model")
+        transform_outputs = transform.n_outputs
+    if isinstance(fiducial, coord.SkyCoord):
+        coordinate_frame = coordinate_frames.CelestialFrame(reference_frame=fiducial.frame,
+                                                            unit=(fiducial.spherical.lon.unit,
+                                                                  fiducial.spherical.lat.unit))
+        fiducial_transform = _sky_transform(fiducial, projection)
+    elif isinstance(coordinate_frame, coordinate_frames.CompositeFrame):
+        trans_from_fiducial = []
+        for item in coordinate_frame.frames:
+            ind = coordinate_frame.frames.index(item)
+            try:
+                model = frame2transform[item.__class__](fiducial[ind], projection=projection)
+            except KeyError:
+                raise TypeError("Coordinate frame {0} is not supported".format(item))
+            trans_from_fiducial.append(model)
+        fiducial_transform = functools.reduce(lambda x, y: x & y,
+                                              [tr for tr in trans_from_fiducial])
+    else:
+        # The case of one coordinate frame with more than 1 axes.
+        try:
+            fiducial_transform = frame2transform[coordinate_frame.__class__](fiducial, projection=projection)
+        except KeyError:
+            raise TypeError("Coordinate frame {0} is not supported".format(coordinate_frame))
+
+    if transform is not None:
+        forward_transform = transform | fiducial_transform
+    else:
+        forward_transform = fiducial_transform
+    if domain is not None:
+        if len(domain) != forward_transform.n_outputs:
+            raise ValueError("Expected the number of items in 'domain' to be equal to the "
+                             "number of outputs of the forawrd transform.")
+        forward_transform.meta['domain'] = domain
+    return WCS(output_frame=coordinate_frame, forward_transform=forward_transform,
+               name=name)
+
+def _verify_projection(projection):
+    if projection is None:
+        raise ValueError("Celestial coordinate frame requires a projection to be specified.")
+    if not isinstance(projection, projections.Projection):
+        raise UnsupportedProjectionError(projection)
+
+def _sky_transform(skycoord, projection):
+    """
+    A sky transform is a projection, followed by a rotation on the sky.
+    """
+    _verify_projection(projection)
+    lon_pole = _compute_lon_pole(skycoord, projection)
+    if isinstance(skycoord, coord.SkyCoord):
+        lon, lat = skycoord.spherical.lon, skycoord.spherical.lat
+    else:
+        lon, lat = skycoord
+    sky_rotation = models.RotateNative2Celestial(lon, lat, lon_pole)
+    return projection | sky_rotation
+
+def _spectral_transform(fiducial, **kwargs):
+    """
+    A spectral transform is a shift by the fiducial.
+    """
+    return models.Shift(fiducial)
+
+def _frame2D_transform(fiducial, **kwargs):
+    fiducial_transform = functools.reduce(lambda x, y: x & y,
+                                          [models.Shift(val) for val in fiducial])
+    return fiducial_transform
+
+frame2transform = {coordinate_frames.CelestialFrame: _sky_transform,
+                   coordinate_frames.SpectralFrame: _spectral_transform,
+                   coordinate_frames.Frame2D: _frame2D_transform
+                   }

--- a/gwcs/wcstools.py
+++ b/gwcs/wcstools.py
@@ -90,11 +90,13 @@ def wcs_from_fiducial(fiducial, coordinate_frame=None, projection=None,
     return WCS(output_frame=coordinate_frame, forward_transform=forward_transform,
                name=name)
 
+
 def _verify_projection(projection):
     if projection is None:
         raise ValueError("Celestial coordinate frame requires a projection to be specified.")
     if not isinstance(projection, projections.Projection):
         raise UnsupportedProjectionError(projection)
+
 
 def _sky_transform(skycoord, projection):
     """
@@ -109,16 +111,19 @@ def _sky_transform(skycoord, projection):
     sky_rotation = models.RotateNative2Celestial(lon, lat, lon_pole)
     return projection | sky_rotation
 
+
 def _spectral_transform(fiducial, **kwargs):
     """
     A spectral transform is a shift by the fiducial.
     """
     return models.Shift(fiducial)
 
+
 def _frame2D_transform(fiducial, **kwargs):
     fiducial_transform = functools.reduce(lambda x, y: x & y,
                                           [models.Shift(val) for val in fiducial])
     return fiducial_transform
+
 
 frame2transform = {coordinate_frames.CelestialFrame: _sky_transform,
                    coordinate_frames.SpectralFrame: _spectral_transform,

--- a/setup.py
+++ b/setup.py
@@ -56,10 +56,6 @@ if not RELEASE:
 # modify distutils' behavior.
 cmdclassd = register_commands(PACKAGENAME, VERSION, RELEASE)
 
-# Adjust the compiler in case the default on this platform is to use a
-# broken one.
-adjust_compiler(PACKAGENAME)
-
 # Freeze build information in version.py
 generate_version_py(PACKAGENAME, VERSION, RELEASE,
                     get_debug_option(PACKAGENAME))


### PR DESCRIPTION
This implements a method to create a WCS object from a fiducial in one of the coordinate frames supported by gwcs. 

In the case of an image it takes an `astropy.coordinates.SkyCoord` object and a projection. The forward transform in this case is a deprojection, followed by a rotation on the sky. The output coordinate system is derived from the `SkyCoord` object. If the `transform` argument is provided this transform is prepended. 

In all other cases the `fiducial` argument is a tuple of floats and a `coordinate_frame` is required.
The transform created from the fiducial in this case is a shift.

I am pinging everyone who I think might be interested. Please provide comments on the interface and the implementation. 

@perrygreenfield @larrybradley @mcara @jdavies-st