### PR TITLE
add domain attribute

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@
 New Features
 ^^^^^^^^^^^^
 - Added ``wcs_from_fiducial`` function to wcstools. [#34]
+- Added ``domain`` to the WCS object. [#36]
+- Added ``grid_from_domain``` function. [#36]
 
 API_Changes
 ^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ New Features
 ^^^^^^^^^^^^
 - Added ``wcs_from_fiducial`` function to wcstools. [#34]
 - Added ``domain`` to the WCS object. [#36]
-- Added ``grid_from_domain``` function. [#36]
+- Added ``grid_from_domain`` function. [#36]
 
 API_Changes
 ^^^^^^^^^^^

--- a/docs/gwcs/wcstools.rst
+++ b/docs/gwcs/wcstools.rst
@@ -18,8 +18,14 @@ To create a WCS from a pointing on the sky, as a minimum pass a sky coordinate a
 
 Any additional transforms are prepended to the projection and sky rotation.
 
-  >>> trans = models.Shift(-1024) & models.Shift(2048) | models.Scale(.05) & models.Scale(.05)
+  >>> trans = models.Shift(-2048) & models.Shift(-1024) | models.Scale(1.38*10**-5) & models.Scale(1.38*10**-5)
   >>> w = wcs_from_fiducial(fiducial, projection=tan, transform=trans)
-  >>> w(1024, 2048)
+  >>> w(2048, 1024)
       (5.46, -72.2)
 
+`~gwcs.wcstools.grid_from_domain` is a function which returns a grid of input points based on the domain of the WCS.
+
+  >>> from gwcs.wcstools import grid_from_domain
+  >>> domain=[{'lower': 0, 'upper': 4096}, {'lower': 0, 'upper': 2048}]
+  >>> x, y = grid_from_domain(domain)
+  >>> ra, dec = w(x, y)

--- a/gwcs/utils.py
+++ b/gwcs/utils.py
@@ -84,8 +84,7 @@ def _toindex(value):
     >>> _toindex(np.array([1.5, 2.49999]))
     array([2, 2])
     """
-    indx = np.empty(value.shape, dtype=np.int32)
-    indx = np.floor(value + 0.5, out=indx)
+    indx = np.asarray(np.floor(value + 0.5, out=indx), dtype=np.int)
     return indx
 
 

--- a/gwcs/utils.py
+++ b/gwcs/utils.py
@@ -89,6 +89,28 @@ def _toindex(value):
     return indx
 
 
+def _domain_to_bounds(domain):
+    def _get_bounds(axis_domain):
+        step = axis_domain.get('step', 1)
+        x = axis_domain['lower'] if axis_domain.get('includes_lower', True) \
+            else axis_domain['lower'] + step
+        y = axis_domain['upper'] - 1 if not axis_domain.get('includes_upper', False) \
+            else axis_domain['upper']
+        return (x, y)
+
+    bounds = [_get_bounds(d) for d in domain]
+    return bounds
+
+
+def _get_slice(axis_domain):
+    step = axis_domain.get('step', 1)
+    x = axis_domain['lower'] if axis_domain.get('includes_lower', True) \
+      else axis_domain['lower'] + step
+    y = axis_domain['upper'] if not axis_domain.get('includes_upper', False) \
+      else axis_domain['upper'] + step
+    return slice(x, y, step)
+
+
 def _compute_lon_pole(skycoord, projection):
     """
     Compute the longitude of the celestial pole of a standard frame in the

--- a/gwcs/utils.py
+++ b/gwcs/utils.py
@@ -84,7 +84,7 @@ def _toindex(value):
     >>> _toindex(np.array([1.5, 2.49999]))
     array([2, 2])
     """
-    indx = np.asarray(np.floor(value + 0.5, out=indx), dtype=np.int)
+    indx = np.asarray(np.floor(value + 0.5), dtype=np.int)
     return indx
 
 


### PR DESCRIPTION
This adds a `WCS.domain` attribute. 
This is not entirely new as it was a working assumption for a while that models have a domain defined in `Model.meta`. The definition of `domain` is in its [schema](https://github.com/spacetelescope/asdf-standard/blob/master/schemas/stsci.edu/asdf/transform/domain-1.0.0.yaml).
This PR defines the `domain` attribute at the level of the WCS object. It also adds a `step` key of the domain which defaults to 1.

`gwcs.domain` corresponds to `astropy.wcs._naxis1/2` but is more general because it defines a step along the axis and the start of the axis is not assumed to be 1.

Some of its use cases are computing footprints, or evaluating transforms which have limited range of validity. This raises the question of what should the return value of the `WCS` be outside the domain. Any suggestions?

Of course this is very similar to the [bounding_box](http://astropy.readthedocs.org/en/latest/api/astropy.modeling.Model.html#astropy.modeling.Model.bounding_box) of models and eventually the two should be merged.

Additionally `step` should be added to the domain schema.


 