### PR TITLE
Add Snell and Sellmeier transforms

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,8 @@ New Features
 - Update the ``StokesFrame`` to work for arrays of coordinates and integrate
   with APE 14. [#258]
 
+- Added ``Snell3D``, ``SellmeierGlass`` and ``SellmeierZemax`` transforms. [#269]
+
 API Changes
 ^^^^^^^^^^^
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,7 +22,7 @@ New Features
 - Update the ``StokesFrame`` to work for arrays of coordinates and integrate
   with APE 14. [#258]
 
-- Added ``Snell3D``, ``SellmeierGlass`` and ``SellmeierZemax`` transforms. [#269]
+- Added ``Snell3D``, ``SellmeierGlass`` and ``SellmeierZemax`` transforms. [#270]
 
 API Changes
 ^^^^^^^^^^^

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -332,4 +332,4 @@ Reference/API
 .. automodapi:: gwcs.coordinate_frames
 .. automodapi:: gwcs.wcstools
 .. automodapi:: gwcs.selector
-
+.. automodapi:: gwcs.spectroscopy

--- a/gwcs/schemas/stsci.edu/gwcs/sellmeier_glass-1.0.0.yaml
+++ b/gwcs/schemas/stsci.edu/gwcs/sellmeier_glass-1.0.0.yaml
@@ -1,0 +1,38 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://stsci.edu/schemas/gwcs/sellmeier_glass-1.0.0"
+tag: "tag:stsci.edu:gwcs/sellmeier_glass-1.0.0"
+title: Sellmeier equation for glass
+
+description: |
+  Sellmeier equation for glass.
+
+  $$ n(\\lambda)^2 = 1 + \\frac{(B1 * \\lambda^2 )}{(\\lambda^2 - C1)} +
+     \\frac{(B2 * \\lambda^2 )}{(\\lambda^2 - C2)} +
+     \\frac{(B3 * \\lambda^2 )}{(\\lambda^2 - C3)} $$
+
+allOf:
+  - $ref: "tag:stsci.edu:asdf/transform/transform-1.1.0"
+  - type: object
+    properties:
+      B_coef:
+        description: |
+          B coefficients in Sellmeier equation.
+        anyOf:
+          - type: array
+          - $ref: "tag:stsci.edu:asdf/core/ndarray-1.0.0"
+        items:
+          type: number
+        minItems: 3
+        maxItems: 3
+      C_coef:
+        description: |
+          C coefficients in Sellmeier equation.
+        anyOf:
+          - type: array
+          - $ref: "tag:stsci.edu:asdf/core/ndarray-1.0.0"
+        items:
+          type: number
+        minItems: 3
+        maxItems: 3

--- a/gwcs/schemas/stsci.edu/gwcs/sellmeier_zemax-1.0.0.yaml
+++ b/gwcs/schemas/stsci.edu/gwcs/sellmeier_zemax-1.0.0.yaml
@@ -1,0 +1,72 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://stsci.edu/schemas/gwcs/sellmeier_zemax-1.0.0"
+tag: "tag:stsci.edu:gwcs/sellmeier_zemax-1.0.0"
+title: Sellmeier equation for glass used by Zemax
+
+description: |
+  Sellmeier equation for glass used by Zemax
+
+allOf:
+  - $ref: "tag:stsci.edu:asdf/transform/transform-1.1.0"
+  - type: object
+    properties:
+      B_coef:
+        description: |
+          B coefficients in Sellmeier equation.
+        anyOf:
+          - type: array
+          - $ref: "tag:stsci.edu:asdf/core/ndarray-1.0.0"
+        items:
+          type: number
+        minItems: 3
+        maxItems: 3
+      C_coef:
+        description: |
+          C coefficients in Sellmeier equation.
+        anyOf:
+          - type: array
+          - $ref: "tag:stsci.edu:asdf/core/ndarray-1.0.0"
+        items:
+          type: number
+        minItems: 3
+        maxItems: 3
+      D_coef:
+        description: |
+          Thermal D coefficients of the glass.
+        anyOf:
+          - type: array
+          - $ref: "tag:stsci.edu:asdf/core/ndarray-1.0.0"
+        items:
+          type: number
+        minItems: 3
+        maxItems: 3
+      E_coef:
+        description: |
+          Thermal E coefficients of the glass.
+        anyOf:
+          - type: array
+          - $ref: "tag:stsci.edu:asdf/core/ndarray-1.0.0"
+        items:
+          type: number
+        minItems: 3
+        maxItems: 3
+      ref_temperature:
+        description: |
+          Reference temperature of the glass in Kelvin.
+        type: number
+      ref_pressure:
+        description: |
+          Reference pressure of the glass in ATM.
+        type: number
+      temperature:
+        description: |
+          System temperature in Kelvin.
+        type: number
+      pressure:
+        description: |
+          System pressure in ATM.
+        type: number
+    required: [B_coef, C_coef, D_coef, E_coef, ref_temperature,
+               ref_pressure, temperature, pressure]

--- a/gwcs/schemas/stsci.edu/gwcs/snell3d-1.0.0.yaml
+++ b/gwcs/schemas/stsci.edu/gwcs/snell3d-1.0.0.yaml
@@ -1,0 +1,23 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://stsci.edu/schemas/gwcs/snell3d-1.0.0"
+tag: "tag:stsci.edu:gwcs/snell3d-1.0.0"
+title: Snell Law in 3D space
+
+description: |
+  Snell Law in 3D - inputs and outputs are direction cosines.
+
+allOf:
+  - $ref: "tag:stsci.edu:asdf/transform/transform-1.1.0"
+  - type: object
+    properties:
+      refraction_index:
+        description: |
+          The refraction index of the prism.
+        type: number
+    required: [refraction_index]
+<<<<<<< HEAD
+=======
+    
+>>>>>>> 55a3ad1... add Snell3D and Sellmeier equations

--- a/gwcs/schemas/stsci.edu/gwcs/snell3d-1.0.0.yaml
+++ b/gwcs/schemas/stsci.edu/gwcs/snell3d-1.0.0.yaml
@@ -12,8 +12,8 @@ allOf:
   - $ref: "tag:stsci.edu:asdf/transform/transform-1.1.0"
   - type: object
     properties:
-      refraction_index:
+      refractive_index:
         description: |
-          The refraction index of the prism.
+          Index of refraction.
         type: number
-    required: [refraction_index]
+    required: [refractive_index]

--- a/gwcs/schemas/stsci.edu/gwcs/snell3d-1.0.0.yaml
+++ b/gwcs/schemas/stsci.edu/gwcs/snell3d-1.0.0.yaml
@@ -8,12 +8,4 @@ title: Snell Law in 3D space
 description: |
   Snell Law in 3D - inputs and outputs are direction cosines.
 
-allOf:
-  - $ref: "tag:stsci.edu:asdf/transform/transform-1.1.0"
-  - type: object
-    properties:
-      refractive_index:
-        description: |
-          Index of refraction.
-        type: number
-    required: [refractive_index]
+$ref: "tag:stsci.edu:asdf/transform/transform-1.1.0"

--- a/gwcs/schemas/stsci.edu/gwcs/snell3d-1.0.0.yaml
+++ b/gwcs/schemas/stsci.edu/gwcs/snell3d-1.0.0.yaml
@@ -6,6 +6,8 @@ tag: "tag:stsci.edu:gwcs/snell3d-1.0.0"
 title: Snell Law in 3D space
 
 description: |
-  Snell Law in 3D - inputs and outputs are direction cosines.
+  Snell Law in 3D.
+  Inputs are index of refraction and direction cosines.
+  Outputs are direction cosines.
 
 $ref: "tag:stsci.edu:asdf/transform/transform-1.1.0"

--- a/gwcs/schemas/stsci.edu/gwcs/snell3d-1.0.0.yaml
+++ b/gwcs/schemas/stsci.edu/gwcs/snell3d-1.0.0.yaml
@@ -17,7 +17,3 @@ allOf:
           The refraction index of the prism.
         type: number
     required: [refraction_index]
-<<<<<<< HEAD
-=======
-    
->>>>>>> 55a3ad1... add Snell3D and Sellmeier equations

--- a/gwcs/spectroscopy.py
+++ b/gwcs/spectroscopy.py
@@ -5,17 +5,25 @@ Spectroscopy related models.
 
 import numpy as np
 from astropy.modeling.core import Model
+<<<<<<< HEAD
 from astropy.modeling.parameters import Parameter
+=======
+from astropy.modeling.parameters import Parameter, InputParameterError
+>>>>>>> 9137125... add grating equation models
 import astropy.units as u
 
 
 __all__ = ['ToDirectionCosines', 'FromDirectionCosines',
-           'WavelengthFromGratingEquation', 'AnglesFromGratingEquation3D']
+           'WavelengthFromGratingEquation', 'AnglesFromGratingEquation3D',
+           'Snell3D', 'SellmeierGlass', 'SellmeierZemax']
 
 
+<<<<<<< HEAD
 __doctest_skip__ = ['AnglesFromGratingEquation3D', 'WavelengthFromGratingEquation']
 
 
+=======
+>>>>>>> 9137125... add grating equation models
 class ToDirectionCosines(Model):
     """
     Transform a vector to direction cosines.
@@ -67,11 +75,15 @@ class WavelengthFromGratingEquation(Model):
     r""" Solve the Grating Dispersion Law for the wavelength.
 
     .. Note:: This form of the equation can be used for paraxial
-    (small angle approximation) as well as oblique incident angles.
-    With paraxial systems the inputs are sin of the angles and it
-    transforms to :math:`\sin(alpha_in) + \sin(alpha_out) / m * d` .
-    With oblique angles the inputs are the direction cosines of the
-    angles.
+      (small angle approximation) as well as oblique incident angles.
+      With paraxial systems the inputs are ``sin`` of the angles and it
+      transforms to
+
+      :math:`(\sin(alpha_in) + \sin(alpha_out)) / (m * d)`.
+
+      With oblique angles the inputs are the direction cosines
+      of the angles.
+
 
     Parameters
     ----------
@@ -149,7 +161,6 @@ class AnglesFromGratingEquation3D(Model):
     """
 
     _separable = False
-
     linear = False
 
     n_inputs = 3
@@ -192,3 +203,223 @@ class AnglesFromGratingEquation3D(Model):
             return {'wavelength': 1 / self.groove_density.unit,
                     'alpha_in': u.Unit(1),
                     'beta_in': u.Unit(1)}
+
+
+class Snell3D(Model):
+    """
+    Snell model in 3D form.
+
+    Inputs are direction cosines.
+
+    Parameters
+    ----------
+    n : float
+        Refraction index of the material.
+
+    Returns
+    -------
+    alpha_out, beta_out, gamma_out : float
+        Direction cosines.
+    """
+    _separable = False
+    linear = False
+
+    n_inputs = 3
+    n_outputs = 3
+
+    n = Parameter(default=1)
+
+    def __init__(self, n=n, **kwargs):
+        super().__init__(n=n, **kwargs)
+        self.inputs = ('alpha_in', 'beta_in', 'gamma_in')
+        self.outputs = ('alpha_out', 'beta_out', 'gamma_out')
+
+    @staticmethod
+    def evaluate(alpha_in, beta_in, gamma_in, n):
+        # Apply Snell's law through front surface,
+        # eq 5.3.3 II in Nirspec docs
+        xout = alpha_in / n
+        yout = beta_in / n
+        zout = np.sqrt(1.0 - xout**2 - yout**2)
+        return xout, yout, zout
+
+
+class SellmeierGlass(Model):
+    """
+    Sellmeier equation for glass.
+
+    Parameters
+    ----------
+    B_coef : ndarray
+        Iterable of size 3 containing B coefficients.
+    C_coef : ndarray
+        Iterable of size 3 containing c coefficients in
+        units of `u.um**2`.
+
+    Returns
+    -------
+    n : float
+        Refraction index.
+
+    Examples
+    --------
+    >>> import astropy.units as u
+    >>> b_coef = [0.58339748, 0.46085267, 3.8915394]
+    >>> c_coef = [0.00252643, 0.010078333, 1200.556] * u.um**2
+    >>> model = SellmeierGlass(b_coef, c_coef)
+    >>> model(2 * u.m)
+        <Quantity 2.43634758>
+
+    References
+    ----------
+    .. [1] https://en.wikipedia.org/wiki/Sellmeier_equation
+
+    Notes
+    -----
+
+    Model formula:
+
+        .. math::
+
+            n(\\lambda)^2 = 1 + \\frac{(B1 * \\lambda^2 )}{(\\lambda^2 - C1)} +
+            \\frac{(B2 * \\lambda^2 )}{(\\lambda^2 - C2)} +
+            \\frac{(B3 * \\lambda^2 )}{(\\lambda^2 - C3)}
+
+    """
+    _separable = False
+    standard_broadcasting = False
+    linear = False
+
+    n_inputs = 1
+    n_outputs = 1
+
+    B_coef = Parameter(default=np.array([1, 1, 1]))
+    """ B1, B2, B3 coefficients. """
+    C_coef = Parameter(default=np.array([0, 0, 0]))
+    """ C1, C2, C3 coefficients in units of um ** 2. """
+
+
+    def __init__(self, B_coef, C_coef, **kwargs):
+        super().__init__(B_coef, C_coef)
+        self.inputs = ('wavelength',)
+        self.outputs = ('n',)
+
+    @staticmethod
+    def evaluate(wavelength, B_coef, C_coef):
+        B1, B2, B3 = B_coef[0]
+        C1, C2, C3 = C_coef[0]
+
+        n = np.sqrt(1. +
+                    B1 * wavelength ** 2 / (wavelength ** 2 - C1) +
+                    B2 * wavelength ** 2 / (wavelength ** 2 - C2) +
+                    B3 * wavelength ** 2 / (wavelength ** 2 - C3)
+                    )
+        return n
+
+    @property
+    def input_units(self):
+        if self.C_coef.unit is None:
+            return None
+        else:
+            return {'wavelength': u.um}
+
+
+class SellmeierZemax(Model):
+    """
+    Sellmeier equation used by Zemax.
+
+    Parameters
+    ----------
+    temperature : float
+        Temperature of the material in `u.Kelvin`.
+    ref_temperature : float
+        Reference emperature of the glass in `u.Kelvin`.
+    ref_pressure : float
+        Reference pressure in ATM.
+    pressure : float
+        Measured pressure in ATM.
+    B_coef : ndarray
+        Iterable of size 3 containing B coefficients.
+    C_coef : ndarray
+        Iterable of size 3 containing C coefficients in
+        units of `u.um**2`.
+    D_coef : ndarray
+        Iterable of size 3 containing constants to describe the
+        behavior of the material.
+    E_coef : ndarray
+        Iterable of size 3 containing constants to describe the
+        behavior of the material.
+
+    Returns
+    -------
+    n : float
+        Refraction index.
+
+    """
+    _separable = False
+    standard_broadcasting = False
+    linear = False
+
+    n_inputs = 1
+    n_outputs = 1
+
+    temperature = Parameter(default=0)
+    ref_temperature = Parameter(default=0)
+    ref_pressure = Parameter(default=0)
+    pressure = Parameter(default=0)
+    B_coef = Parameter(default=[1, 1, 1])
+    C_coef = Parameter(default=[0, 0, 0])
+    D_coef = Parameter(default=[0, 0, 0])
+    E_coef = Parameter(default=[1, 1, 1])
+
+    def __init__(self, temperature=temperature, ref_temperature=ref_temperature,
+                 ref_pressure=ref_pressure, pressure=pressure, B_coef=B_coef,
+                 C_coef=C_coef, D_coef=D_coef, E_coef=E_coef, **kwargs):
+
+        super().__init__(temperature=temperature, ref_temperature=ref_temperature,
+                         ref_pressure=ref_pressure, pressure=pressure, B_coef=B_coef,
+                         C_coef=C_coef, D_coef=D_coef, E_coef=E_coef, **kwargs)
+        self.inputs = ('wavelength',)
+        self.outputs =('n',)
+
+    def evaluate(self, wavelength, temp, ref_temp, ref_pressure,
+                 pressure, B_coef, C_coef, D_coef, E_coef):
+        """
+        Input ``wavelength`` is in units of microns.
+        """
+        if isinstance(temp, u.Quantity):
+            temp = temp.to(u.Celsius)
+            ref_temp = ref_temp.to(u.Celsius)
+        else:
+            KtoC = 273.15  # kelvin to celcius conversion
+            temp -= KtoC
+            ref_temp -= KtoC
+        delt = temp - ref_temp
+        K1, K2, K3 = B_coef[0]
+        L1, L2, L3 = C_coef[0]
+        D0, D1, D2 = D_coef[0]
+        E0, E1, lam_tk = E_coef[0]
+
+        nref = 1. + (6432.8 + 2949810. * wavelength ** 2 /
+                    (146.0 * wavelength ** 2 - 1.) + (5540.0 * wavelength ** 2) /
+                    (41.0 * wavelength ** 2 - 1.)) * 1e-8
+        # T should be in C, P should be in ATM
+        nair_obs = 1.0 + ((nref - 1.0) * pressure) / (1.0 + (temp - 15.) * 3.4785e-3)
+        nair_ref = 1.0 + ((nref - 1.0) * ref_pressure) / (1.0 + (ref_temp - 15) * 3.4785e-3)
+
+        # Compute the relative index of the glass at Tref and Pref using Sellmeier equation I.
+        lamrel = wavelength * nair_obs / nair_ref
+        nrel = SellmeierGlass.evaluate(lamrel[0], B_coef, C_coef)
+        # Convert the relative index of refraction at the reference temperature and pressure
+        # to absolute.
+        nabs_ref = nrel * nair_ref
+
+        # Compute the absolute index of the glass
+        delnabs = (0.5 * (nrel ** 2 - 1.) / nrel) * \
+                    (D0 * delt + D1 * delt ** 2 + D2 * delt ** 3 + \
+                    (E0 * delt + E1 * delt ** 2) / (lamrel ** 2  - lam_tk ** 2))
+        nabs_obs = nabs_ref + delnabs
+
+        # Define the relative index at the system's operating T and P.
+        n = nabs_obs / nair_obs
+        return n

--- a/gwcs/spectroscopy.py
+++ b/gwcs/spectroscopy.py
@@ -14,9 +14,6 @@ __all__ = ['ToDirectionCosines', 'FromDirectionCosines',
            'Snell3D', 'SellmeierGlass', 'SellmeierZemax']
 
 
-#__doctest_skip__ = ['AnglesFromGratingEquation3D', 'WavelengthFromGratingEquation']
-
-
 class ToDirectionCosines(Model):
     """
     Transform a vector to direction cosines.
@@ -72,7 +69,7 @@ class WavelengthFromGratingEquation(Model):
       With paraxial systems the inputs are ``sin`` of the angles and it
       transforms to
 
-      :math:`(\sin(alpha_in) + \sin(alpha_out)) / (m * d)`.
+      :math:`(\sin(alpha_in) + \sin(alpha_out)) / (groove_density * spectral_order)`.
 
       With oblique angles the inputs are the direction cosines
       of the angles.
@@ -204,11 +201,6 @@ class Snell3D(Model):
 
     Inputs are direction cosines.
 
-    Parameters
-    ----------
-    n : float
-        Refractive index of the material.
-
     Returns
     -------
     alpha_out, beta_out, gamma_out : float
@@ -217,18 +209,16 @@ class Snell3D(Model):
     _separable = False
     linear = False
 
-    n_inputs = 3
+    n_inputs = 4
     n_outputs = 3
 
-    n = Parameter(default=1)
-
-    def __init__(self, n=n, **kwargs):
-        super().__init__(n=n, **kwargs)
-        self.inputs = ('alpha_in', 'beta_in', 'gamma_in')
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.inputs = ('n', 'alpha_in', 'beta_in', 'gamma_in')
         self.outputs = ('alpha_out', 'beta_out', 'gamma_out')
 
     @staticmethod
-    def evaluate(alpha_in, beta_in, gamma_in, n):
+    def evaluate(n, alpha_in, beta_in, gamma_in):
         # Apply Snell's law through front surface,
         # eq 5.3.3 II in Nirspec docs
         xout = alpha_in / n

--- a/gwcs/spectroscopy.py
+++ b/gwcs/spectroscopy.py
@@ -199,7 +199,7 @@ class Snell3D(Model):
     """
     Snell model in 3D form.
 
-    Inputs are direction cosines.
+    Inputs are index of refraction and direction cosines.
 
     Returns
     -------
@@ -221,10 +221,10 @@ class Snell3D(Model):
     def evaluate(n, alpha_in, beta_in, gamma_in):
         # Apply Snell's law through front surface,
         # eq 5.3.3 II in Nirspec docs
-        xout = alpha_in / n
-        yout = beta_in / n
-        zout = np.sqrt(1.0 - xout**2 - yout**2)
-        return xout, yout, zout
+        alpha_out = alpha_in / n
+        beta_out = beta_in / n
+        gamma_out = np.sqrt(1.0 - xout**2 - yout**2)
+        return alpha_out, beta_out, gamma_out
 
 
 class SellmeierGlass(Model):

--- a/gwcs/spectroscopy.py
+++ b/gwcs/spectroscopy.py
@@ -14,7 +14,7 @@ __all__ = ['ToDirectionCosines', 'FromDirectionCosines',
            'Snell3D', 'SellmeierGlass', 'SellmeierZemax']
 
 
-__doctest_skip__ = ['AnglesFromGratingEquation3D', 'WavelengthFromGratingEquation']
+#__doctest_skip__ = ['AnglesFromGratingEquation3D', 'WavelengthFromGratingEquation']
 
 
 class ToDirectionCosines(Model):

--- a/gwcs/spectroscopy.py
+++ b/gwcs/spectroscopy.py
@@ -223,7 +223,7 @@ class Snell3D(Model):
         # eq 5.3.3 II in Nirspec docs
         alpha_out = alpha_in / n
         beta_out = beta_in / n
-        gamma_out = np.sqrt(1.0 - xout**2 - yout**2)
+        gamma_out = np.sqrt(1.0 - alpha_out**2 - beta_out**2)
         return alpha_out, beta_out, gamma_out
 
 

--- a/gwcs/spectroscopy.py
+++ b/gwcs/spectroscopy.py
@@ -207,7 +207,7 @@ class Snell3D(Model):
     Parameters
     ----------
     n : float
-        Refraction index of the material.
+        Refractive index of the material.
 
     Returns
     -------
@@ -252,7 +252,7 @@ class SellmeierGlass(Model):
     Returns
     -------
     n : float
-        Refraction index.
+        Refractive index.
 
     Examples
     --------
@@ -346,7 +346,7 @@ class SellmeierZemax(Model):
     Returns
     -------
     n : float
-        Refraction index.
+        Refractive index.
 
     """
     _separable = False

--- a/gwcs/spectroscopy.py
+++ b/gwcs/spectroscopy.py
@@ -5,11 +5,7 @@ Spectroscopy related models.
 
 import numpy as np
 from astropy.modeling.core import Model
-<<<<<<< HEAD
-from astropy.modeling.parameters import Parameter
-=======
 from astropy.modeling.parameters import Parameter, InputParameterError
->>>>>>> 9137125... add grating equation models
 import astropy.units as u
 
 
@@ -18,12 +14,9 @@ __all__ = ['ToDirectionCosines', 'FromDirectionCosines',
            'Snell3D', 'SellmeierGlass', 'SellmeierZemax']
 
 
-<<<<<<< HEAD
 __doctest_skip__ = ['AnglesFromGratingEquation3D', 'WavelengthFromGratingEquation']
 
 
-=======
->>>>>>> 9137125... add grating equation models
 class ToDirectionCosines(Model):
     """
     Transform a vector to direction cosines.

--- a/gwcs/spectroscopy.py
+++ b/gwcs/spectroscopy.py
@@ -5,7 +5,7 @@ Spectroscopy related models.
 
 import numpy as np
 from astropy.modeling.core import Model
-from astropy.modeling.parameters import Parameter, InputParameterError
+from astropy.modeling.parameters import Parameter
 import astropy.units as u
 
 

--- a/gwcs/tags/__init__.py
+++ b/gwcs/tags/__init__.py
@@ -1,5 +1,13 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 # -*- coding: utf-8 -*-
-
+from astropy import units as u
 from .wcs import *
 from .selectortags import *
+
+
+def _parameter_to_value(param):
+    if param.unit is not None:
+        return u.Quantity(param)
+    else:
+        return param.value
+        

--- a/gwcs/tags/spectroscopy_models.py
+++ b/gwcs/tags/spectroscopy_models.py
@@ -89,9 +89,9 @@ class Snell3DType(GWCSTransformType):
 
     @classmethod
     def from_tree_transform(cls, node, ctx):
-        return Snell3D(node['refraction_index'])
+        return Snell3D(node['refractive_index'])
 
     @classmethod
     def to_tree_transform(cls, model, ctx):
-        node = {'refraction_index': _parameter_to_value(model.n)}
+        node = {'refractive_index': _parameter_to_value(model.n)}
         return yamlutil.custom_tree_to_tagged_tree(node, ctx)

--- a/gwcs/tags/spectroscopy_models.py
+++ b/gwcs/tags/spectroscopy_models.py
@@ -7,9 +7,11 @@ from numpy.testing import assert_array_equal
 from asdf import yamlutil
 from ..gwcs_types import GWCSTransformType
 from .. spectroscopy import *
+from . import _parameter_to_value
 
 
-__all__ = ['DirectionCosinesType']
+__all__ = ['DirectionCosinesType', 'SellmeierGlassType',
+           'SellmeierZemaxType', 'Snell3D']
 
 
 class DirectionCosinesType(GWCSTransformType):
@@ -36,4 +38,60 @@ class DirectionCosinesType(GWCSTransformType):
         else:
             raise TypeError(f"Model of type {model.__class__} is not supported.")
         node = {'transform_type': transform_type}
+        return yamlutil.custom_tree_to_tagged_tree(node, ctx)
+
+
+class SellmeierGlassType(GWCSTransformType):
+    name = "sellmeier_glass"
+    types = [SellmeierGlass]
+    version = "1.0.0"
+
+    @classmethod
+    def from_tree_transform(cls, node, ctx):
+        return SellmeierGlass(node['B_coef'], node['C_coef'])
+
+    @classmethod
+    def to_tree_transform(cls, model, ctx):
+        node = {'B_coef': _parameter_to_value(model.B_coef),
+                'C_coef': _parameter_to_value(model.C_coef)}
+        return yamlutil.custom_tree_to_tagged_tree(node, ctx)
+
+
+class SellmeierZemaxType(GWCSTransformType):
+    name = "sellmeier_zemax"
+    types = [SellmeierZemax]
+    version = "1.0.0"
+
+    @classmethod
+    def from_tree_transform(cls, node, ctx):
+        return SellmeierZemax(node['temperature'], node['ref_temperature'],
+                              node['ref_pressure'], node['pressure'],
+                              node['B_coef'], node['C_coef'], node['D_coef'],
+                              node['E_coef'])
+
+    @classmethod
+    def to_tree_transform(cls, model, ctx):
+        node = {'B_coef': _parameter_to_value(model.B_coef),
+                'C_coef': _parameter_to_value(model.C_coef),
+                'D_coef': _parameter_to_value(model.D_coef),
+                'E_coef': _parameter_to_value(model.E_coef),
+                'temperature': _parameter_to_value(model.temperature),
+                'ref_temperature': _parameter_to_value(model.ref_temperature),
+                'pressure': _parameter_to_value(model.pressure),
+                'ref_pressure': _parameter_to_value(model.ref_pressure)}
+        return yamlutil.custom_tree_to_tagged_tree(node, ctx)
+
+
+class Snell3DType(GWCSTransformType):
+    name = "snell3d"
+    types = [Snell3D]
+    version = "1.0.0"
+
+    @classmethod
+    def from_tree_transform(cls, node, ctx):
+        return Snell3D(node['refraction_index'])
+
+    @classmethod
+    def to_tree_transform(cls, model, ctx):
+        node = {'refraction_index': _parameter_to_value(model.n)}
         return yamlutil.custom_tree_to_tagged_tree(node, ctx)

--- a/gwcs/tags/spectroscopy_models.py
+++ b/gwcs/tags/spectroscopy_models.py
@@ -89,9 +89,8 @@ class Snell3DType(GWCSTransformType):
 
     @classmethod
     def from_tree_transform(cls, node, ctx):
-        return Snell3D(node['refractive_index'])
+        return Snell3D()
 
     @classmethod
     def to_tree_transform(cls, model, ctx):
-        node = {'refractive_index': _parameter_to_value(model.n)}
-        return yamlutil.custom_tree_to_tagged_tree(node, ctx)
+        return yamlutil.custom_tree_to_tagged_tree({}, ctx)

--- a/gwcs/tags/tests/test_spectroscopy.py
+++ b/gwcs/tags/tests/test_spectroscopy.py
@@ -3,17 +3,28 @@
 import pytest
 
 import numpy as np
+
+from astropy.modeling.models import Identity
 from asdf.tests import helpers
 
 from ... import spectroscopy
 
-transforms = [spectroscopy.ToDirectionCosines(),
-              spectroscopy.FromDirectionCosines(),
-              spectroscopy.Snell3D(1.45),
-              spectroscopy.SellmeierGlass(B_coef=[0.58339748, 0.46085267, 3.8915394],
-                                          C_coef=[0.00252643, 0.010078333, 1200.556]),
-              spectroscopy.SellmeierZemax(65, 35, 0, 0, [0.58339748, 0.46085267, 3.8915394],
-                                          [0.00252643, 0.010078333, 1200.556], [-2.66e-05, 0.0, 0.0]),
+
+sell_glass = spectroscopy.SellmeierGlass(B_coef=[0.58339748, 0.46085267, 3.8915394],
+                                         C_coef=[0.00252643, 0.010078333, 1200.556])
+sell_zemax = spectroscopy.SellmeierZemax(65, 35, 0, 0, [0.58339748, 0.46085267, 3.8915394],
+                                         [0.00252643, 0.010078333, 1200.556], [-2.66e-05, 0.0, 0.0])
+snell = spectroscopy.Snell3D()
+todircos = spectroscopy.ToDirectionCosines()
+fromdircos = spectroscopy.FromDirectionCosines()
+
+transforms = [todircos,
+              fromdircos,
+              snell,
+              sell_glass,
+              sell_zemax,
+              sell_zemax & todircos| snell & Identity(1) | fromdircos,
+              sell_glass & todircos | snell & Identity(1) | fromdircos,
               ]
 
 

--- a/gwcs/tags/tests/test_spectroscopy.py
+++ b/gwcs/tags/tests/test_spectroscopy.py
@@ -8,7 +8,12 @@ from asdf.tests import helpers
 from ... import spectroscopy
 
 transforms = [spectroscopy.ToDirectionCosines(),
-              spectroscopy.FromDirectionCosines()
+              spectroscopy.FromDirectionCosines(),
+              spectroscopy.Snell3D(1.45),
+              spectroscopy.SellmeierGlass(B_coef=[0.58339748, 0.46085267, 3.8915394],
+                                          C_coef=[0.00252643, 0.010078333, 1200.556]),
+              spectroscopy.SellmeierZemax(65, 35, 0, 0, [0.58339748, 0.46085267, 3.8915394],
+                                          [0.00252643, 0.010078333, 1200.556], [-2.66e-05, 0.0, 0.0]),
               ]
 
 

--- a/gwcs/tests/conftest.py
+++ b/gwcs/tests/conftest.py
@@ -11,6 +11,7 @@ from astropy.modeling import models
 from astropy.time import Time
 
 from .. import coordinate_frames as cf
+from .. import spectroscopy as sp
 from .. import wcs
 
 # frames
@@ -203,3 +204,21 @@ def gwcs_with_frames_strings():
             ('world', None)
            ]
     return wcs.WCS(pipe)
+
+
+@pytest.fixture
+def sellmeier_glass():
+    B_coef =  [0.58339748, 0.46085267, 3.8915394]
+    C_coef = [0.00252643, 0.010078333, 1200.556]
+    return sp.SellmeierGlass(B_coef, C_coef)
+
+
+@pytest.fixture
+def sellmeier_zemax():
+    B_coef =  [0.58339748, 0.46085267, 3.8915394]
+    C_coef = [0.00252643, 0.010078333, 1200.556]
+    D_coef = [-2.66e-05, 0.0, 0.0]
+    E_coef = [0., 0., 0.]
+    return sp.SellmeierZemax(65, 35, 0, 0, B_coef = B_coef,
+                             C_coef=C_coef, D_coef=D_coef,
+                             E_coef=E_coef)

--- a/gwcs/tests/test_spectroscopy_models.py
+++ b/gwcs/tests/test_spectroscopy_models.py
@@ -1,5 +1,6 @@
 import pytest
 import astropy.units as u
+from astropy.modeling.models import Identity
 import numpy as np
 from numpy.testing import assert_allclose
 from .. import spectroscopy as sp# noqa
@@ -55,35 +56,33 @@ def test_wavelength_grating_equation_units():
                           (2, 1.42575377),
                           (5, 1.40061966)
                           ])
-def test_SellmeierGlass(wavelength, n):
+def test_SellmeierGlass(wavelength, n, sellmeier_glass):
     """ Test from Nirspec team.
 
     Wavelength is in microns.
     """
-
-    B_coef =  [0.58339748, 0.46085267, 3.8915394]
-    C_coef = [0.00252643, 0.010078333, 1200.556]
-    model = sp.SellmeierGlass(B_coef, C_coef)
-    n_result = model(wavelength)
+    n_result = sellmeier_glass(wavelength)
     assert_allclose(n_result, n)
 
 
-def test_SellmeierZemax():
+def test_SellmeierZemax(sellmeier_zemax):
     """ The data for this test come from Nirspec."""
-    kcoef = [0.58339748, 0.46085267, 3.8915394]
-    lcoef = [0.00252643, 0.010078333, 1200.556]
-    D_coef = [-2.66e-05, 0.0, 0.0]
-    E_coef = [0., 0., 0.]
-    model = sp.SellmeierZemax(65, 35, 0, 0, B_coef = kcoef,
-                              C_coef=lcoef, D_coef=D_coef,
-                              E_coef=E_coef)
     n = 1.4254647475849418
-    assert_allclose(model(2), n)
+    assert_allclose(sellmeier_zemax(2), n)
 
 
-def test_Snell3D():
+def test_Snell3D(sellmeier_glass):
     """ Test from Nirspec."""
-    n = 1.4254647475849418
-    model = sp.Snell3D(n)
     expected = (0.07015255913513296, 0.07015255913513296, 0.9950664484814988)
-    assert_allclose(model(.1, .1, .1), expected)
+    model = sp.Snell3D()
+    n = 1.4254647475849418
+    assert_allclose(model(n, .1, .1, .9), expected)
+
+
+def test_snell_sellmeier_comboned(sellmeier_glass):
+    fromdircos = sp.FromDirectionCosines()
+    todircos = sp.ToDirectionCosines()
+    model = sellmeier_glass & todircos | sp.Snell3D() & Identity(1) | fromdircos
+
+    expected = (0.07013833805527926, 0.07013833805527926, 1.0050677723764139)
+    assert_allclose(model(2, .1, .1, .9), expected)

--- a/gwcs/tests/test_spectroscopy_models.py
+++ b/gwcs/tests/test_spectroscopy_models.py
@@ -1,3 +1,4 @@
+import pytest
 import astropy.units as u
 import numpy as np
 from numpy.testing import assert_allclose
@@ -47,3 +48,42 @@ def test_wavelength_grating_equation_units():
 
     result = model(-u.Quantity(alpha_in), -u.Quantity(alpha_in))
     assert_allclose(result, wave)
+
+
+@pytest.mark.parametrize(('wavelength', 'n'),
+                         [(1, 1.43079543),
+                          (2, 1.42575377),
+                          (5, 1.40061966)
+                          ])
+def test_SellmeierGlass(wavelength, n):
+    """ Test from Nirspec team.
+
+    Wavelength is in microns.
+    """
+
+    B_coef =  [0.58339748, 0.46085267, 3.8915394]
+    C_coef = [0.00252643, 0.010078333, 1200.556]
+    model = sp.SellmeierGlass(B_coef, C_coef)
+    n_result = model(wavelength)
+    assert_allclose(n_result, n)
+
+
+def test_SellmeierZemax():
+    """ The data for this test come from Nirspec."""
+    kcoef = [0.58339748, 0.46085267, 3.8915394]
+    lcoef = [0.00252643, 0.010078333, 1200.556]
+    D_coef = [-2.66e-05, 0.0, 0.0]
+    E_coef = [0., 0., 0.]
+    model = sp.SellmeierZemax(65, 35, 0, 0, B_coef = kcoef,
+                              C_coef=lcoef, D_coef=D_coef,
+                              E_coef=E_coef)
+    n = 1.4254647475849418
+    assert_allclose(model(2), n)
+
+
+def test_Snell3D():
+    """ Test from Nirspec."""
+    n = 1.4254647475849418
+    model = sp.Snell3D(n)
+    expected = (0.07015255913513296, 0.07015255913513296, 0.9950664484814988)
+    assert_allclose(model(.1, .1, .1), expected)


### PR DESCRIPTION
This PR adds transforms and schemas implementing the `Snell` law in 3D, the most common `Sellmeier` equation for glass and a `Sellmeier` equation used by Zemax. There's no public reference for the last one (the Zemax documentation is not public). It is taken from the JWST Nirspec documentation. This implementation of the `Snell` law takes as inputs and returns results as direction cosines. A more general `Snell` law can be implemented as needed, i.e. the one on the WCS papers.