### PR TITLE
Update utils.isnumerical(...) to recognize big-endian dtypes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,7 @@ New Features
 Bug Fixes
 ^^^^^^^^^
 
+- Update util.isnumerical(...) to recognize big-endian types as numeric. [#225]
 
 0.10.0 (12/20/2018)
 -------------------

--- a/gwcs/tests/test_utils.py
+++ b/gwcs/tests/test_utils.py
@@ -95,3 +95,6 @@ def test_isnumerical():
     assert gwutils.isnumerical(np.array(0))
 
     assert not gwutils.isnumerical(np.array(['s200', '234']))
+
+    assert gwutils.isnumerical(np.array(0, dtype='>f8'))
+    assert gwutils.isnumerical(np.array(0, dtype='>i4'))

--- a/gwcs/utils.py
+++ b/gwcs/utils.py
@@ -456,13 +456,13 @@ def isnumerical(val):
     """
     Determine if a value is numerical (number or np.array of numbers).
     """
-    dtypes = ['uint64', 'float64', 'int8', 'int64', 'int16', 'uint16', 'uint8',
-              'float32', 'int32', 'uint32']
     isnum = True
     if isinstance(val, coords.SkyCoord):
         isnum = False
     elif isinstance(val, u.Quantity):
         isnum = False
-    elif isinstance(val, np.ndarray) and val.dtype not in dtypes:
+    elif (isinstance(val, np.ndarray)
+          and not np.issubdtype(val.dtype, np.floating)
+          and not np.issubdtype(val.dtype, np.integer)):
         isnum = False
     return isnum


### PR DESCRIPTION
This change will allow isnumerical to recognize any integer or floating point dtype, regardless of endian-ness (endianity???).