### PR TITLE
pixel_to_world is not providing world units

### DIFF
--- a/gwcs/api.py
+++ b/gwcs/api.py
@@ -15,8 +15,8 @@ __all__ = ["GWCSAPIMixin"]
 class GWCSAPIMixin(BaseHighLevelWCS, BaseLowLevelWCS):
     """
     A mix-in class that is intended to be inherited by the
-    :class:`~gwcs.wcs.WCS` class and provides the low- and high-level 
-    WCS API described in the astropy APE 14 
+    :class:`~gwcs.wcs.WCS` class and provides the low- and high-level
+    WCS API described in the astropy APE 14
     (https://doi.org/10.5281/zenodo.1188875).
     """
 
@@ -100,8 +100,8 @@ class GWCSAPIMixin(BaseHighLevelWCS, BaseLowLevelWCS):
         """
         result = self.invert(*world_arrays, with_units=False)
         return result
-    
-    
+
+
     def world_to_array_index_values(self, *world_arrays):
         """
         Convert world coordinates to array indices.
@@ -132,7 +132,7 @@ class GWCSAPIMixin(BaseHighLevelWCS, BaseLowLevelWCS):
     @array_shape.setter
     def array_shape(self, value):
         self._array_shape = value
-        
+
     @property
     def pixel_bounds(self):
         """
@@ -185,9 +185,10 @@ class GWCSAPIMixin(BaseHighLevelWCS, BaseLowLevelWCS):
         """
         Convert pixel values to world coordinates.
         """
+        call_kwargs = {}
         if not self.forward_transform.uses_quantity:
-            kwargs = {'with_units': True}
-        return self(*pixel_arrays, **kwargs)
+            call_kwargs['with_units'] = True
+        return self(*pixel_arrays, **call_kwargs)
 
     def array_index_to_world(self, *index_arrays):
         """
@@ -209,4 +210,3 @@ class GWCSAPIMixin(BaseHighLevelWCS, BaseLowLevelWCS):
         """
         result = self.invert(*world_objects, with_units=True)[::-1]
         return tuple([utils._toindex(r) for r in result])
-    

--- a/gwcs/api.py
+++ b/gwcs/api.py
@@ -186,7 +186,7 @@ class GWCSAPIMixin(BaseHighLevelWCS, BaseLowLevelWCS):
         Convert pixel values to world coordinates.
         """
         call_kwargs = {}
-        if not self.forward_transform.uses_quantity:
+        if self.forward_transform.uses_quantity:
             call_kwargs['with_units'] = True
         return self(*pixel_arrays, **call_kwargs)
 


### PR DESCRIPTION
This is a bit confusing because it's really an issue, but I've made a PR, because the first commit in the PR is trivial but necessary to see the underlying issue.  So *after* this PR is applied, I see the following behavior:

```
>>> import numpy as np
>>> import astropy.units as u
>>> import gwcs
>>> from astropy.modeling.tabular import Tabular1D
>>> from gwcs.coordinate_frames import SpectralFrame
>>> q =  u.Quantity(np.arange(10) * u.AA)
>>> spec_frame = SpectralFrame(unit=q.unit, axes_order=(0,))
>>> forward_transform = Tabular1D(np.arange(len(q)), q.value)
>>> tabular_gwcs = gwcs.wcs.WCS(forward_transform=forward_transform, output_frame=spec_frame)
>>> tabular_gwcs.pixel_to_world(1)
1.0
```

This is surprising because the `SpectralFrame` use units of angstroms.  So shouldn't the output be a *quantity* with units of 1 Angstrom?

Not that if I force the matter by having ``call_kwargs['with_units'] = True`` for *all* cases (i.e. drop the ``if`` statement in the changed file here), it has the expected behavior.  That's what is happening in my *second* commit.  But presumably that would fail for transforms that don't have units?


cc @nmearl (who originally pointed this out in the context of specutils)