### PR TITLE
remove testing on python 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ addons:
             - dvipng
 
 python:
-    - 2.7
     - 3.5
     - 3.6
 
@@ -40,20 +39,16 @@ matrix:
 
     include:
 
-        # Do a coverage test in Python 2.
-        - python: 2.7
+        # Do a coverage test.
+        - python: 3.5
           env: SETUP_CMD='test --coverage'
 
         # Check for sphinx doc build warnings - we do this first because it
         # may run for a long time
-        - python: 2.7
+        - python: 3.6
           env: SETUP_CMD='build_sphinx -w'
 
         # Numpy
-        - python: 2.7
-          env: NUMPY_VERSION=1.12 SETUP_CMD="test"
-        - python: 2.7
-          env: NUMPY_VERSION=1.10 SETUP_CMD="test"
         - python: 3.6
           env: NUMPY_VERSION=1.12 SETUP_CMD="test"
         - python: 3.6


### PR DESCRIPTION
As of Sep 21st `astropy` has dropped support for Python 2.
This PR updates the Travis matrix to not test on Python 2.