### PR TITLE
test against 3.1.x release branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,11 +19,12 @@ env:
         # to repeat them for all configurations.
         - PYTHON_VERSION=3.6
         - NUMPY_VERSION=stable
-        - ASTROPY_VERSION=development
+        #- ASTROPY_VERSION=development
         - MAIN_CMD='python setup.py'
         - CONDA_DEPENDENCIES='scipy'
         - ASDF_GIT='git+https://github.com/spacetelescope/asdf.git#egg=asdf'
-        - PIP_DEPENDENCIES="pytest-astropy $ASDF_GIT"
+        - ASTROPY_GIT='git+https://github.com/astropy/astropy.git@v3.1.x'
+        - PIP_DEPENDENCIES="$ASTROPY_GIT pytest-astropy asdf"
         - ASTROPY_USE_SYSTEM_PYTEST=1
         - PYTEST_VERSION=3.6
 
@@ -61,6 +62,16 @@ matrix:
     allow_failures:
         - python: 3.5
           env: MAIN_CMD='flake8 gwcs --count' SETUP_CMD=''
+
+        - python: 3.6
+          env: NUMPY_VERSION=dev SETUP_CMD='test'
+
+        - python: 3.6
+          env: ASTROPY_VERSION=development SETUP_CMD='test'
+
+        - python: 3.6
+          env: PIP_DEPENDENCIES="$ASDF_GIT" SETUP_CMD='test'
+
 
 install:
     - git clone git://github.com/astropy/ci-helpers.git

--- a/gwcs/conftest.py
+++ b/gwcs/conftest.py
@@ -9,7 +9,7 @@ from astropy.tests.plugins.display import PYTEST_HEADER_MODULES, TESTED_VERSIONS
 
 # Uncomment the following line to treat all DeprecationWarnings as
 # exceptions
-enable_deprecations_as_exceptions()
+#enable_deprecations_as_exceptions()
 
 try:
     PYTEST_HEADER_MODULES['Astropy'] = 'astropy'


### PR DESCRIPTION
Changed the tests on Travis to;

- test against released versions of astropy and asdf
- to not turn warnings into errors (because of a bug in coordinates)
- include allowed failures for tests with dev versions of asdf, numpy and astropy