### PR TITLE
fix grid_from_bounding_box 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,9 @@ Bug Fixes
 
 - Fixed a bug in ``bounding_box`` definition when the WCS has only one axis. [#117]
 
+- Fixed a bug in ``grid_from_bounding_box`` which caused the grid to be larger than
+  the image in cases when the bounding box is on the edges of an image. [#121]
+
 
 0.8.0 (2017-11-02)
 ------------------

--- a/gwcs/tests/test_wcs.py
+++ b/gwcs/tests/test_wcs.py
@@ -225,6 +225,23 @@ def test_grid_from_bounding_box():
     assert_allclose(y[-1], 15)
 
 
+def test_grid_from_bounding_box_1d():
+    # Test 1D case
+    x = grid_from_bounding_box((-.5, 4.5))
+    assert_allclose(x, [ 0.,  1.,  2.,  3.,  4.])
+
+
+def test_grid_from_bounding_box_step():
+    bb = ((-0.5, 5.5), (-0.5, 4.5))
+    x, y = grid_from_bounding_box(bb)
+    x1, y1 = grid_from_bounding_box(bb, step=(1, 1))
+    assert_allclose(x, x1)
+    assert_allclose(y, y1)
+
+    with pytest.raises(ValueError):
+        grid_from_bounding_box(bb, step=(1, 2, 1))
+
+
 def test_grid_from_bounding_box_2():
     bb = ((-0.5, 5.5), (-0.5, 4.5))
     x, y = grid_from_bounding_box(bb)
@@ -232,7 +249,7 @@ def test_grid_from_bounding_box_2():
     assert_allclose(y, np.repeat(np.array([np.arange(5)]), 6, 0).T)
 
     bb = ((-0.5, 5.5), (-0.5, 4.6))
-    x, y = grid_from_bounding_box(bb)
+    x, y = grid_from_bounding_box(bb, center=True)
     assert_allclose(x, np.repeat([np.arange(6)], 6, axis=0))
     assert_allclose(y, np.repeat(np.array([np.arange(6)]), 6, 0).T)
 

--- a/gwcs/tests/test_wcs.py
+++ b/gwcs/tests/test_wcs.py
@@ -228,7 +228,7 @@ def test_grid_from_bounding_box():
 def test_grid_from_bounding_box_1d():
     # Test 1D case
     x = grid_from_bounding_box((-.5, 4.5))
-    assert_allclose(x, [ 0.,  1.,  2.,  3.,  4.])
+    assert_allclose(x, [0., 1., 2., 3., 4.])
 
 
 def test_grid_from_bounding_box_step():

--- a/gwcs/tests/test_wcs.py
+++ b/gwcs/tests/test_wcs.py
@@ -225,6 +225,18 @@ def test_grid_from_bounding_box():
     assert_allclose(y[-1], 15)
 
 
+def test_grid_from_bounding_box_2():
+    bb = ((-0.5, 5.5), (-0.5, 4.5))
+    x, y = grid_from_bounding_box(bb)
+    assert_allclose(x, np.repeat([np.arange(6)], 5, axis=0))
+    assert_allclose(y, np.repeat(np.array([np.arange(5)]), 6, 0).T)
+
+    bb = ((-0.5, 5.5), (-0.5, 4.6))
+    x, y = grid_from_bounding_box(bb)
+    assert_allclose(x, np.repeat([np.arange(6)], 6, axis=0))
+    assert_allclose(y, np.repeat(np.array([np.arange(6)]), 6, 0).T)
+
+
 def test_bounding_box_eval():
     """
     Tests evaluation with and without respecting the bounding_box.

--- a/gwcs/wcstools.py
+++ b/gwcs/wcstools.py
@@ -138,6 +138,12 @@ def grid_from_bounding_box(bounding_box, step=1, center=True):
     """
     Create a grid of input points from the WCS bounding_box.
 
+    Note: If ``bbox`` is a tuple describing the range of an axis in ``bounding_box``,
+          ``x.5`` is considered part of the next pixel in ``bbox[0]``
+          and part of the previous pixel in ``bbox[1]``. In this way if
+          ``bbox`` describes the edges of an image the indexing includes
+          only pixels within the image.
+
     Parameters
     ----------
     bounding_box : tuple
@@ -152,23 +158,30 @@ def grid_from_bounding_box(bounding_box, step=1, center=True):
     Examples
     --------
     >>> bb = ((-1, 2.9), (6, 7.5))
-    >>> grid_from_bounding_box(bb, step=(1, .5))
+    >>> grid_from_bounding_box(bb, step=(1, .5), center=False)
     array([[[-1. ,  0. ,  1. ,  2. ,  3. ],
-        [-1. ,  0. ,  1. ,  2. ,  3. ],
-        [-1. ,  0. ,  1. ,  2. ,  3. ],
-        [-1. ,  0. ,  1. ,  2. ,  3. ],
-        [-1. ,  0. ,  1. ,  2. ,  3. ]],
-       [[ 6. ,  6. ,  6. ,  6. ,  6. ],
-        [ 6.5,  6.5,  6.5,  6.5,  6.5],
-        [ 7. ,  7. ,  7. ,  7. ,  7. ],
-        [ 7.5,  7.5,  7.5,  7.5,  7.5],
-        [ 8. ,  8. ,  8. ,  8. ,  8. ]]])
+            [-1. ,  0. ,  1. ,  2. ,  3. ],
+            [-1. ,  0. ,  1. ,  2. ,  3. ],
+            [-1. ,  0. ,  1. ,  2. ,  3. ]],
+           [[ 6. ,  6. ,  6. ,  6. ,  6. ],
+            [ 6.5,  6.5,  6.5,  6.5,  6.5],
+            [ 7. ,  7. ,  7. ,  7. ,  7. ],
+            [ 7.5,  7.5,  7.5,  7.5,  7.5]]])
+
+    >>> bb = ((-1, 2.9), (6, 7.5))
+    >>> grid_from_bounding_box(bb)
+    array([[[-1.,  0.,  1.,  2.,  3.],
+            [-1.,  0.,  1.,  2.,  3.]],
+           [[ 6.,  6.,  6.,  6.,  6.],
+            [ 7.,  7.,  7.,  7.,  7.]]])
 
     Returns
     -------
     x, y [, z]: ndarray
         Grid of points.
     """
+    def _bbox_to_pixel(bbox):
+        return (np.floor(bbox[0] + 0.5), np.ceil(bbox[1] - 0.5))
     # 1D case
     if np.isscalar(bounding_box[0]):
         nd = 1
@@ -176,7 +189,8 @@ def grid_from_bounding_box(bounding_box, step=1, center=True):
     else:
         nd = len(bounding_box)
     if center:
-        bb = tuple([tuple(bb) for bb in _toindex(bounding_box)])
+        bb = tuple([_bbox_to_pixel(bb) for bb in bounding_box])
+
     else:
         bb = bounding_box
 

--- a/gwcs/wcstools.py
+++ b/gwcs/wcstools.py
@@ -185,12 +185,12 @@ def grid_from_bounding_box(bounding_box, step=1, center=True):
     # 1D case
     if np.isscalar(bounding_box[0]):
         nd = 1
+        print('nd', nd)
         bounding_box = (bounding_box, )
     else:
         nd = len(bounding_box)
     if center:
         bb = tuple([_bbox_to_pixel(bb) for bb in bounding_box])
-
     else:
         bb = bounding_box
 
@@ -206,4 +206,8 @@ def grid_from_bounding_box(bounding_box, step=1, center=True):
     slices = []
     for d, s in zip(bb, step):
         slices.append(slice(d[0], d[1] + s, s))
-    return np.mgrid[slices[::-1]][::-1]
+    grid = np.mgrid[slices[::-1]][::-1]
+    if nd == 1:
+        return grid[0]
+    else:
+        return grid


### PR DESCRIPTION
#117 changed `grid_from_bounding_box` to use `utils._toindex()` to compute the values corresponding to the center of the pixels. `_toindex` defines that `x.5` belongs to the pixel on the right, i.e. `x+` pixel. When the bounding box describes the edges of an image, this results in a grid which is one pixel larger than the actual image.
The approach take in the PR is to treat the first pixel from -0.5 inclusive to 0.5 exclusive and the last pixel from 
(n-1).5 inclusive to n.5 inclusive. This effectively means that if the bounding box describes the edges of an image, all (and only) pixels within the image fall on the grid.
For example:
```
bb = ((-.5, 3.5), (-.5, 2.6))
In [3]: wcstools.grid_from_bounding_box(bb)
array([[[ 0.,  1.,  2.,  3.],
        [ 0.,  1.,  2.,  3.],
        [ 0.,  1.,  2.,  3.],
        [ 0.,  1.,  2.,  3.]],

       [[ 0.,  0.,  0.,  0.],
        [ 1.,  1.,  1.,  1.],
        [ 2.,  2.,  2.,  2.],
        [ 3.,  3.,  3.,  3.]]])

```
@philhodge @jdavies-st Does this seem reasonable?