### PR TITLE
Improve bbox evaluation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ env:
         - NUMPY_VERSION=1.9
         - ASTROPY_VERSION=development
         - MAIN_CMD='python setup.py'
-        - CONDA_DEPENDENCIES=''
+        - CONDA_DEPENDENCIES='scipy'
         - PIP_DEPENDENCIES='git+https://github.com/spacetelescope/pyasdf.git#egg=pyasdf'
     matrix:
         - SETUP_CMD='egg_info'

--- a/gwcs/tests/test_wcs.py
+++ b/gwcs/tests/test_wcs.py
@@ -233,6 +233,17 @@ def test_bounding_box_eval():
     # test ``transform`` method
     assert_allclose(w.transform('detector', 'sky', 1, 7, 3), [np.nan, np.nan, np.nan])
 
+    
+def test_number_of_inputs():
+    points = np.arange(5)
+    values = np.array([1.5, 3.4, 6.7, 7, 32])
+    t = models.Tabular1D(points, values)
+    pipe = [('detector', t), ('world', None)]
+    w = wcs.WCS(pipe)
+    assert_allclose(w(1), 3.4)
+    assert_allclose(w([1, 2]), [3.4, 6.7])
+    assert np.isscalar(w(1))
+
 
 class TestImaging(object):
 

--- a/gwcs/tests/test_wcs.py
+++ b/gwcs/tests/test_wcs.py
@@ -234,7 +234,7 @@ def test_bounding_box_eval():
     assert_allclose(w.transform('detector', 'sky', 1, 7, 3), [np.nan, np.nan, np.nan])
 
     
-def test_number_of_inputs():
+def test_format_output():
     points = np.arange(5)
     values = np.array([1.5, 3.4, 6.7, 7, 32])
     t = models.Tabular1D(points, values)

--- a/gwcs/wcs.py
+++ b/gwcs/wcs.py
@@ -281,8 +281,6 @@ class WCS(object):
         bbox = kwargs.pop('bbox', None)
         fill_value = kwargs.pop('fill_value', np.nan)
 
-        # Set values outside the ``bounding_box`` to `fill_value``.
-
         if bbox is None:
             try:
                 # Get the bbox from the transform
@@ -307,7 +305,7 @@ class WCS(object):
             axis_ind = np.zeros(inp.shape, dtype=np.bool)
             axis_ind = np.logical_or(inp < bbox[ind][0], inp > bbox[ind][1], out=axis_ind)
             nan_ind[axis_ind] = 1
-        
+
         # get an array with indices of valid inputs
         valid_ind = np.logical_not(nan_ind).nonzero()
         # inputs holds only inputs within the bbox
@@ -315,8 +313,8 @@ class WCS(object):
         for arg in args:
             if not arg.shape:
                 # shape is ()
-                if valid_ind[0] != 0:
-                    return tuple([np.nan for a in args])
+                if nan_ind:
+                    return tuple([fill_value for a in args])
                 else:
                     inputs.append(arg)
             else:
@@ -326,7 +324,7 @@ class WCS(object):
             valid_result = [valid_result]
         # combine the valid results with the ``fill_value`` values 
         # outside the bbox
-        result = [np.zeros(args[0].shape) + kwargs['fill_value'] for i in range(len(valid_result))]
+        result = [np.zeros(args[0].shape) + fill_value for i in range(len(valid_result))]
         for ind, r in enumerate(valid_result):
             if not result[ind].shape:
                 # the sahpe is () 

--- a/gwcs/wcs.py
+++ b/gwcs/wcs.py
@@ -279,25 +279,63 @@ class WCS(object):
         """
         transform = kwargs.pop('transform', None)
         bbox = kwargs.pop('bbox', None)
+        fill_value = kwargs.pop('fill_value', np.nan)
 
         # Set values outside the ``bounding_box`` to `fill_value``.
-        result = transform(*args)
+
         if bbox is None:
             try:
-                bbox = transform.bounding_box[::-1]
+                # Get the bbox from the transform
+                bbox = transform.bounding_box
             except NotImplementedError:
                 bbox = None
+            if transform.n_inputs > 1 and bbox is not None:
+                # The bbox on a transform is in python order
+                bbox = bbox[::-1]
         if bbox is None:
-            return result
-        inputs = [np.array(arg) for arg in args]
-        result = [np.array(r) for r in result]
-
-        for ind, inp in enumerate(inputs):
+            return transform(*args)
+        
+        args = [np.array(arg) for arg in args]
+        if len(args) == 1:
+            bbox = [bbox]
+            
+        # indices where input is outside the bbox
+        # have a value of 1 in ``nan_ind``
+        nan_ind = np.zeros(args[0].shape)
+        for ind, inp in enumerate(args):
             # Pass an ``out`` array so that ``axis_ind`` is array for scalars as well.
             axis_ind = np.zeros(inp.shape, dtype=np.bool)
             axis_ind = np.logical_or(inp < bbox[ind][0], inp > bbox[ind][1], out=axis_ind)
-            for ind, _ in enumerate(result):
-                result[ind][axis_ind] = kwargs['fill_value']
+            nan_ind[axis_ind] = 1
+        
+        # get an array with indices of valid inputs
+        valid_ind = np.logical_not(nan_ind).nonzero()
+        # inputs holds only inputs within the bbox
+        inputs = []
+        for arg in args:
+            if not arg.shape:
+                # shape is ()
+                if valid_ind[0] != 0:
+                    return tuple([np.nan for a in args])
+                else:
+                    inputs.append(arg)
+            else:
+                inputs.append(arg[valid_ind])
+        valid_result = transform(*inputs)
+        if transform.n_outputs == 1:
+            valid_result = [valid_result]
+        # combine the valid results with the ``fill_value`` values 
+        # outside the bbox
+        result = [np.zeros(args[0].shape) + kwargs['fill_value'] for i in range(len(valid_result))]
+        for ind, r in enumerate(valid_result):
+            if not result[ind].shape:
+                # the sahpe is () 
+                result[ind] = r
+            else:
+                result[ind][valid_ind] = r
+        # format output
+        if transform.n_outputs == 1:
+            return result[0]
         if np.isscalar(args[0]):
             result = tuple([np.asscalar(r) for r in result])
         else:
@@ -494,14 +532,16 @@ class WCS(object):
         transform_0 = self.get_transform(frames[0], frames[1])
         try:
             # Model.bounding_box is in numpy order, need to reverse it first.
-            bb = transform_0.bounding_box[::-1]
+            bb = transform_0.bounding_box#[::-1]
         except NotImplementedError:
             return None
+        if transform_0.n_inputs == 1:
+            return bb
         try:
             axes_order = self.input_frame.axes_order
         except AttributeError:
             axes_order = np.arange(transform_0.n_inputs)
-        bb = np.array(bb)[np.array(axes_order)]
+        bb = np.array(bb[::-1])[np.array(axes_order)]
         return tuple(tuple(item) for item in bb)
 
     @bounding_box.setter


### PR DESCRIPTION
Fixed a bug related to output formatting reported at the spectroscopy workshop. Refactored evaluation with `bounding_box` to pass only valid inputs to the transform. Previously all inputs were passed and the baounding box was applied to the result. However this approach fails when inputs are indices into array and are outside the array bounds.