### PR TITLE
Fix unified WCS API for transforms that use Quantity

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,9 @@ Bug Fixes
 
 - Update util.isnumerical(...) to recognize big-endian types as numeric. [#225]
 
+- Fixed issue in unified WCS API (APE14) for transforms that use
+  ``Quantity``. [#222]
+
 0.10.0 (12/20/2018)
 -------------------
 

--- a/gwcs/api.py
+++ b/gwcs/api.py
@@ -6,6 +6,7 @@ in astropy APE 14 (https://doi.org/10.5281/zenodo.1188875).
 """
 from astropy.wcs.wcsapi import BaseHighLevelWCS, BaseLowLevelWCS
 from astropy.modeling import separable
+import astropy.units as u
 
 from . import utils
 
@@ -193,7 +194,7 @@ class GWCSAPIMixin(BaseHighLevelWCS, BaseLowLevelWCS):
         objects).
         """
         pixel_arrays = index_arrays[::-1]
-        if self.forward_transform.uses_quantity:
+        if self.forward_transform.uses_quantity and not isinstance(pixel_arrays[0], u.Quantity):
             pixel_arrays = [pixel * self.input_frame.unit[i]
                             for i, pixel in enumerate(pixel_arrays)]
         return self(*pixel_arrays, with_units=True)

--- a/gwcs/api.py
+++ b/gwcs/api.py
@@ -201,7 +201,11 @@ class GWCSAPIMixin(BaseHighLevelWCS, BaseLowLevelWCS):
         """
         Convert world coordinates to pixel values.
         """
-        return self.invert(*world_objects)
+        if not self.forward_transform.uses_quantity:
+            return self.invert(*world_objects)
+        else:
+            xpix, ypix = self.invert(*world_objects)
+            return xpix.value, ypix.value
 
     def world_to_array_index(self, *world_objects):
         """

--- a/gwcs/api.py
+++ b/gwcs/api.py
@@ -6,6 +6,7 @@ in astropy APE 14 (https://doi.org/10.5281/zenodo.1188875).
 """
 from astropy.wcs.wcsapi import BaseHighLevelWCS, BaseLowLevelWCS
 from astropy.modeling import separable
+import astropy.units as u
 
 from . import utils
 
@@ -182,6 +183,8 @@ class GWCSAPIMixin(BaseHighLevelWCS, BaseLowLevelWCS):
         """
         Convert pixel values to world coordinates.
         """
+        if self.forward_transform.uses_quantity:
+            pixel_arrays = pixel_arrays * u.pix  # *= only for newer astropy
         return self(*pixel_arrays, with_units=True)
 
     def array_index_to_world(self, *index_arrays):
@@ -189,7 +192,10 @@ class GWCSAPIMixin(BaseHighLevelWCS, BaseLowLevelWCS):
         Convert array indices to world coordinates (represented by Astropy
         objects).
         """
-        return self(*(index_arrays[::-1]), with_units=True)
+        pixel_arrays = index_arrays[::-1]
+        if self.forward_transform.uses_quantity:
+            pixel_arrays = pixel_arrays * u.pix  # *= only for newer astropy
+        return self(*pixel_arrays, with_units=True)
 
     def world_to_pixel(self, *world_objects):
         """

--- a/gwcs/api.py
+++ b/gwcs/api.py
@@ -183,9 +183,16 @@ class GWCSAPIMixin(BaseHighLevelWCS, BaseLowLevelWCS):
         """
         Convert pixel values to world coordinates.
         """
-        if self.forward_transform.uses_quantity and not isinstance(pixel_arrays[0], u.Quantity):
+        if (self.forward_transform.uses_quantity and
+                not isinstance(pixel_arrays[0], u.Quantity)):
             pixel_arrays = [pixel * self.input_frame.unit[i]
                             for i, pixel in enumerate(pixel_arrays)]
+        if (not self.forward_transform.uses_quantity and
+                isinstance(pixel_arrays[0], u.Quantity)):
+            for pixel in pixel_arrays:
+                if pixel.unit != u.pixel:
+                    raise ValueError('inputs should have pixel units')
+            pixel_arrays = [pixel.value for pixel in pixel_arrays]
         return self(*pixel_arrays, with_units=True)
 
     def array_index_to_world(self, *index_arrays):
@@ -194,9 +201,16 @@ class GWCSAPIMixin(BaseHighLevelWCS, BaseLowLevelWCS):
         objects).
         """
         pixel_arrays = index_arrays[::-1]
-        if self.forward_transform.uses_quantity and not isinstance(pixel_arrays[0], u.Quantity):
+        if (self.forward_transform.uses_quantity and
+                not isinstance(pixel_arrays[0], u.Quantity)):
             pixel_arrays = [pixel * self.input_frame.unit[i]
                             for i, pixel in enumerate(pixel_arrays)]
+        if (not self.forward_transform.uses_quantity and
+                isinstance(pixel_arrays[0], u.Quantity)):
+            for pixel in pixel_arrays:
+                if pixel.unit != u.pixel:
+                    raise ValueError('inputs should have pixel units')
+            pixel_arrays = [pixel.value for pixel in pixel_arrays]
         return self(*pixel_arrays, with_units=True)
 
     def world_to_pixel(self, *world_objects):

--- a/gwcs/api.py
+++ b/gwcs/api.py
@@ -182,7 +182,7 @@ class GWCSAPIMixin(BaseHighLevelWCS, BaseLowLevelWCS):
         """
         Convert pixel values to world coordinates.
         """
-        if self.forward_transform.uses_quantity:
+        if self.forward_transform.uses_quantity and not isinstance(pixel_arrays[0], u.Quantity):
             pixel_arrays = [pixel * self.input_frame.unit[i]
                             for i, pixel in enumerate(pixel_arrays)]
         return self(*pixel_arrays, with_units=True)

--- a/gwcs/api.py
+++ b/gwcs/api.py
@@ -172,7 +172,6 @@ class GWCSAPIMixin(BaseHighLevelWCS, BaseLowLevelWCS):
         raise NotImplementedError()
 
     # High level APE 14 API
-
     def low_level_wcs(self):
         """
         Returns a reference to the underlying low-level WCS object.

--- a/gwcs/tests/test_api.py
+++ b/gwcs/tests/test_api.py
@@ -225,3 +225,21 @@ def test_array_index_to_world_quantity():
     assert_allclose(result1.data.lat, result2.data.lat)
     assert_allclose(result0.data.lon, result1.data.lon)
     assert_allclose(result0.data.lat, result1.data.lat)
+
+
+def test_world_to_pixel_quantity():
+    skycoord = wcs_noquantity.pixel_to_world(x, y)
+    result1 = wcs_noquantity.world_to_pixel(skycoord)
+    result2 = wcs_quantity.world_to_pixel(skycoord)
+    assert_allclose(result1, (x, y))
+    assert_allclose(result2, (x, y))
+
+
+def test_world_to_array_index_quantity():
+    skycoord = wcs_noquantity.pixel_to_world(x, y)
+    result0 = wcs_noquantity.world_to_pixel(skycoord)
+    result1 = wcs_noquantity.world_to_array_index(skycoord)
+    result2 = wcs_quantity.world_to_array_index(skycoord)
+    assert_allclose(result0, (x, y))
+    assert_allclose(result1, (y, x))
+    assert_allclose(result2, (y, x))

--- a/gwcs/tests/test_api.py
+++ b/gwcs/tests/test_api.py
@@ -24,7 +24,6 @@ spec2 = cf.SpectralFrame(name='wave', unit=[u.m, ], axes_order=(2, ), axes_names
 comp1 = cf.CompositeFrame([sky_frame, spec1])
 
 # transforms
-
 m1 = models.Shift(1) & models.Shift(2)
 m2 = models.Scale(2)
 m = m1 & m2
@@ -35,6 +34,7 @@ pipe = [(detector, m1),
 
 example_wcs = wcs.WCS(pipe)
 
+
 def create_example_wcs():
     example_wcs = [wcs.WCS([(detector, m1),
                             (sky_frame, None)]),
@@ -42,7 +42,7 @@ def create_example_wcs():
                             (spec1, None)]),
                    wcs.WCS([(detector, m),
                             (comp1, None)])
-                  ]
+                   ]
 
     pixel_world_ndim = [(2, 2), (2, 1), (2, 3)]
     physical_types = [("pos.eq.ra", "pos.eq.dec"), ("em.freq",), ("pos.eq.ra", "pos.eq.dec", "em.freq")]
@@ -50,18 +50,21 @@ def create_example_wcs():
 
     return example_wcs, pixel_world_ndim, physical_types, world_units
 
+
 # x, y inputs - scalar and array
 x, y = 1, 2
 xarr, yarr = np.ones((3, 4)), np.ones((3, 4)) + 1
 
 # ra, dec inputs - scalar, arrays and SkyCoord objects
 ra, dec = 2, 4
-sky = coord.SkyCoord(ra * u.deg, dec*u.deg, frame = sky_frame.reference_frame)
+sky = coord.SkyCoord(ra * u.deg, dec * u.deg, frame=sky_frame.reference_frame)
 raarr = np.ones((3, 4)) * ra
 decarr = np.ones((3, 4)) * dec
-skyarr = coord.SkyCoord(raarr * u.deg, decarr*u.deg, frame = sky_frame.reference_frame)
+skyarr = coord.SkyCoord(raarr * u.deg, decarr * u.deg,
+                        frame=sky_frame.reference_frame)
 
 ex_wcs, dims, physical_types, world_units = create_example_wcs()
+
 
 @pytest.mark.parametrize(("wcsobj", "ndims"), zip(ex_wcs, dims))
 def test_pixel_n_dim(wcsobj, ndims):
@@ -143,7 +146,7 @@ def test_axis_correlation_matrix():
 
 def test_serialized_classes():
     wcsobj = example_wcs
-    assert wcsobj.serialized_classes() == False
+    assert not wcsobj.serialized_classes()
 
 
 def test_low_level_wcs():
@@ -164,7 +167,7 @@ def test_pixel_to_world():
 
 def test_array_index_to_world():
     wcsobj = example_wcs
-    comp =  wcsobj(x, y, with_units=True)
+    comp = wcsobj(x, y, with_units=True)
     comp = wcsobj.output_frame.coordinates(comp)
     result = wcsobj.array_index_to_world(y, x)
     assert isinstance(comp, coord.SkyCoord)

--- a/gwcs/tests/test_api.py
+++ b/gwcs/tests/test_api.py
@@ -215,6 +215,17 @@ def test_pixel_to_world_quantity():
     assert_allclose(result1.data.lon, result2.data.lon)
     assert_allclose(result1.data.lat, result2.data.lat)
 
+    # test with Quantity pixel inputs
+    result1 = wcs_noquantity.pixel_to_world(x * u.pix, y * u.pix)
+    result2 = wcs_quantity.pixel_to_world(x * u.pix, y * u.pix)
+    assert isinstance(result2, coord.SkyCoord)
+    assert_allclose(result1.data.lon, result2.data.lon)
+    assert_allclose(result1.data.lat, result2.data.lat)
+
+    # test for pixel units
+    with pytest.raises(ValueError):
+        wcs_noquantity.pixel_to_world(x * u.Jy, y * u.Jy)
+
 
 def test_array_index_to_world_quantity():
     result0 = wcs_noquantity.pixel_to_world(x, y)
@@ -225,6 +236,20 @@ def test_array_index_to_world_quantity():
     assert_allclose(result1.data.lat, result2.data.lat)
     assert_allclose(result0.data.lon, result1.data.lon)
     assert_allclose(result0.data.lat, result1.data.lat)
+
+    # test with Quantity pixel inputs
+    result0 = wcs_noquantity.pixel_to_world(x * u.pix, y * u.pix)
+    result1 = wcs_noquantity.array_index_to_world(y * u.pix, x * u.pix)
+    result2 = wcs_quantity.array_index_to_world(y * u.pix, x * u.pix)
+    assert isinstance(result2, coord.SkyCoord)
+    assert_allclose(result1.data.lon, result2.data.lon)
+    assert_allclose(result1.data.lat, result2.data.lat)
+    assert_allclose(result0.data.lon, result1.data.lon)
+    assert_allclose(result0.data.lat, result1.data.lat)
+
+    # test for pixel units
+    with pytest.raises(ValueError):
+        wcs_noquantity.array_index_to_world(x * u.Jy, y * u.Jy)
 
 
 def test_world_to_pixel_quantity():

--- a/gwcs/tests/test_api.py
+++ b/gwcs/tests/test_api.py
@@ -43,11 +43,11 @@ def create_example_wcs():
                    wcs.WCS([(detector, m),
                             (comp1, None)])
                   ]
-    
+
     pixel_world_ndim = [(2, 2), (2, 1), (2, 3)]
     physical_types = [("pos.eq.ra", "pos.eq.dec"), ("em.freq",), ("pos.eq.ra", "pos.eq.dec", "em.freq")]
     world_units = [("deg", "deg"), ("Hz",), ("deg", "deg", "Hz")]
-    
+
     return example_wcs, pixel_world_ndim, physical_types, world_units
 
 # x, y inputs - scalar and array
@@ -67,17 +67,17 @@ ex_wcs, dims, physical_types, world_units = create_example_wcs()
 def test_pixel_n_dim(wcsobj, ndims):
     assert wcsobj.pixel_n_dim == ndims[0]
 
-    
+
 @pytest.mark.parametrize(("wcsobj", "ndims"), zip(ex_wcs, dims))
 def test_world_n_dim(wcsobj, ndims):
     assert wcsobj.world_n_dim == ndims[1]
 
-    
+
 @pytest.mark.parametrize(("wcsobj", "physical_types"), zip(ex_wcs, physical_types))
 def test_world_axis_physical_types(wcsobj, physical_types):
     assert wcsobj.world_axis_physical_types == physical_types
 
-    
+
 @pytest.mark.parametrize(("wcsobj", "world_units"), zip(ex_wcs, world_units))
 def test_world_axis_units(wcsobj, world_units):
     assert wcsobj.world_axis_units == world_units
@@ -119,7 +119,7 @@ def test_world_axis_object_classes():
     with pytest.raises(NotImplementedError):
         wcsobj.world_axis_object_classes()
 
-        
+
 def test_array_shape():
     wcsobj = example_wcs
     assert wcsobj.array_shape is None
@@ -160,7 +160,7 @@ def test_pixel_to_world():
     assert isinstance(result, coord.SkyCoord)
     assert_allclose(comp.data.lon, result.data.lon)
     assert_allclose(comp.data.lat, result.data.lat)
-    
+
 
 def test_array_index_to_world():
     wcsobj = example_wcs


### PR DESCRIPTION
The high-level unified WCS API methods currently raise errors for WCS transforms that use `Quantity`.  Here's an example using the gwcs transform defined on the main doc page:

```python
import numpy as np
from astropy.modeling import models
from astropy import coordinates as coord
from astropy import units as u
from gwcs import wcs
from gwcs import coordinate_frames as cf

shift_by_crpix = models.Shift(-2047*u.pix) & models.Shift(-1023*u.pix)
matrix = np.array([[1.290551569736E-05, 5.9525007864732E-06],
                   [5.0226382102765E-06 , -1.2644844123757E-05]])
rotation = models.AffineTransformation2D(matrix * u.deg,
                                         translation=[0, 0] * u.deg)
rotation.input_units_equivalencies = {"x": u.pixel_scale(1*u.deg/u.pix),
                                      "y": u.pixel_scale(1*u.deg/u.pix)}
rotation.inverse = models.AffineTransformation2D(np.linalg.inv(matrix) * u.pix,
                                                 translation=[0, 0] * u.pix)
rotation.inverse.input_units_equivalencies = {"x": u.pixel_scale(1*u.pix/u.deg),
                                              "y": u.pixel_scale(1*u.pix/u.deg)}
tan = models.Pix2Sky_TAN()
celestial_rotation =  models.RotateNative2Celestial(5.63056810618*u.deg, -72.05457184279*u.deg, 180*u.deg)
det2sky = shift_by_crpix | rotation | tan | celestial_rotation
det2sky.name = "linear_transform"
detector_frame = cf.Frame2D(name="detector", axes_names=("x", "y"),
                            unit=(u.pix, u.pix))
sky_frame = cf.CelestialFrame(reference_frame=coord.ICRS(), name='icrs',
                              unit=(u.deg, u.deg))
pipeline = [(detector_frame, det2sky), (sky_frame, None)]
wcsobj = wcs.WCS(pipeline)
wcsobj.pixel_to_world(10, 10)
...
<snip>
...
UnitsError: linear_transform: Units of input 'x0', (dimensionless), could not be converted to required input units of pix (unknown)
```

This PR fixes the `pixel_to_world`, `array_index_to_world`, and `world_to_pixel` methods to give the same results for transforms with and without `Quantity`.

I also uncovered what I think is another bug (but did not fix):
```python
>>> skycoord = wcsobj.pixel_to_world(10, 10)
>>> wcsobj.invert(skycoord, with_units=False)
(<Quantity 10. pix>, <Quantity 10. pix>)  # OK

>>> wcsobj.invert(sc, with_units=True)
(<Quantity 10. pix2>, <Quantity 10. pix2>)  # bad units
```

Notice that the returned units are `pix2`, which isn't correct.  Despite this, `world_to_pixel` and `world_to_array_index` currently work because they simply strip the units (i.e. `.value` in `world_to_pixel` and `utils._to_index` in `world_to_array_index`).