### PR TITLE
Improve world(pixel)_n_dim computation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,8 @@ matrix:
         # may run for a long time
         - python: 3.6
 
-          env: PIP_DEPENDENCIES="$ASTROPY_GIT $ASDF_GIT .[docs]"
+          env: PIP_DEPENDENCIES="$ASTROPY_GIT $ASDF_GIT sphinx sphinx-automodapi sphinx-rtd-theme stsci-rtd-theme sphinx-astropy -sphinx-asdf"
+               # PIP_DEPENDENCIES=".[docs]""
                TEST_COMMAND="make --directory=docs html"
 
         - python: 3.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ addons:
 python:
   - 3.6
   - 3.7
-  
+
 env:
     global:
         # The following versions are the 'default' for tests, unless
@@ -52,7 +52,7 @@ matrix:
         # may run for a long time
         - python: 3.6
 
-          env: PIP_DEPENDENCIES='.[docs]'
+          env: PIP_DEPENDENCIES="$ASTROPY_GIT $ASDF_GIT .[docs]"
                TEST_COMMAND="make --directory=docs html"
 
         - python: 3.6
@@ -71,7 +71,7 @@ matrix:
         - python: 3.6
           env:
             - TEST_COMMAND="flake8 gwcs --count --select=F, E101, E111, E112, E113, E401, E402, E711, E722, E30 --max-line-length=110"
-            - PIP_DEPENDENCIES="flake8" 
+            - PIP_DEPENDENCIES="flake8"
 
         - python: 3.6
           env:

--- a/gwcs/api.py
+++ b/gwcs/api.py
@@ -27,6 +27,8 @@ class GWCSAPIMixin(BaseHighLevelWCS, BaseLowLevelWCS):
         """
         The number of axes in the pixel coordinate system.
         """
+        if self.input_frame is None:
+            return self.forward_transform.n_inputs
         return self.input_frame.naxes
 
     @property
@@ -34,6 +36,8 @@ class GWCSAPIMixin(BaseHighLevelWCS, BaseLowLevelWCS):
         """
         The number of axes in the world coordinate system.
         """
+        if self.output_frame is None:
+            return self.forward_transform.n_outputs
         return self.output_frame.naxes
 
     @property

--- a/gwcs/tests/conftest.py
+++ b/gwcs/tests/conftest.py
@@ -178,6 +178,14 @@ def gwcs_3spectral_orders():
                                 unit=(u.pix, u.pix))
     m = model_2d_shift & model_1d_scale
 
-
     return wcs.WCS([(detector_frame, m),
                     (comp1, None)])
+
+
+@pytest.fixture
+def gwcs_with_frames_strings():
+    transform = models.Shift(1) & models.Shift(1) & models.Polynomial2D(1)
+    pipe = [('detector', transform),
+            ('world', None)
+           ]
+    return wcs.WCS(pipe)

--- a/gwcs/tests/test_api.py
+++ b/gwcs/tests/test_api.py
@@ -381,3 +381,9 @@ def test_world_to_array_index_values(gwcs_2d_spatial_shift, sky_ra_dec):
 
     assert_allclose(wcsobj.world_to_array_index_values(sky),
                     wcsobj.invert(ra, dec, with_units=False)[::-1])
+
+
+def test_ndim_str_frames(gwcs_with_frames_strings):
+    wcsobj = gwcs_with_frames_strings
+    assert wcsobj.pixel_n_dim == 4
+    assert wcsobj.world_n_dim == 3


### PR DESCRIPTION
It's possible to create a `gwcs` object with frames of type  `str`. This is really useful only for interactive testing. In this case all WCS APE methods which use `world_n_dim` or `pixel_n_dim` will fail. This PR introspects the transform to return the dimensions.

@Cadair Could you please review (I can't set you as a reviewer formally.) This addresses the concerns raised [here](https://github.com/spacetelescope/gwcs/pull/260/files#r353998031).