### PR TITLE
WCSAxes Support

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,9 @@ API Changes
 Bug Fixes
 ^^^^^^^^^
 
+- Ensure that ``world_to_pixel_values`` and ``pixel_to_world_values`` always
+  accept and return floats, even if the underlying transform uses units. [#248]
+
 0.11.0 (2019/07/26)
 -------------------
 

--- a/gwcs/api.py
+++ b/gwcs/api.py
@@ -63,9 +63,9 @@ class GWCSAPIMixin(BaseHighLevelWCS, BaseLowLevelWCS):
     def _remove_quantity_output(self, result, frame):
         if self.forward_transform.uses_quantity:
             if self.output_frame.naxes == 1:
-                return result.to_value(self.output_frame.unit)
-            else:
-                return [r.to_value(unit) for r, unit in zip(result, frame.unit)]
+                result = [result]
+
+            return [r.to_value(unit) for r, unit in zip(result, frame.unit)]
 
         return result
 

--- a/gwcs/api.py
+++ b/gwcs/api.py
@@ -67,6 +67,8 @@ class GWCSAPIMixin(BaseHighLevelWCS, BaseLowLevelWCS):
             else:
                 return [r.to_value(unit) for r, unit in zip(result, frame.unit)]
 
+        return result
+
     def _add_units_input(self, arrays, transform, frame):
         if transform.uses_quantity:
             return [u.Quantity(array, unit) for array, unit in zip(arrays, frame.unit)]

--- a/gwcs/tags/wcs.py
+++ b/gwcs/tags/wcs.py
@@ -99,8 +99,8 @@ class FrameType(GWCSType):
             kwargs['unit'] = tuple(
                 yamlutil.tagged_tree_to_custom_tree(node['unit'], ctx))
 
-        if 'axis_physical_type' in node:
-            kwargs['axis_physical_type'] = tuple(node['axis_physical_type'])
+        if 'axis_physical_types' in node:
+            kwargs['axis_physical_types'] = tuple(node['axis_physical_types'])
 
         return kwargs
 

--- a/gwcs/tests/conftest.py
+++ b/gwcs/tests/conftest.py
@@ -17,8 +17,8 @@ detector_2d = cf.Frame2D(name='detector', axes_order=(0, 1))
 icrs_sky_frame = cf.CelestialFrame(reference_frame=coord.ICRS(),
                                    axes_order=(0, 1))
 
-freq_frame = cf.SpectralFrame(name='freq', unit=[u.Hz], axes_order=(2, ))
-wave_frame = cf.SpectralFrame(name='wave', unit=[u.m], axes_order=(2, ),
+freq_frame = cf.SpectralFrame(name='freq', unit=u.Hz, axes_order=(2, ))
+wave_frame = cf.SpectralFrame(name='wave', unit=u.m, axes_order=(2, ),
                               axes_names=('lambda', ))
 
 # transforms
@@ -62,6 +62,14 @@ def gwcs_2d_shift_scale():
     m3 = m1 | m2
     pipe = [(detector_2d, m3), (icrs_sky_frame, None)]
     return wcs.WCS(pipe)
+
+
+@pytest.fixture
+def gwcs_1d_freq_quantity():
+
+    detector_1d = cf.CoordinateFrame(name='detector', axes_order=(0,), naxes=1, unit=u.pix, axes_type="detector")
+    return wcs.WCS([(detector_1d, models.Multiply(1 * u.Hz / u.pix)), (freq_frame, None)])
+
 
 
 @pytest.fixture

--- a/gwcs/tests/test_api.py
+++ b/gwcs/tests/test_api.py
@@ -85,20 +85,32 @@ def test_pixel_to_world_values(gwcs_2d_spatial_shift, x, y):
 @pytest.mark.parametrize(("x", "y"), zip((x, xarr), (y, yarr)))
 def test_pixel_to_world_values_units_2d(gwcs_2d_shift_scale_quantity, x, y):
     wcsobj = gwcs_2d_shift_scale_quantity
-    call_output = wcsobj(x*u.pix, y*u.pix, with_units=False)
-    api_output = wcsobj.pixel_to_world_values(x, y)
+
+    call_pixel = x*u.pix, y*u.pix
+    api_pixel = x, y
+
+    call_world = wcsobj(*call_pixel, with_units=False)
+    api_world = wcsobj.pixel_to_world_values(*api_pixel)
 
     # Check that call returns quantities and api dosen't
-    assert all(list(isinstance(a, u.Quantity) for a in call_output))
-    assert all(list(not isinstance(a, u.Quantity) for a in api_output))
+    assert all(list(isinstance(a, u.Quantity) for a in call_world))
+    assert all(list(not isinstance(a, u.Quantity) for a in api_world))
 
     # Check that they are the same (and implicitly in the same units)
-    assert_allclose(u.Quantity(call_output).value, api_output)
+    assert_allclose(u.Quantity(call_world).value, api_world)
+
+
+    new_call_pixel = wcsobj.invert(*call_world, with_units=False)
+    [assert_allclose(n, p) for n, p in zip(new_call_pixel, call_pixel)]
+
+    new_api_pixel = wcsobj.world_to_pixel_values(*api_world)
+    [assert_allclose(n, p) for n, p in zip(new_api_pixel, api_pixel)]
 
 
 @pytest.mark.parametrize(("x"), (x, xarr))
 def test_pixel_to_world_values_units_1d(gwcs_1d_freq_quantity, x):
     wcsobj = gwcs_1d_freq_quantity
+
     call_pixel = x * u.pix
     api_pixel = x
 

--- a/gwcs/tests/test_api.py
+++ b/gwcs/tests/test_api.py
@@ -83,6 +83,44 @@ def test_pixel_to_world_values(gwcs_2d_spatial_shift, x, y):
 
 
 @pytest.mark.parametrize(("x", "y"), zip((x, xarr), (y, yarr)))
+def test_pixel_to_world_values_units_2d(gwcs_2d_shift_scale_quantity, x, y):
+    wcsobj = gwcs_2d_shift_scale_quantity
+    call_output = wcsobj(x*u.pix, y*u.pix, with_units=False)
+    api_output = wcsobj.pixel_to_world_values(x, y)
+
+    # Check that call returns quantities and api dosen't
+    assert all(list(isinstance(a, u.Quantity) for a in call_output))
+    assert all(list(not isinstance(a, u.Quantity) for a in api_output))
+
+    # Check that they are the same (and implicitly in the same units)
+    assert_allclose(u.Quantity(call_output).value, api_output)
+
+
+@pytest.mark.parametrize(("x"), (x, xarr))
+def test_pixel_to_world_values_units_1d(gwcs_1d_freq_quantity, x):
+    wcsobj = gwcs_1d_freq_quantity
+    call_pixel = x * u.pix
+    api_pixel = x
+
+    call_world = wcsobj(call_pixel, with_units=False)
+    api_world = wcsobj.pixel_to_world_values(api_pixel)
+
+    # Check that call returns quantities and api dosen't
+    assert isinstance(call_world, u.Quantity)
+    assert not isinstance(api_world, u.Quantity)
+
+    # Check that they are the same (and implicitly in the same units)
+    assert_allclose(u.Quantity(call_world).value, api_world[0])
+
+
+    new_call_pixel = wcsobj.invert(call_world, with_units=False)
+    assert_allclose(new_call_pixel, call_pixel)
+
+    new_api_pixel = wcsobj.world_to_pixel_values(*api_world)[0]
+    assert_allclose(new_api_pixel, api_pixel)
+
+
+@pytest.mark.parametrize(("x", "y"), zip((x, xarr), (y, yarr)))
 def test_array_index_to_world_values(gwcs_2d_spatial_shift, x, y):
     wcsobj = gwcs_2d_spatial_shift
     assert_allclose(wcsobj.array_index_to_world_values(x, y), wcsobj(y, x, with_units=False))


### PR DESCRIPTION
These were some issues I encountered while trying to use WCSAxes with a fully unit specified model.

The low level WCS API explicitly requires that inputs and outputs to the low level `pixel_to_world_values` and `world_to_pixel_values` (and their array index counterparts) are float. So this adds code to enforce this even if the underlying model that gWCS is using is fully united on input and output.

This needs some tests.