### PR TITLE
Support velocity physical type in wcs validation

### DIFF
--- a/gwcs/coordinate_frames.py
+++ b/gwcs/coordinate_frames.py
@@ -138,7 +138,7 @@ class CoordinateFrame:
             elif self.unit[0].physical_type == "energy":
                 ph_type = ("em.energy",)
             elif self.unit[0].physical_type == "speed":
-                ph_type = ("phys.veloc",)
+                ph_type = ("spect.dopplerVeloc",)
             else:
                 ph_type = ("custom:{}".format(self.unit[0].physical_type),)
         elif isinstance(self, TemporalFrame):

--- a/gwcs/coordinate_frames.py
+++ b/gwcs/coordinate_frames.py
@@ -2,6 +2,7 @@
 """
 Defines coordinate frames and ties them to data axes.
 """
+import logging
 import numpy as np
 
 from astropy.utils.misc import isiterable
@@ -139,6 +140,10 @@ class CoordinateFrame:
                 ph_type = ("em.energy",)
             elif self.unit[0].physical_type == "speed":
                 ph_type = ("spect.dopplerVeloc",)
+                logging.warning("Physical type may be ambiguous. Consider "
+                                "setting the physical type explicitly as "
+                                "either 'spect.dopplerVeloc.optical' or "
+                                "'spect.dopplerVeloc.radio'.")
             else:
                 ph_type = ("custom:{}".format(self.unit[0].physical_type),)
         elif isinstance(self, TemporalFrame):

--- a/gwcs/coordinate_frames.py
+++ b/gwcs/coordinate_frames.py
@@ -80,7 +80,7 @@ class CoordinateFrame:
         else:
             axes_names = tuple([""] * naxes)
         self._axes_names = axes_names
-        
+
         if name is None:
             self._name = self.__class__.__name__
         else:
@@ -99,7 +99,7 @@ class CoordinateFrame:
     def _set_axis_physical_types(self, pht=None):
         """
         Set the physical type of the coordinate axes using VO UCD1+ v1.23 definitions.
-        
+
         """
         if pht is not None:
             if isinstance(pht, str):
@@ -116,7 +116,7 @@ class CoordinateFrame:
                     ph_type.append(axt)
             validate_physical_types(ph_type)
             return tuple(ph_type)
-        
+
         if isinstance(self, CelestialFrame):
             if isinstance(self.reference_frame, coord.Galactic):
                 ph_type = "pos.galactic.lon", "pos.galactic.lat"
@@ -137,6 +137,8 @@ class CoordinateFrame:
                 ph_type = ("em.wl",)
             elif self.unit[0].physical_type == "energy":
                 ph_type = ("em.energy",)
+            elif self.unit[0].physical_type == "speed":
+                ph_type = ("phys.veloc",)
             else:
                 ph_type = ("custom:{}".format(self.unit[0].physical_type),)
         elif isinstance(self, TemporalFrame):
@@ -352,7 +354,7 @@ class SpectralFrame(CoordinateFrame):
                                             unit=unit, name=name,
                                             reference_position=reference_position,
                                             axis_physical_types=axis_physical_types)
-        
+
     def coordinates(self, *args, equivalencies=[]):
         if hasattr(args[0], 'unit'):
             return args[0].to(self.unit[0], equivalencies=equivalencies)
@@ -470,7 +472,7 @@ class CompositeFrame(CoordinateFrame):
                                              unit=unit, axes_names=axes_names,
                                              name=name)
         self._axis_physical_types = tuple(ph_type)
-        
+
     @property
     def frames(self):
         return self._frames

--- a/gwcs/tests/test_coordinate_systems.py
+++ b/gwcs/tests/test_coordinate_systems.py
@@ -308,7 +308,7 @@ def test_axis_physical_type():
     assert spec2.axis_physical_types == ("em.wl",)
     assert spec3.axis_physical_types == ("em.energy",)
     assert spec4.axis_physical_types == ("custom:unknown",)
-    assert spec5.axis_physical_types == ("phys.veloc",)
+    assert spec5.axis_physical_types == ("spect.dopplerVeloc",)
     assert comp1.axis_physical_types == ("pos.eq.ra", "pos.eq.dec", "em.freq")
     assert comp2.axis_physical_types == ("custom:x", "custom:y", "em.wl")
     assert comp3.axis_physical_types == ("pos.eq.ra", "pos.eq.dec", "em.energy")

--- a/gwcs/tests/test_coordinate_systems.py
+++ b/gwcs/tests/test_coordinate_systems.py
@@ -31,11 +31,13 @@ spec1 = cf.SpectralFrame(name='freq', unit=[u.Hz, ], axes_order=(2, ))
 spec2 = cf.SpectralFrame(name='wave', unit=[u.m, ], axes_order=(2, ), axes_names=('lambda', ))
 spec3 = cf.SpectralFrame(name='energy', unit=[u.J, ], axes_order=(2, ))
 spec4 = cf.SpectralFrame(name='pixel', unit=[u.pix, ], axes_order=(2, ))
+spec5 = cf.SpectralFrame(name='speed', unit=[u.m/u.s, ], axes_order=(2, ))
 
 comp1 = cf.CompositeFrame([icrs, spec1])
 comp2 = cf.CompositeFrame([focal, spec2])
 comp3 = cf.CompositeFrame([icrs, spec3])
 comp4 = cf.CompositeFrame([icrs, spec4])
+comp5 = cf.CompositeFrame([icrs, spec5])
 comp = cf.CompositeFrame([comp1, cf.SpectralFrame(axes_order=(3,), unit=(u.m,))])
 
 xscalar = 1
@@ -52,6 +54,8 @@ def test_units():
     assert(comp1.unit == (u.deg, u.deg, u.Hz))
     assert(comp2.unit == (u.m, u.m, u.m))
     assert(comp3.unit == (u.deg, u.deg, u.J))
+    assert(comp4.unit == (u.deg, u.deg, u.pix))
+    assert(comp5.unit == (u.deg, u.deg, u.m/u.s))
     assert(comp.unit == (u.deg, u.deg, u.Hz, u.m))
 
 
@@ -185,7 +189,7 @@ def test_coordinate_to_quantity_celestial(inp):
     with pytest.raises(ValueError):
         cel.coordinate_to_quantity((1, 2))
 
-        
+
 @pytest.mark.parametrize('inp', [
     (100,),
     (100 * u.nm,),
@@ -296,7 +300,7 @@ def test_coordinate_to_quantity_error():
     frame = cf.TemporalFrame(unit=u.s)
     with pytest.raises(ValueError):
         frame.coordinate_to_quantity(1)
-    
+
 
 def test_axis_physical_type():
     assert icrs.axis_physical_types == ("pos.eq.ra", "pos.eq.dec")
@@ -304,14 +308,15 @@ def test_axis_physical_type():
     assert spec2.axis_physical_types == ("em.wl",)
     assert spec3.axis_physical_types == ("em.energy",)
     assert spec4.axis_physical_types == ("custom:unknown",)
+    assert spec5.axis_physical_types == ("phys.veloc",)
     assert comp1.axis_physical_types == ("pos.eq.ra", "pos.eq.dec", "em.freq")
     assert comp2.axis_physical_types == ("custom:x", "custom:y", "em.wl")
     assert comp3.axis_physical_types == ("pos.eq.ra", "pos.eq.dec", "em.energy")
     assert comp.axis_physical_types == ('pos.eq.ra', 'pos.eq.dec', 'em.freq', 'em.wl')
 
-    spec5 = cf.SpectralFrame(name='waven', axes_order=(1,),
+    spec6 = cf.SpectralFrame(name='waven', axes_order=(1,),
                              axis_physical_types='em.wavenumber')
-    assert spec5.axis_physical_types == ('em.wavenumber',)
+    assert spec6.axis_physical_types == ('em.wavenumber',)
 
     t = cf.TemporalFrame(reference_time=Time("2018-01-01T00:00:00"), unit=u.s)
     assert t.axis_physical_types == ('time',)
@@ -330,7 +335,7 @@ def test_axis_physical_type():
 
     fr = cf.CelestialFrame(reference_frame=coord.ICRS(), axis_physical_types=("ra", "dec"))
     assert fr.axis_physical_types == ("custom:ra", "custom:dec")
-    
+
     fr = cf.CelestialFrame(reference_frame=coord.BarycentricTrueEcliptic())
     assert fr.axis_physical_types == ('pos.ecliptic.lon', 'pos.ecliptic.lat')
 


### PR DESCRIPTION
Adds support for the VO table definition `phys.veloc` for dispersion axes provided in velocity space.