### PR TITLE
add grating equation models

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,8 +52,8 @@ matrix:
         # may run for a long time
         - python: 3.6
 
-          env: PIP_DEPENDENCIES="$ASTROPY_GIT $ASDF_GIT sphinx sphinx-automodapi sphinx-rtd-theme stsci-rtd-theme sphinx-astropy -sphinx-asdf"
-               # PIP_DEPENDENCIES=".[docs]""
+          env: #PIP_DEPENDENCIES="$ASTROPY_GIT $ASDF_GIT sphinx sphinx-automodapi sphinx-rtd-theme stsci-rtd-theme sphinx-astropy -sphinx-asdf"
+               PIP_DEPENDENCIES=".[docs]""
                TEST_COMMAND="make --directory=docs html"
 
         - python: 3.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,7 @@ matrix:
         - python: 3.6
 
           env: #PIP_DEPENDENCIES="$ASTROPY_GIT $ASDF_GIT sphinx sphinx-automodapi sphinx-rtd-theme stsci-rtd-theme sphinx-astropy -sphinx-asdf"
-               PIP_DEPENDENCIES=".[docs]""
+               PIP_DEPENDENCIES=".[docs]"
                TEST_COMMAND="make --directory=docs html"
 
         - python: 3.6

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,8 @@ New Features
 
 - Added two new transforms - ``ToDirectionCosines`` and ``FromDirectionCosines``. [#256]
 
+- Added new transforms ``WavelengthFromGratingEquation``, ``AnglesFromGratingEquation3D``. [#259]
+
 API Changes
 ^^^^^^^^^^^
 

--- a/gwcs/spectroscopy.py
+++ b/gwcs/spectroscopy.py
@@ -5,9 +5,15 @@ Spectroscopy related models.
 
 import numpy as np
 from astropy.modeling.core import Model
+from astropy.modeling.parameters import Parameter
+import astropy.units as u
 
 
-__all__ = ['ToDirectionCosines', 'FromDirectionCosines']
+__all__ = ['ToDirectionCosines', 'FromDirectionCosines',
+           'WavelengthFromGratingEquation', 'AnglesFromGratingEquation3D']
+
+
+__doctest_skip__ = ['AnglesFromGratingEquation3D', 'WavelengthFromGratingEquation']
 
 
 class ToDirectionCosines(Model):
@@ -55,3 +61,134 @@ class FromDirectionCosines(Model):
 
     def inverse(self):
         return ToDirectionCosines()
+
+
+class WavelengthFromGratingEquation(Model):
+    r""" Solve the Grating Dispersion Law for the wavelength.
+
+    .. Note:: This form of the equation can be used for paraxial
+    (small angle approximation) as well as oblique incident angles.
+    With paraxial systems the inputs are sin of the angles and it
+    transforms to :math:`\sin(alpha_in) + \sin(alpha_out) / m * d` .
+    With oblique angles the inputs are the direction cosines of the
+    angles.
+
+    Parameters
+    ----------
+    groove_density : int
+        Grating ruling density in units of 1/length.
+    spectral_order : int
+        Spectral order.
+
+    Examples
+    --------
+    >>> from astropy.modeling.models import math
+    >>> model = WavelengthFromGratingEquation(groove_density=20000*1/u.m, spectral_order=-1)
+    >>> alpha_in = (math.Deg2radUfunc() | math.SinUfunc())(.0001 * u.deg)
+    >>> alpha_out = (math.Deg2radUfunc() | math.SinUfunc())(.0001 * u.deg)
+    >>> lam = model(alpha_in, alpha_out)
+    >>> print(lam)
+    -1.7453292519934437e-10 m
+
+    """
+
+    _separable = False
+
+    linear = False
+
+    n_inputs = 2
+    n_outputs = 1
+
+    groove_density = Parameter(default=1)
+    """ Grating ruling density in units of 1/m."""
+    spectral_order = Parameter(default=1)
+    """ Spectral order."""
+
+    def __init__(self, groove_density, spectral_order, **kwargs):
+        super().__init__(groove_density=groove_density,
+                         spectral_order=spectral_order, **kwargs)
+        self.inputs = ("alpha_in", "alpha_out")
+        """ Sine function of the angles or the direction cosines."""
+        self.outputs = ("wavelength",)
+        """ Wavelength."""
+
+    def evaluate(self, alpha_in, alpha_out, groove_density, spectral_order):
+        return (alpha_in + alpha_out) / (groove_density * spectral_order)
+
+    @property
+    def return_units(self):
+        if self.groove_density.unit is None:
+            return None
+        else:
+            return {'wavelength': u.Unit(1 / self.groove_density.unit)}
+
+
+class AnglesFromGratingEquation3D(Model):
+    """
+    Solve the 3D Grating Dispersion Law in Direction Cosine
+    space for the refracted angle.
+
+    Parameters
+    ----------
+    groove_density : int
+        Grating ruling density in units of 1/m.
+    order : int
+        Spectral order.
+
+    Examples
+    --------
+    >>> from astropy.modeling.models import math
+    >>> model = AnglesFromGratingEquation3D(groove_density=20000*1/u.m, spectral_order=-1)
+    >>> alpha_in = (math.Deg2radUfunc() | math.SinUfunc())(.0001 * u.deg)
+    >>> beta_in = (math.Deg2radUfunc() | math.SinUfunc())(.0001 * u.deg)
+    >>> lam = 2e-6 * u.m
+    >>> alpha_out, beta_out, gamma_out = model(lam, alpha_in, beta_in)
+    >>> print(alpha_out, beta_out, gamma_out)
+    0.04000174532925199 -1.7453292519934436e-06 0.9991996098716049
+
+    """
+
+    _separable = False
+
+    linear = False
+
+    n_inputs = 3
+    n_outputs = 3
+
+    groove_density = Parameter(default=1)
+    """ Grating ruling density in units 1/ length."""
+
+    spectral_order = Parameter(default=1)
+    """ Spectral order."""
+
+    def __init__(self, groove_density, spectral_order, **kwargs):
+        super().__init__(groove_density=groove_density,
+                         spectral_order=spectral_order, **kwargs)
+        self.inputs = ("wavelength", "alpha_in", "beta_in")
+        """ Wavelength and 2 angle coordinates going into the grating."""
+
+        self.outputs = ("alpha_out", "beta_out", "gamma_out")
+        """ Two angles coming out of the grating. """
+
+    def evaluate(self, wavelength, alpha_in, beta_in,
+                 groove_density, spectral_order):
+        if alpha_in.shape != beta_in.shape:
+            raise ValueError("Expected input arrays to have the same shape.")
+
+        if isinstance(groove_density, u.Quantity):
+            alpha_in = u.Quantity(alpha_in)
+            beta_in = u.Quantity(beta_in)
+
+        alpha_out = -groove_density * spectral_order * wavelength + alpha_in
+        beta_out = - beta_in
+        gamma_out = np.sqrt(1 - alpha_out ** 2 - beta_out ** 2)
+        return alpha_out, beta_out, gamma_out
+
+    @property
+    def input_units(self):
+        if self.groove_density.unit is None:
+            return None
+        else:
+            return {'wavelength': 1 / self.groove_density.unit,
+                    'alpha_in': u.Unit(1),
+                    'beta_in': u.Unit(1)}

--- a/gwcs/tests/test_spectroscopy_models.py
+++ b/gwcs/tests/test_spectroscopy_models.py
@@ -1,0 +1,49 @@
+import astropy.units as u
+import numpy as np
+from numpy.testing import assert_allclose
+from .. import spectroscopy as sp# noqa
+
+
+def test_angles_grating_equation():
+    """ Test agaibst the Nispec implementation."""
+    lam = np.array([2e-6] * 4)
+    alpha_in = np.linspace(.01, .05, 4)
+
+    model = sp.AnglesFromGratingEquation3D(20000, -1)
+
+    # Eq. from Nirspec model.
+    xout = -alpha_in - (model.groove_density * model.spectral_order * lam)
+
+    alpha_out, beta_out, gamma_out = model(lam, -alpha_in, alpha_in)
+    assert_allclose(alpha_out, xout)
+    assert_allclose(beta_out, -alpha_in)
+    assert_allclose(gamma_out, np.sqrt(1 -  alpha_out**2 - beta_out**2))
+
+    # Now with units
+    model = sp.AnglesFromGratingEquation3D(20000 * 1/u.m, -1)
+
+    # Eq. from Nirspec model.
+    xout = -alpha_in - (model.groove_density * model.spectral_order * lam * u.m)
+
+    alpha_out, beta_out, gamma_out = model(lam * u.m, -u.Quantity(alpha_in), u.Quantity(alpha_in))
+    assert_allclose(alpha_out, xout)
+    assert_allclose(beta_out, -alpha_in)
+    assert_allclose(gamma_out, np.sqrt(1 -  alpha_out**2 - beta_out**2))
+
+
+def test_wavelength_grating_equation_units():
+    alpha_in = np.linspace(.01, .05, 4)
+
+    model = sp.WavelengthFromGratingEquation(20000, -1)
+    # Eq. from Nirspec model.
+    wave = -(alpha_in + alpha_in) / (20000 * -1)
+    result = model(-alpha_in, -alpha_in)
+    assert_allclose(result, wave)
+
+    # Now with units
+    model = sp.WavelengthFromGratingEquation(20000 * 1/u.m, -1)
+    # Eq. from Nirspec model.
+    wave = -(u.Quantity(alpha_in) + u.Quantity(alpha_in)) / (20000 * 1/u.m * -1)
+
+    result = model(-u.Quantity(alpha_in), -u.Quantity(alpha_in))
+    assert_allclose(result, wave)

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ schemas = get_package_data()
 PACKAGE_DATA ={'gwcs':schemas}
 
 entry_points = {'asdf_extensions': 'gwcs = gwcs.extension:GWCSExtension',
-                 'bandit.formatters': 'bson = bandit_bson:formatter'}
+                'bandit.formatters': 'bson = bandit_bson:formatter'}
 
 DOCS_REQUIRE = [
     #'matplotlib',
@@ -59,8 +59,8 @@ DOCS_REQUIRE = [
 TESTS_REQUIRE = [
     'pytest',
     'pytest-doctestplus',
-    'pytest-astropy',
-    'scipy'
+    #'pytest-astropy<=0.7',
+    'scipy',
 ]
 
 setup(name=PACKAGENAME,


### PR DESCRIPTION
This pull request implements the grating equation in two models - one solves it for the wavelength and one for the angle (in 3D form).
In this form the implementation is valid for small and oblique angles. When used with small angles
sine of the angles should be passed in as inputs. When used with oblique angles the inputs are the direction cosines. In its second form it is used in the Nirspec WCS pipeline.

The best reference I can find for this implementation is
"Description of Diffraction Grating Behavior in Direction Cosine Space" by James E. Harvey and Cynthia L. Vernold in Applied Optics, Vol. 73, Issue 9, pp. 1105-1112 (1983), linked below, though I'm not sure it's visible by everyone. I need to use it in cosine space.

https://www.osapublishing.org/ao/fulltext.cfm?uri=ao-37-34-8158&id=170236