### PR TITLE
Test with stable versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ env:
         - ASTROPY_VERSION=stable
         - MAIN_CMD='python setup.py'
         - CONDA_DEPENDENCIES='scipy'
-        - PIP_DEPENDENCIES="pytest-astropy"
+        - PIP_DEPENDENCIES="pytest-astropy asdf"
         - ASTROPY_USE_SYSTEM_PYTEST=1
 
     matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,11 +22,10 @@ env:
         # overidden underneath. They are defined here in order to save having
         # to repeat them for all configurations.
         - NUMPY_VERSION=stable
-        - ASTROPY_VERSION=development
+        - ASTROPY_VERSION=stable
         - MAIN_CMD='python setup.py'
         - CONDA_DEPENDENCIES='scipy'
-        - ASDF_GIT='git+https://github.com/spacetelescope/asdf.git#egg=asdf'
-        - PIP_DEPENDENCIES="pytest-astropy $ASDF_GIT"
+        - PIP_DEPENDENCIES="pytest-astropy"
         - ASTROPY_USE_SYSTEM_PYTEST=1
 
     matrix:


### PR DESCRIPTION
The 0.9.1 branch is intended as a public release and should be tested with the stable versions of asdf and astropy.