### PR TITLE
fix installation problem

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ def get_package_data():
     return schemas
 
 schemas = get_package_data()
-PACKAGE_DATA ={'jwst':schemas}
+PACKAGE_DATA ={'gwcs':schemas}
 
 entry_points = {'asdf_extensions': 'gwcs = gwcs.extension:GWCSExtension',
                  'bandit.formatters': 'bson = bandit_bson:formatter'}


### PR DESCRIPTION
This fixes a typo which led to a pretty severe installation problem where schemas were not installed properly. This problem does not affect jwst master because the hashes we use are pinned to an earlier version. However, I would expect the regression tests on Jenkins unstable which use gwcs master to fail and they did not.
@jdavies-st 