### PR TITLE
Rename pyasdf to asdf

### DIFF
--- a/docs/gwcs/selector_model.rst
+++ b/docs/gwcs/selector_model.rst
@@ -52,13 +52,13 @@ The image above shows the projection of the 6 slits on the detector. Pixels, wit
 not belong to any slit. Assuming the array is stored in
 `ASDF <http://asdf-standard.readthedocs.org/en/latest>`__ format, create the mask:
 
-  >>> from pyasdf import AsdfFile
+  >>> from asdf import AsdfFile
   >>> f = AsdfFile.open('mask.asdf')
   >>> data = f.tree['mask']
   >>> mask = selector.LabelMapperArray(data)
 
-For more information on using the `ASDF <http://asdf-standard.readthedocs.org/en/latest/>`__ format
-see `PyASDF <http://pyasdf.readthedocs.org/en/latest/>`__
+For more information on using the `ASDF standard <http://asdf-standard.readthedocs.org/en/latest/>`__ format
+see `asdf <http://pyasdf.readthedocs.org/en/latest/>`__
 
 Create the pixel to world transform for the entire IFU:
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -30,7 +30,7 @@ Installation
 
 - `astropy <http://www.astropy.org/>`__ 1.1 or later
 
-- `pyasdf <http://pyasdf.readthedocs.org/en/latest/>`__
+- `asdf <http://pyasdf.readthedocs.org/en/latest/>`__
 
 
 Getting Started

--- a/gwcs/conftest.py
+++ b/gwcs/conftest.py
@@ -12,7 +12,7 @@ enable_deprecations_as_exceptions()
 
 try:
     PYTEST_HEADER_MODULES['Astropy'] = 'astropy'
-    PYTEST_HEADER_MODULES['pyasdf'] = 'pyasdf'
+    PYTEST_HEADER_MODULES['asdf'] = 'asdf'
     del PYTEST_HEADER_MODULES['h5py']
 except (NameError, KeyError):
     pass

--- a/gwcs/extension.py
+++ b/gwcs/extension.py
@@ -1,8 +1,8 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, unicode_literals, print_function
 
-from pyasdf.extension import BuiltinExtension
-from pyasdf import util, resolver
+from asdf.extension import BuiltinExtension
+from asdf import util, resolver
 from .tags import LabelMapperType, RegionsSelectorType
 
 

--- a/gwcs/tags/selectortags.py
+++ b/gwcs/tags/selectortags.py
@@ -9,9 +9,9 @@ from numpy.testing import assert_array_equal
 from astropy.modeling import models
 from astropy.utils.misc import isiterable
 
-from pyasdf import yamlutil
-from pyasdf.tags.transform.basic import TransformType
-from pyasdf.tags.core.ndarray import NDArrayType
+from asdf import yamlutil
+from asdf.tags.transform.basic import TransformType
+from asdf.tags.core.ndarray import NDArrayType
 
 from ..selector import *
 

--- a/gwcs/tags/tests/test_selector.py
+++ b/gwcs/tags/tests/test_selector.py
@@ -8,7 +8,7 @@ import numpy as np
 from astropy.modeling.models import Mapping, Shift, Scale, Polynomial2D
 from astropy.tests.helper import pytest
 from ... import selector, extension
-from pyasdf.tests import helpers
+from asdf.tests import helpers
 from ...tests.test_region import create_range_mapper, create_scalar_mapper
 from ...extension import GWCSExtension
 


### PR DESCRIPTION
`pyasdf` was renamed to `asdf`. This PR changes the imports in gwcs.