### PR TITLE
fix names and links

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,10 +6,10 @@ New Features
 - Added ``wcs_from_fiducial`` function to wcstools. [#34]
 - Added ``domain`` to the WCS object. [#36]
 - Added ``grid_from_domain`` function. [#36]
-- The WCS object can return now an `~astropy.coordinates.SkyCoord` 
+- The WCS object can return now an `~astropy.coordinates.SkyCoord`
   or `~astropy.units.Quantity` object. This is triggered by a new
   parameter to the ``__call__`` method, ``output`` which takes values
-  of "numericaals" (default) or "numericasl_plus".    [#64]
+  of "numericals" (default) or "numericals_plus".    [#64]
 
 API_Changes
 ^^^^^^^^^^^

--- a/docs/gwcs/selector_model.rst
+++ b/docs/gwcs/selector_model.rst
@@ -50,15 +50,15 @@ belongs to.
 
 The image above shows the projection of the 6 slits on the detector. Pixels, with a label of 0 do
 not belong to any slit. Assuming the array is stored in
-`ASDF <http://asdf-standard.readthedocs.org/en/latest>`__ format, create the mask:
+`ASDF <https://asdf-standard.readthedocs.io/en/latest>`__ format, create the mask:
 
   >>> from asdf import AsdfFile
   >>> f = AsdfFile.open('mask.asdf')
   >>> data = f.tree['mask']
   >>> mask = selector.LabelMapperArray(data)
 
-For more information on using the `ASDF standard <http://asdf-standard.readthedocs.org/en/latest/>`__ format
-see `asdf <http://pyasdf.readthedocs.org/en/latest/>`__
+For more information on using the `ASDF standard <https://asdf-standard.readthedocs.io/en/latest/>`__ format
+see `asdf <https://asdf.readthedocs.io/en/latest/>`__
 
 Create the pixel to world transform for the entire IFU:
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -29,7 +29,7 @@ Installation
 
 - `astropy <http://www.astropy.org/>`__ 1.2 or later
 
-- `asdf <http://pyasdf.readthedocs.org/en/latest/>`__
+- `asdf <https://asdf.readthedocs.io/en/latest/>`__
 
 To install from source::
 
@@ -41,7 +41,7 @@ To install the latest release::
 
     pip install gwcs
 
-GWCS is also available as part of astroconda.
+GWCS is also available as part of `astroconda <https://github.com/astroconda/astroconda>`__.
 
 .. _getting-started:
 
@@ -128,9 +128,9 @@ See also
   <http://docs.astropy.org/en/stable/coordinates/>`__
 
 - The `Advanced Scientific Data Format (ASDF) standard
-  <http://asdf-standard.readthedocs.org/>`__
+  <https://asdf-standard.readthedocs.io/>`__
   and its `Python implementation
-  <http://pyasdf.readthedocs.org/>`__
+  <https://asdf.readthedocs.io/>`__
 
 
 Reference/API

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,7 @@ long_description = Tools for managing the WCS of astronomical observations in a 
 author = gwcs developers
 author_email = help@stsci.edu
 license = BSD
-url = http://gwcs.readthedocs.org/en/latest/
+url = https://gwcs.readthedocs.io/en/latest/
 edit_on_github = False
 github_project = spacetelescope/gwcs
 


### PR DESCRIPTION
This fixes links to readthedocs and correctly references the now renamed `pyasdf` package. Includes changes by @adamchainz and closes #62.