### PR TITLE
fix grid-from-domain order

### DIFF
--- a/gwcs/tests/test_wcs.py
+++ b/gwcs/tests/test_wcs.py
@@ -148,10 +148,10 @@ def test_grid_from_domain():
     domain = [{'lower': -1, 'upper': 10, 'includes_lower': True, 'includes_upper': False, 'step': .1},
               {'lower': 6, 'upper': 15, 'includes_lower': False, 'includes_upper': True, 'step': .5}]
     x, y = grid_from_domain(domain)
-    assert_allclose(y[:, 0], 6.5)
-    assert_allclose(y[:, -1], 15)
-    assert_allclose(x[0], -1)
-    assert_allclose(x[-1], 9.9)
+    assert_allclose(x[:, 0], -1)
+    assert_allclose(x[:, -1], 9.9)
+    assert_allclose(y[0], 6.5)
+    assert_allclose(y[-1], 15)
 
 
 class TestImaging(object):

--- a/gwcs/wcstools.py
+++ b/gwcs/wcstools.py
@@ -142,5 +142,5 @@ def grid_from_domain(domain):
         Input points.
     """
     slices = [_get_slice(d) for d in domain]
-    x, y = np.mgrid[slices]
+    y, x = np.mgrid[slices[::-1]]
     return x, y


### PR DESCRIPTION
Fix the order of the axes in `np.mgrid`.

@stsci-hack @brechmos-stsci @jdavies-st 