### PR TITLE
Copy

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,11 @@
 New Features
 ^^^^^^^^^^^^
 
+- Initializing a ``WCS`` object with a ``pipeline`` list now keeps
+  the complete ``CoordinateFrame`` objects in the ``WCS.pipeline``.
+  The effect is that a ``WCS`` object can now be initialized with
+  a ``pipeline`` from a different ``WCS`` object. [#174]
+
 Bug Fixes
 ^^^^^^^^^
 

--- a/docs/gwcs/using_wcs.rst
+++ b/docs/gwcs/using_wcs.rst
@@ -78,7 +78,7 @@ Transforms in the pipeline can be replaced by new transforms.
   >>> from astropy.modeling.models import Shift
   >>> new_transform = Shift(1) & Shift(1.5) | distortion
   >>> wcsobj.set_transform('detector', 'focal_frame', new_transform)
-  >>> wcsobj(1, 2)
+  >>> wcsobj(1, 2)         # doctest: +FLOAT_CMP
       (10.338562883899195, -42.331828785194055)
 
 A transform can be inserted before or after a frame in the pipeline.
@@ -86,7 +86,7 @@ A transform can be inserted before or after a frame in the pipeline.
   >>> from astropy.modeling.models import Scale
   >>> scale = Scale(2) & Scale(1)
   >>> wcsobj.insert_transform('icrs', scale, after=False)
-  >>> wcsobj(1, 2)
+  >>> wcsobj(1, 2)          # doctest: +FLOAT_CMP
       (20.67712576779839, -42.331828785194055)
 
 The WCS object has an attribute ``domain`` which describes the range of

--- a/docs/gwcs/using_wcs.rst
+++ b/docs/gwcs/using_wcs.rst
@@ -79,7 +79,7 @@ Transforms in the pipeline can be replaced by new transforms.
   >>> new_transform = Shift(1) & Shift(1.5) | distortion
   >>> wcsobj.set_transform('detector', 'focal_frame', new_transform)
   >>> wcsobj(1, 2)
-      (10.338562883899195, -42.33182878519405)
+      (10.338562883899195, -42.331828785194055)
 
 A transform can be inserted before or after a frame in the pipeline.
 
@@ -87,7 +87,7 @@ A transform can be inserted before or after a frame in the pipeline.
   >>> scale = Scale(2) & Scale(1)
   >>> wcsobj.insert_transform('icrs', scale, after=False)
   >>> wcsobj(1, 2)
-      (20.67712576779839, -42.33182878519405)
+      (20.67712576779839, -42.331828785194055)
 
 The WCS object has an attribute ``domain`` which describes the range of
 acceptable values for each input axis.

--- a/gwcs/tests/test_wcs.py
+++ b/gwcs/tests/test_wcs.py
@@ -86,7 +86,7 @@ def test_insert_transform():
 
 def test_set_transform():
     """ Test setting a transform between two frames in the pipeline."""
-    w = wcs.WCS(input_frame=detector, output_frame=icrs, forward_transform=pipe)
+    w = wcs.WCS(forward_transform=pipe[:])
     w.set_transform('detector', 'focal', models.Identity(2))
     assert_allclose(w(1, 1), (2, -2))
     with pytest.raises(CoordinateFrameError):
@@ -97,7 +97,7 @@ def test_set_transform():
 
 def test_get_transform():
     """ Test getting a transform between two frames in the pipeline."""
-    w = wcs.WCS(pipe)
+    w = wcs.WCS(pipe[:])
     tr_forward = w.get_transform('detector', 'focal')
     tr_back = w.get_transform('icrs', 'detector')
     x, y = 1, 2
@@ -126,7 +126,7 @@ def test_backward_transform():
 
 def test_return_coordinates():
     """Test converting to coordinate objects or quantities."""
-    w = wcs.WCS(pipe)
+    w = wcs.WCS(pipe[:])
     x = 1
     y = 2.3
     numerical_result = (26.8, -0.6)


### PR DESCRIPTION
The coordinate objects in a WCS.pipeline can be of type string or CoordinateFrame. They are assigned as attributes to the WCS object. If CoordinateFrame objects, only the name was kept in the pipeline.
This PR ensures the entire CoordinateFrame object is kept in the pipeline list.

```
sky = cf.CelestialFrame(name='world', reference_frame=coord.ICRS(), unit=(u.deg, u.deg))
det=cf.Frame2D(name='detector', unit=(u.pix, u.pix))
pipe=[(det, m), (sky, None)]
w = wcs WCS(pipe)
```
Previously:
```
w.pipeline
[('detector', <CompoundModel0(offset_0=1., offset_1=2.)>), ('world', None)]
```
With this PR:
```
w.pipeline
[(<Frame2D(name="detector", unit=(Unit("pix"), Unit("pix")), axes_names=('x', 'y'), axes_order=(0, 1))>,
  <CompoundModel0(offset_0=1., offset_1=2.)>),
 (<CelestialFrame(name="world", unit=(Unit("deg"), Unit("deg")), axes_names=('lon', 'lat'), axes_order=(0, 1), reference_frame=<ICRS Frame>)>,
  None)]
```
Resolves #173.

@Cadair I don't think this should have an effect your use of gwcs but in case it does let me know if you agree with the change.