### PR TITLE
update docs header to say gwcs instead of astropy

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -107,6 +107,15 @@ release = package.__version__
 # name of a builtin theme or the name of a custom theme in html_theme_path.
 #html_theme = None
 
+
+# Please update these texts to match the name of your package.
+html_theme_options = {
+    'logotext1': 'g',  # white,  semi-bold
+    'logotext2': 'wcs',  # orange, light
+    'logotext3': ':docs'   # white,  light
+    }
+
+
 # Custom sidebar templates, maps document names to template names.
 #html_sidebars = {}
 


### PR DESCRIPTION
This makes a small change to the docs conf.py to have the header indicate the docs are gwcs and not the astropy core.

Note that we could have the "g" also be orange if others thing the look of that is better.  I think this makes it pop a bit better, but either could work fine.  (just requires a one character swap in the PR)


Before:
![image](https://user-images.githubusercontent.com/346587/40403042-2cbe154a-5e1d-11e8-85f9-f7848a54b661.png)

After:
![image](https://user-images.githubusercontent.com/346587/40403053-3cfd967e-5e1d-11e8-8c1e-e4a34b525919.png)
