### PR TITLE
TST: Change PEP8 check to use flake8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,10 +55,14 @@ matrix:
         - python: 3.6
           env: NUMPY_VERSION=1.13 SETUP_CMD="test"
 
-        # Do a PEP8 test with pycodestyle
+        # Do a PEP8 test with flake8
         - python: 3.5
-          env: MAIN_CMD='pycodestyle gwcs --count' SETUP_CMD=''
+          env: MAIN_CMD='flake8 gwcs --count' SETUP_CMD=''
 
+    allow_failures:
+
+       - python: 3.5
+          env: MAIN_CMD='flake8 gwcs --count' SETUP_CMD=''
 
 install:
     - git clone git://github.com/astropy/ci-helpers.git
@@ -71,6 +75,6 @@ after_success:
     # If coveralls.io is set up for this package, uncomment the line
     # below and replace "packagename" with the name of your package.
     # The coveragerc file may be customized as needed for your package.
-    - if [[ $SETUP_CMD == *--coverage* ]]; then 
-          coveralls --rcfile='gwcs/tests/coveragerc'; 
+    - if [[ $SETUP_CMD == *--coverage* ]]; then
+          coveralls --rcfile='gwcs/tests/coveragerc';
       fi

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,7 @@ asdf_schema_root = gwcs/schemas
 [ah_bootstrap]
 auto_use = True
 
-[pycodestyle]
+[flake8]
 # E101 - mix of tabs and spaces
 # W191 - use of tabs
 # W291 - trailing whitespace
@@ -41,4 +41,3 @@ license = BSD
 url = https://gwcs.readthedocs.io/en/latest/
 edit_on_github = False
 github_project = spacetelescope/gwcs
-


### PR DESCRIPTION
Change PEP8 check to use `flake8`. Allow to fail until *someone* has time to fix it.

This is because my `flake8` plugin in Emacs is complaining about things that `pycodestyle` missed here; e.g. unused imports.