### PR TITLE
Update to reflect tags moving from ASDF to astropy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,8 @@ env:
         - ASTROPY_VERSION=development
         - MAIN_CMD='python setup.py'
         - CONDA_DEPENDENCIES='scipy'
-        - PIP_DEPENDENCIES='pytest-astropy git+https://github.com/spacetelescope/asdf.git#egg=asdf'
+        - ASDF_GIT='git+https://github.com/spacetelescope/asdf.git#egg=asdf'
+        - PIP_DEPENDENCIES="pytest-astropy $ASDF_GIT"
         - ASTROPY_USE_SYSTEM_PYTEST=1
 
     matrix:

--- a/gwcs/tags/selectortags.py
+++ b/gwcs/tags/selectortags.py
@@ -11,8 +11,8 @@ from astropy.modeling.core import Model
 from astropy.utils.misc import isiterable
 
 from asdf import yamlutil
-from asdf.tags.transform.basic import TransformType
 from asdf.tags.core.ndarray import NDArrayType
+from astropy.io.misc.asdf.tags.transform.basic import TransformType
 
 from ..selector import *
 


### PR DESCRIPTION
~**DO NOT MERGE**~ This is an update to reflect the fact that certain tags are being moved from ASDF to astropy. This PR should not be merged until the changes to ASDF and astropy have been merged into master.

In the meantime, the CI script has been updated to test against forked branches of ASDF and astropy. This should be reverted before merging this PR.