### PR TITLE
Fix Python3 incompatibility with configparser

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -43,7 +43,11 @@ from astropy_helpers.sphinx.conf import *
 
 # Get configuration information from setup.cfg
 from distutils import config
-conf = config.ConfigParser()
+try:
+    from ConfigParser import ConfigParser
+except ImportError:
+    from configparser import ConfigParser
+conf = ConfigParser()
 conf.read([os.path.join(os.path.dirname(__file__), '..', 'setup.cfg')])
 setup_cfg = dict(conf.items('metadata'))
 

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,11 @@ from astropy_helpers.version_helpers import generate_version_py
 
 # Get some values from the setup.cfg
 from distutils import config
-conf = config.ConfigParser()
+try:
+    from ConfigParser import ConfigParser
+except ImportError:
+    from configparser import ConfigParser
+conf = ConfigParser()
 conf.read(['setup.cfg'])
 metadata = dict(conf.items('metadata'))
 


### PR DESCRIPTION
Updated submodule. Fixed configparser Python 3 compatibility.

@jhunkeler , merge it if it fixes your build problem.