### PR TITLE
Support 'custom' physical type in wcs validation

### DIFF
--- a/gwcs/coordinate_frames.py
+++ b/gwcs/coordinate_frames.py
@@ -137,6 +137,8 @@ class CoordinateFrame:
                 ph_type = ("em.wl",)
             elif self.unit[0].physical_type == "energy":
                 ph_type = ("em.energy",)
+            else:
+                ph_type = ("custom:{}".format(self.unit[0].physical_type),)
         elif isinstance(self, TemporalFrame):
             ph_type = ("time",)
         elif isinstance(self, Frame2D):

--- a/gwcs/tests/test_coordinate_systems.py
+++ b/gwcs/tests/test_coordinate_systems.py
@@ -30,10 +30,12 @@ focal = cf.Frame2D(name='focal', axes_order=(0, 1), unit=(u.m, u.m))
 spec1 = cf.SpectralFrame(name='freq', unit=[u.Hz, ], axes_order=(2, ))
 spec2 = cf.SpectralFrame(name='wave', unit=[u.m, ], axes_order=(2, ), axes_names=('lambda', ))
 spec3 = cf.SpectralFrame(name='energy', unit=[u.J, ], axes_order=(2, ))
+spec4 = cf.SpectralFrame(name='pixel', unit=[u.pix, ], axes_order=(2, ))
 
 comp1 = cf.CompositeFrame([icrs, spec1])
 comp2 = cf.CompositeFrame([focal, spec2])
 comp3 = cf.CompositeFrame([icrs, spec3])
+comp4 = cf.CompositeFrame([icrs, spec4])
 comp = cf.CompositeFrame([comp1, cf.SpectralFrame(axes_order=(3,), unit=(u.m,))])
 
 xscalar = 1
@@ -301,14 +303,15 @@ def test_axis_physical_type():
     assert spec1.axis_physical_types == ("em.freq",)
     assert spec2.axis_physical_types == ("em.wl",)
     assert spec3.axis_physical_types == ("em.energy",)
+    assert spec4.axis_physical_types == ("custom:unknown",)
     assert comp1.axis_physical_types == ("pos.eq.ra", "pos.eq.dec", "em.freq")
     assert comp2.axis_physical_types == ("custom:x", "custom:y", "em.wl")
     assert comp3.axis_physical_types == ("pos.eq.ra", "pos.eq.dec", "em.energy")
     assert comp.axis_physical_types == ('pos.eq.ra', 'pos.eq.dec', 'em.freq', 'em.wl')
 
-    spec4 = cf.SpectralFrame(name='waven', axes_order=(1,),
+    spec5 = cf.SpectralFrame(name='waven', axes_order=(1,),
                              axis_physical_types='em.wavenumber')
-    assert spec4.axis_physical_types == ('em.wavenumber',)
+    assert spec5.axis_physical_types == ('em.wavenumber',)
 
     t = cf.TemporalFrame(reference_time=Time("2018-01-01T00:00:00"), unit=u.s)
     assert t.axis_physical_types == ('time',)


### PR DESCRIPTION
The `validate_physical_types` function [in astropy](https://github.com/astropy/astropy/blob/master/astropy/wcs/wcsapi/low_level_api.py#L271) allows for custom physical types that don't exist in the VO definition list. Currently, specutils needs gwcs to handle cases where there aren't explicit VO definitions available for input units (e.g. if the spectral axis is in pixels, or no units are defined; see astropy/specutils#435/astropy/specutils#437). This PR provides a fall-through to set the physical type to this custom value.