### PR TITLE
MNT: Ignore .eggs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ docs/_build
 
 # Packages/installer info
 *.egg
+*.eggs
 *.egg-info
 dist
 build


### PR DESCRIPTION
When I install from source, this is shown as untracked, but it really should be ignored.