### PR TITLE
relax requirement to match number of axes and number of inputs/outputs

### DIFF
--- a/gwcs/tests/test_wcs.py
+++ b/gwcs/tests/test_wcs.py
@@ -76,20 +76,6 @@ def test_insert_transform():
     assert(gw.forward_transform(1.2) == (m1 | m2)(1.2))
 
 
-def test_wrong_ndim():
-    """
-    Tests that exception is raised if n_inputs/n_outputs does not
-    match number of input/output axes.
-    """
-    det = cf.Frame2D(name='detector')
-    icrs = cf.CelestialFrame(reference_frame=coord.ICRS(), name='icrs')
-    m = models.Shift(1)
-    with pytest.raises(ModelDimensionalityError):
-        w = wcs.WCS(output_frame='icrs', forward_transform=m, input_frame=det)
-    with pytest.raises(ModelDimensionalityError):
-        w = wcs.WCS(output_frame=icrs, forward_transform=m)
-
-
 def test_set_transform():
     """ Tests setting a transform between two frames in the pipeline."""
     w = wcs.WCS(input_frame=det, output_frame=icrs, forward_transform=pipe)

--- a/gwcs/wcs.py
+++ b/gwcs/wcs.py
@@ -65,17 +65,7 @@ class WCS(object):
                                 "(frame, transform) list, got {0}".format(
                                     type(forward_transform)))
             _inp_frame = getattr(self, self.input_frame)
-            if  _inp_frame is not None and _inp_frame.naxes != self.forward_transform.n_inputs:
-                message = "The number of inputs {0} of the forward transform \
-                does not match the number of axes {1} of the input axes. \
-                ".format(self.forward_transform.n_inputs, _inp_frame.naxes)
-                raise ModelDimensionalityError(message)
             _outp_frame = getattr(self, self.output_frame)
-            if _outp_frame is not None and _outp_frame.naxes != self.forward_transform.n_outputs:
-                message = "The number of outputs {0} of the forward transform \
-                does not match the number of axes {1} of the output axes. \
-                ".format(self.forward_transform.n_outputs, _outp_frame.naxes)
-                raise ModelDimensionalityError(message)
         else:
             if output_frame is None:
                 raise CoordinateFrameError("An output_frame must be specified"
@@ -435,3 +425,5 @@ class WCS(object):
             vertices += .5
         result = self.__call__(*vertices)
         return np.asarray(result)
+
+


### PR DESCRIPTION
The code required that the number of inputs matches the number of axes in the input coordinate frame and the number of outputs matches the number of axes in the output frame. This becomes too limiting when quantities which are not strictly cooridnates (like slit number or spectral order) are used as inputs.
The models in `astropy.modeling` have a good and strict enough checks for matching inputs and outputs of combined transforms. Additional checks are not necessary in `gwcs` and are removed with this PR.