### PR TITLE
Fix range mapper

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,9 @@
 0.8 (Unreleased)
 ----------------
 
+- ``LabelMapperRange`` now returns ``LabelMapperRange._no_label`` when the key is
+  not within any range. [#71]
+
 0.7 (2016-12-23)
 ----------------
 

--- a/gwcs/selector.py
+++ b/gwcs/selector.py
@@ -434,7 +434,7 @@ class LabelMapperRange(_LabelMapper):
                                           np.nan, temp)
             ind = ~np.isnan(temp)
 
-            if ind:
+            if ind.any():
                 inputs = [a[ind] for a in args]
                 res[ind] = self.mapper[tuple(val_range)](*inputs)
             else:

--- a/gwcs/selector.py
+++ b/gwcs/selector.py
@@ -66,7 +66,7 @@ label mappers.
 
 """
 from __future__ import absolute_import, division, unicode_literals, print_function
-
+import warnings
 import numpy as np
 from astropy.modeling.core import Model
 
@@ -420,7 +420,7 @@ class LabelMapperRange(_LabelMapper):
             keys = args
         keys = keys.flatten()
         # Define an array for the results.
-        res = np.empty(keys.shape)
+        res = np.zeros(keys.shape) + self._no_label
         nan_ind = np.isnan(keys)
         res[nan_ind] = self._no_label
         value_ranges = list(self.mapper.keys())
@@ -428,17 +428,20 @@ class LabelMapperRange(_LabelMapper):
         # which fall within the range it defines.
         for val_range in value_ranges:
             temp = keys.copy()
-            temp[nan_ind] = self._no_label
+            temp[nan_ind] = np.nan
             temp = np.where(np.logical_or(temp <= val_range[0],
                                           temp >= val_range[1]),
-                                          0, temp)
-            ind = temp.nonzero()
+                                          np.nan, temp)
+            ind = ~np.isnan(temp)
+
             if ind:
                 inputs = [a[ind] for a in args]
                 res[ind] = self.mapper[tuple(val_range)](*inputs)
             else:
                 continue
         res.shape = shape
+        if len(np.nonzero(res)[0]) == 0:
+            warnings.warn("All data is outside the valid range - {0}.".format(self.name))
         return res
 
 

--- a/gwcs/tests/test_region.py
+++ b/gwcs/tests/test_region.py
@@ -83,10 +83,10 @@ def test_create_mask_two_polygons():
 
 def create_range_mapper():
     m = []
-    for i in np.arange(9) *.1:
+    for i in np.arange(1, 10) *.1:
         c0_0, c1_0, c0_1, c1_1 = np.ones((4,)) * i
-        m.append(models.Polynomial2D(2, c0_0=c0_0,
-                                     c1_0=c1_0, c0_1=c0_1, c1_1=c1_1))
+        m.append(models.Polynomial2D(2, c0_0=c0_0, c1_0=c1_0, c0_1=c0_1, c1_1=c1_1))
+
     keys = np.array([[  4.88,   5.64],
                      [  5.75,   6.5],
                      [  6.67,   7.47 ],
@@ -130,12 +130,12 @@ def test_LabelMapperDict():
 
 def test_LabelMapperRange():
     sel = create_range_mapper()
-    assert(sel(6, 2) == 2.1)
+    assert(sel(6, 2) == 4.2)
 
 
 def test_overalpping_ranges():
     """
-    Overlapping ranges should raise an error.
+    Initializing a ``LabelMapperRange`` with overlapping ranges should raise an error.
     """
     keys = np.array([[  4.88,   5.75],
                      [  5.64,   6.5],
@@ -145,4 +145,13 @@ def test_overalpping_ranges():
         rmapper[tuple(key)] = models.Const1D(4)
     with pytest.raises(ValueError):
         lmr = selector.LabelMapperRange(('x', 'y'), rmapper, inputs_mapping=((0,)))
+
+
+def test_outside_range():
+    """
+    Return ``_no_label`` value when keys are outside the range.
+    """
+    lmr = create_range_mapper()
+    assert lmr(1, 1) == 0
+    assert lmr(5, 1) == 1.2
 

--- a/gwcs/utils.py
+++ b/gwcs/utils.py
@@ -203,7 +203,7 @@ def read_wcs_from_header(header):
     except KeyError:
         p = re.compile('ctype[\d]*', re.IGNORECASE)
         ctypes = header['CTYPE*']
-        keys = ctypes.keys()
+        keys = list(ctypes.keys())
         for key in keys[::-1]:
             if p.split(key)[-1] != "":
                 keys.remove(key)


### PR DESCRIPTION
When a key is not within any range return ``_no_label`` value instead of raising an error. This allows all models to run and return NaNs instead of erroring.