### PR TITLE
Move evaluation with bounding_box to astropy.modeling.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,11 @@
 - Added a ``LabelMapper`` model where ``mapper`` is an instance of
   `~astropy.modeling.core.Model`. [#78]
 
+- Evaluating a WCS with bounding box was moved to ``astropy.modeling``. [#86]
+
+- RegionsSelector now handles the case when a label does not have a corresponding
+  transform and returns RegionsSelector.undefined_transform_value. [#86]
+
 
 0.7 (2016-12-23)
 ----------------

--- a/gwcs/selector.py
+++ b/gwcs/selector.py
@@ -541,7 +541,12 @@ class RegionsSelector(Model):
         for rid in uniq:
             ind = (rids == rid)
             inputs = [a[ind] for a in args]
-            result = self._selector[rid](*inputs)
+            if rid in self._selector:
+                result = self._selector[rid](*inputs)
+            else:
+                # If there's no transform for a label, return np.nan
+                result = [np.empty(inputs[0].shape) +
+                          self._undefined_transform_value for i in range(self.n_outputs)]
             for j in range(self.n_outputs):
                 outputs[j][ind] = result[j]
         return outputs


### PR DESCRIPTION
Changed `RegionsSelector` to handle the case where input is a label which has no transform associated with it, in which case `np.nan` is returned.
Evaluating with bounding_box was moved to `astropy.modeling`.

Need a change log for the selector change. Travis needs to be run again after astropy/modeling#6081 is merged.