### PR TITLE
Change version of six library

### DIFF
--- a/gwcs/coordinate_frames.py
+++ b/gwcs/coordinate_frames.py
@@ -8,7 +8,7 @@ import numpy as np
 from astropy import units as u
 from astropy import utils as astutil
 from astropy import coordinates as coord
-from astropy.extern import six
+import six
 
 
 __all__ = ['Frame2D', 'CelestialFrame', 'SpectralFrame', 'CompositeFrame',

--- a/gwcs/region.py
+++ b/gwcs/region.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, division, unicode_literals, print_functi
 import abc
 from collections import OrderedDict
 import numpy as np
-from astropy.extern import six
+import six
 
 
 @six.add_metaclass(abc.ABCMeta)

--- a/gwcs/wcs.py
+++ b/gwcs/wcs.py
@@ -5,7 +5,7 @@ import functools
 import warnings
 
 import numpy as np
-from astropy.extern import six
+import six
 from astropy.modeling.core import Model
 
 from . import coordinate_frames


### PR DESCRIPTION
Astropy is dropping support of Python 2. To insualate ourselves from this change we are changing the six library to not point to the astropy version.