### PR TITLE
fix_inputs method

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,9 @@ New Features
 
 - Removed astropy-helpers from package. [#249]
 
+- Added a method ``fix_inputs`` which rturns an unique WCS from a compound
+  WCS by fixing inputs. [#254]
+
 API Changes
 ^^^^^^^^^^^
 

--- a/gwcs/coordinate_frames.py
+++ b/gwcs/coordinate_frames.py
@@ -461,7 +461,7 @@ class TemporalFrame(CoordinateFrame):
         else:
             dt = args[0]
 
-        if self.reference_frame.value:
+        if not isinstance(self.reference_frame.value, np.ndarray):
             if not hasattr(dt, 'unit'):
                 dt = dt * self.unit[0]
             return self.reference_frame + dt
@@ -471,7 +471,8 @@ class TemporalFrame(CoordinateFrame):
 
     def coordinate_to_quantity(self, *coords):
         if isinstance(coords[0], time.Time):
-            if self.reference_frame.value:
+            ref_value = self.reference_frame.value
+            if not isinstance(ref_value, np.ndarray):
                 return (coords[0] - self.reference_frame).to(self.unit[0])
             else:
                 # If we can't convert to a quantity just drop the object out

--- a/gwcs/wcs.py
+++ b/gwcs/wcs.py
@@ -622,13 +622,12 @@ class WCS(GWCSAPIMixin):
         >>> w = WCS(pipeline, selector={"spectral_order": [1, 2]}) # doctest: +SKIP
         >>> new_wcs = w.set_inputs(spectral_order=2) # doctest: +SKIP
         >>> new_wcs.inputs # doctest: +SKIP
-
             ("x", "y")
 
         """
         if not HAS_FIX_INPUTS:
             raise ImportError('"fix_inputs" needs astropy version >= 4.0.')
-        keys = fixed.keys()
+
         new_pipeline = []
         step0 = self.pipeline[0]
         new_transform = fix_inputs(step0[1], fixed)

--- a/gwcs/wcs.py
+++ b/gwcs/wcs.py
@@ -619,9 +619,10 @@ class WCS(GWCSAPIMixin):
 
         Examples
         --------
-        >>> w = WCS(pipeline, selector=("spectral_order", inputs=("x", "y", "spectral_order"))
-        >>> new_wcs = w.set_inputs(spectral_order=2)
-        >>> new_wcs.inputs
+        >>> w = WCS(pipeline, selector={"spectral_order": [1, 2]}) # doctest: +SKIP
+        >>> new_wcs = w.set_inputs(spectral_order=2) # doctest: +SKIP
+        >>> new_wcs.inputs # doctest: +SKIP
+
             ("x", "y")
 
         """

--- a/gwcs/wcs.py
+++ b/gwcs/wcs.py
@@ -2,7 +2,7 @@
 import functools
 import itertools
 import numpy as np
-from astropy.modeling.core import Model
+from astropy.modeling.core import Model, fix_inputs
 from astropy.modeling import utils as mutils
 
 from .api import GWCSAPIMixin
@@ -594,3 +594,33 @@ class WCS(GWCSAPIMixin):
                 result = np.squeeze(result)
 
         return result.T
+
+    def fix_inputs(self, fixed):
+        """
+        Return a new unique WCS by fixing inputs to constant values.
+
+        Parameters
+        ----------
+        fixed : dict
+            Keyword arguments with fixed values corresponding to `self.selector`.
+
+        Returns
+        -------
+        new_wcs : `WCS`
+            A new unique WCS corresponding to the values in `fixed`.
+
+        Examples
+        --------
+        >>> w = WCS(pipeline, selector=("spectral_order", inputs=("x", "y", "spectral_order"))
+        >>> new_wcs = w.set_inputs(spectral_order=2)
+        >>> new_wcs.inputs
+            ("x", "y")
+
+        """
+        keys = fixed.keys()
+        new_pipeline = []
+        step0 = self.pipeline[0]
+        new_transform = fix_inputs(step0[1], fixed)
+        new_pipeline.append((step0[0], new_transform))
+        new_pipeline.extend(self.pipeline[1:])
+        return self.__class__(new_pipeline)

--- a/gwcs/wcs.py
+++ b/gwcs/wcs.py
@@ -2,7 +2,7 @@
 import functools
 import itertools
 import numpy as np
-from astropy.modeling.core import Model, fix_inputs
+from astropy.modeling.core import Model # , fix_inputs
 from astropy.modeling import utils as mutils
 
 from .api import GWCSAPIMixin
@@ -10,6 +10,14 @@ from . import coordinate_frames
 from .utils import CoordinateFrameError
 from .utils import _toindex
 from . import utils
+
+
+HAS_FIX_INPUTS = True
+
+try:
+    from astropy.modeling.core import fix_inputs
+except ImportError:
+    HAS_FIX_INPUTS = False
 
 
 __all__ = ['WCS']
@@ -617,6 +625,8 @@ class WCS(GWCSAPIMixin):
             ("x", "y")
 
         """
+        if not HAS_FIX_INPUTS:
+            raise ImportError('"fix_inputs" needs astropy version >= 4.0.')
         keys = fixed.keys()
         new_pipeline = []
         step0 = self.pipeline[0]


### PR DESCRIPTION
Note: This requires astropy master, so the Travis dev test should be passing while the others are expected to fail.

This PR introduces a new method `WCS.fix_inputs` which given a complex WCS where transforms are parametrized by non-coordinate inputs, returns a unique WCS for a specific value of the non-coordinate input. An example is a combined WCS which represents the WCS object for three spectral orders and is called normally by something like `WCS(x, y, spectral_order=3)`. To generate a simpler WCS object matching the transforms for spectral_order 3, one would call
```
wcsobj3 = wcsobj.fix_inputs({'spectral_order': 3})
ra, dec, lam = wcsobj3(x, y)
```

This can be useful for applications, like visualization tools which need to work with one WCS object at a time and can only specify x,y coordinates.
@Cadair I wonder if this can be useful to you too.

TODO: write an example in the documentation