### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/docs/gwcs/selector_model.rst
+++ b/docs/gwcs/selector_model.rst
@@ -50,15 +50,15 @@ belongs to.
 
 The image above shows the projection of the 6 slits on the detector. Pixels, with a label of 0 do
 not belong to any slit. Assuming the array is stored in
-`ASDF <http://asdf-standard.readthedocs.org/en/latest>`__ format, create the mask:
+`ASDF <https://asdf-standard.readthedocs.io/en/latest>`__ format, create the mask:
 
   >>> from asdf import AsdfFile
   >>> f = AsdfFile.open('mask.asdf')
   >>> data = f.tree['mask']
   >>> mask = selector.LabelMapperArray(data)
 
-For more information on using the `ASDF standard <http://asdf-standard.readthedocs.org/en/latest/>`__ format
-see `asdf <http://pyasdf.readthedocs.org/en/latest/>`__
+For more information on using the `ASDF standard <https://asdf-standard.readthedocs.io/en/latest/>`__ format
+see `asdf <https://pyasdf.readthedocs.io/en/latest/>`__
 
 Create the pixel to world transform for the entire IFU:
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -30,7 +30,7 @@ Installation
 
 - `astropy <http://www.astropy.org/>`__ 1.1 or later
 
-- `asdf <http://pyasdf.readthedocs.org/en/latest/>`__
+- `asdf <https://pyasdf.readthedocs.io/en/latest/>`__
 
 
 Getting Started
@@ -112,9 +112,9 @@ See also
   <http://docs.astropy.org/en/stable/coordinates/>`__
 
 - The `Advanced Scientific Data Format (ASDF) standard
-  <http://asdf-standard.readthedocs.org/>`__
+  <https://asdf-standard.readthedocs.io/>`__
   and its `Python implementation
-  <http://pyasdf.readthedocs.org/>`__
+  <https://pyasdf.readthedocs.io/>`__
 
 
 Reference/API

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,7 @@ long_description = Tools for managing the WCS of astronomical observations in a 
 author = gwcs developers
 author_email = help@stsci.edu
 license = BSD
-url = http://gwcs.readthedocs.org/en/latest/
+url = https://gwcs.readthedocs.io/en/latest/
 edit_on_github = False
 github_project = spacetelescope/gwcs
 


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.
