### PR TITLE
fix test

### DIFF
--- a/gwcs/tests/test_coordinate_systems.py
+++ b/gwcs/tests/test_coordinate_systems.py
@@ -78,11 +78,11 @@ def test_coordinates_composite(inputs):
 def test_celestial_attributes_length(frame):
     """
     Test getting default values for 
-    CoordinateFrame attributes from reference_frame.
+    CelestialFrame attributes from reference_frame.
     """
     fr = getattr(coord, frame)
     if issubclass(fr, coord.BaseCoordinateFrame):
-        cel = cf.CelestialFrame(reference_frame=getattr(coord, frame)())
+        cel = cf.CelestialFrame(reference_frame=fr())
         assert(len(cel.axes_names) == len(cel.axes_type) == len(cel.unit) ==
                len(cel.axes_order) == cel.naxes)
 

--- a/gwcs/tests/test_coordinate_systems.py
+++ b/gwcs/tests/test_coordinate_systems.py
@@ -77,11 +77,14 @@ def test_coordinates_composite(inputs):
 @pytest.mark.parametrize(('frame'), coord_frames)
 def test_celestial_attributes_length(frame):
     """
-    Test getting default values for  CoordinateFrame attributes from reference_frame.
+    Test getting default values for 
+    CoordinateFrame attributes from reference_frame.
     """
-    cel = cf.CelestialFrame(reference_frame=getattr(coord, frame)())
-    assert(len(cel.axes_names) == len(cel.axes_type) == len(cel.unit) ==
-           len(cel.axes_order) == cel.naxes)
+    fr = getattr(coord, frame)
+    if issubclass(fr, coord.BaseCoordinateFrame):
+        cel = cf.CelestialFrame(reference_frame=getattr(coord, frame)())
+        assert(len(cel.axes_names) == len(cel.axes_type) == len(cel.unit) ==
+               len(cel.axes_order) == cel.naxes)
 
 
 def test_axes_type():


### PR DESCRIPTION
`astropy.coordinates.builtin_frames` now includes a function. The test initializing with reference frame now checks if the object is a coordinate frame before initializing `CelestialFrame`.