### PR TITLE
Respect the bounding_box when evaluating the WCS

### DIFF
--- a/gwcs/tests/test_wcs.py
+++ b/gwcs/tests/test_wcs.py
@@ -223,9 +223,9 @@ def test_bounding_box_eval():
     # test scalar outside bbox
     assert_allclose(w(1, 7, 3), [np.nan, np.nan, np.nan])
     # test scalar inside bbox
-    assert_allclose(w(1, 7, 5), [11, 4, 4])
+    assert_allclose(w(1, 7, 5), [11, 14, 4])
     # test arrays
-    assert_allclose(w([1, 1], [7, 7], [3, 5]), [[np.nan, 11], [np.nan, 4], [np.nan, 4]])
+    assert_allclose(w([1, 1], [7, 7], [3, 5]), [[np.nan, 11], [np.nan, 14], [np.nan, 4]])
 
 
 class TestImaging(object):

--- a/gwcs/tests/test_wcs.py
+++ b/gwcs/tests/test_wcs.py
@@ -203,17 +203,29 @@ def test_domain():
 
 
 def test_grid_from_bounding_box():
-    #domain = [{'lower': -1, 'upper': 10, 'includes_lower': True,
-               #'includes_upper': False, 'step': .1},
-              #{'lower': 6, 'upper': 15, 'includes_lower': False,
-               #'includes_upper': True, 'step': .5}]
     bb = ((-1, 9.9), (6.5, 15))
-    #x, y = grid_from_domain(domain)
     x, y = grid_from_bounding_box(bb, step=[.1, .5], center=False)
     assert_allclose(x[:, 0], -1)
     assert_allclose(x[:, -1], 9.9)
     assert_allclose(y[0], 6.5)
     assert_allclose(y[-1], 15)
+
+
+def test_bounding_box_eval():
+    """
+    Tests evaluation with and without respecting the bounding_box.
+    """
+    trans3 = models.Shift(10) & models.Scale(2) & models.Shift(-1)
+    pipeline = [('detector', trans3), ('sky', None)]
+    w = wcs.WCS(pipeline)
+    w.bounding_box = ((-1, 10), (6, 15), (4.3, 6.9))
+
+    # test scalar outside bbox
+    assert_allclose(w(1, 7, 3), [np.nan, np.nan, np.nan])
+    # test scalar inside bbox
+    assert_allclose(w(1, 7, 5), [11, 4, 4])
+    # test arrays
+    assert_allclose(w([1, 1], [7, 7], [3, 5]), [[np.nan, 11], [np.nan, 4], [np.nan, 4]])
 
 
 class TestImaging(object):

--- a/gwcs/tests/test_wcs.py
+++ b/gwcs/tests/test_wcs.py
@@ -222,10 +222,16 @@ def test_bounding_box_eval():
 
     # test scalar outside bbox
     assert_allclose(w(1, 7, 3), [np.nan, np.nan, np.nan])
+    assert_allclose(w(1, 7, 3, with_bounding_box=False), [11, 14, 2])
+    assert_allclose(w(1, 7, 3, fill_value=100.3), [100.3, 100.3, 100.3])
+    assert_allclose(w(1, 7, 3, fill_value=np.inf), [np.inf, np.inf, np.inf])
     # test scalar inside bbox
     assert_allclose(w(1, 7, 5), [11, 14, 4])
     # test arrays
     assert_allclose(w([1, 1], [7, 7], [3, 5]), [[np.nan, 11], [np.nan, 14], [np.nan, 4]])
+
+    # test ``transform`` method
+    assert_allclose(w.transform('detector', 'sky', 1, 7, 3), [np.nan, np.nan, np.nan])
 
 
 class TestImaging(object):

--- a/gwcs/utils.py
+++ b/gwcs/utils.py
@@ -141,12 +141,9 @@ def _get_values(units, *args):
     """
     val = []
     values = []
-    print('args', args)
     for arg in args:
-        print('arg', arg)
         if isinstance(arg, coords.SkyCoord):
             try:
-                print('arg1', arg)
                 lon = arg.data.lon
                 lat = arg.data.lat
             except AttributeError:


### PR DESCRIPTION
The new method signature is:

```
WCS.__call__(self, *args, output="numericals", with_bounding_box=True, fill_value=np.nan):
        args : float or array-like
            Inputs in the input coordinate system, separate inputs for each dimension.
        output : str, optional
            One of [``numericals``, ``numericals_plus``]
            If ``numericals_plus`` - returns a `~astropy.coordinates.SkyCoord` or
            `~astropy.units.Quantity` object.
        with_bounding_box : bool, optional
             If True(default) values in the result which correspond to any of the inputs being
             outside the bounding_box are set to ``fill_value``.
        fill_value : float, optional
            Output value for inputs outside the bounding_box (default is np.nan).
```

The goal is to move this to `astropy.modeling` eventually.