### PR TITLE
Rename misnamed variables

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,7 @@ Bug Fixes
 - Fixed a bug in ``LabelMapperDict`` where a wrong index was used.[#29]
 - Changed the order of the inputs when ``LabelMapperArray`` is evaluated as
   the inputs are supposed to be image coordinates. [#29]
+- Renamed variables in read_wcs_from_header to match loop variable [#63]
 
 0.5.1 (2016-02-01)
 ------------------

--- a/gwcs/utils.py
+++ b/gwcs/utils.py
@@ -179,8 +179,8 @@ def read_wcs_from_header(header):
         ctypes = header['CTYPE*']
         keys = ctypes.keys()
         for key in keys[::-1]:
-            if p.split(k)[-1] != "":
-                keys.remove(k)
+            if p.split(key)[-1] != "":
+                keys.remove(key)
         wcs_info['WCSAXES'] = len(keys)
     wcsaxes = wcs_info['WCSAXES']
     # if not present call get_csystem


### PR DESCRIPTION
A loop in read_wcs_from_header uses the undefined variable k when clearly it should have used the loop variable, key.