### PR TITLE
Add Spherical<->Cartesian coordinate transformation models

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,10 @@
 0.12.1 (Unreleased)
-------------------
+-------------------
+New Features
+^^^^^^^^^^^^
+
+- Added two new transforms - ``SphericalToCartesian`` and ``CartesianToSpherical``. [#275]
+
 
 0.12.0 (2019-12-24)
 -------------------

--- a/gwcs/geometry.py
+++ b/gwcs/geometry.py
@@ -5,9 +5,10 @@ Spectroscopy related models.
 
 import numpy as np
 from astropy.modeling.core import Model
+from astropy import units as u
 
-
-__all__ = ['ToDirectionCosines', 'FromDirectionCosines']
+__all__ = ['ToDirectionCosines', 'FromDirectionCosines',
+           'SphericalToCartesian', 'CartesianToSpherical']
 
 
 class ToDirectionCosines(Model):
@@ -55,3 +56,86 @@ class FromDirectionCosines(Model):
 
     def inverse(self):
         return ToDirectionCosines()
+
+
+class SphericalToCartesian(Model):
+    """
+    Convert spherical coordinates on a unit sphere to cartesian coordinates.
+    Spherical coordinates, when not provided as ``Quantity``, are assumed
+    to be in degrees with ``phi`` being the *azimuthal* angle ``[0, 360)``
+    and ``theta`` being the *elevation* angle ``[-90, 90]``.
+
+    """
+    _separable = False
+
+    _input_units_strict = True
+    _input_units_allow_dimensionless = True
+
+    n_inputs = 2
+    n_outputs = 3
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.inputs = ('phi', 'theta')
+        self.outputs = ('x', 'y', 'z')
+
+    @staticmethod
+    def evaluate(phi, theta):
+        if isinstance(phi, u.Quantity) != isinstance(theta, u.Quantity):
+            raise TypeError("All arguments must be of the same type "
+                            "(i.e., quantity or not).")
+
+        phi = np.deg2rad(phi)
+        theta = np.deg2rad(theta)
+
+        cs = np.cos(theta)
+        x = cs * np.cos(phi)
+        y = cs * np.sin(phi)
+        z = np.sin(theta)
+
+        return x, y, z
+
+    def inverse(self):
+        return CartesianToSpherical()
+
+    @property
+    def input_units(self):
+        return {'phi': u.deg, 'theta': u.deg}
+
+
+class CartesianToSpherical(Model):
+    """
+    Convert cartesian coordinates to spherical coordinates on a unit sphere.
+    Spherical coordinates are assumed to be in degrees with ``phi`` being
+    the *azimuthal* angle ``[0, 360)`` and ``theta`` being the *elevation*
+    angle ``[-90, 90]``.
+
+    """
+    _separable = False
+
+    n_inputs = 3
+    n_outputs = 2
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.inputs = ('x', 'y', 'z')
+        self.outputs = ('phi', 'theta')
+
+    @staticmethod
+    def evaluate(x, y, z):
+        nquant = [isinstance(i, u.Quantity) for i in (x, y, z)].count(True)
+        if nquant in [1, 2]:
+            raise TypeError("All arguments must be of the same type "
+                            "(i.e., quantity or not).")
+
+        h = np.hypot(x, y)
+        phi = np.mod(
+            np.rad2deg(np.arctan2(y, x)),
+            360.0 * u.deg if nquant else 360.0
+        )
+        theta = np.rad2deg(np.arctan2(z, h))
+
+        return phi, theta
+
+    def inverse(self):
+        return SphericalToCartesian()

--- a/gwcs/schemas/stsci.edu/gwcs/spherical_cartesian-1.0.0.yaml
+++ b/gwcs/schemas/stsci.edu/gwcs/spherical_cartesian-1.0.0.yaml
@@ -1,0 +1,39 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://stsci.edu/schemas/gwcs/spherical_cartesian-1.0.0"
+tag: "tag:stsci.edu:gwcs/spherical_cartesian-1.0.0"
+
+title: >
+  Convert coordinates between spherical and Cartesian coordinates.
+
+description: |
+  This schema is for transforms which convert between spherical coordinates
+  (on the unit sphere) and Cartesian coordinates.
+
+examples:
+  -
+    - Convert spherical coordinates to Cartesian coordinates.
+
+    - |
+
+        !<tag:stsci.edu:gwcs/spherical_cartesian-1.0.0>
+          transform_type: spherical_to_cartesian
+
+  -
+    - Convert Cartesian coordinates to spherical coordinates.
+
+    - |
+        !<tag:stsci.edu:gwcs/spherical_cartesian-1.0.0>
+          transform_type: cartesian_to_spherical
+
+allOf:
+  - $ref:  "tag:stsci.edu:asdf/transform/transform-1.1.0"
+  - object:
+    properties:
+      transform_type:
+        description: |
+          The type of transform/class to initialize.
+        type: string
+        enum: [spherical_to_cartesian, cartesian_to_spherical]
+    required: [transform_type]

--- a/gwcs/tags/geometry_models.py
+++ b/gwcs/tags/geometry_models.py
@@ -3,10 +3,11 @@ ASDF tags for geometry related models.
 """
 from asdf import yamlutil
 from ..gwcs_types import GWCSTransformType
-from .. geometry import ToDirectionCosines, FromDirectionCosines
+from .. geometry import (ToDirectionCosines, FromDirectionCosines,
+                         SphericalToCartesian, CartesianToSpherical)
 
 
-__all__ = ['DirectionCosinesType']
+__all__ = ['DirectionCosinesType', 'SphericalCartesianType']
 
 
 class DirectionCosinesType(GWCSTransformType):
@@ -30,6 +31,33 @@ class DirectionCosinesType(GWCSTransformType):
             transform_type = 'from_direction_cosines'
         elif isinstance(model, ToDirectionCosines):
             transform_type = 'to_direction_cosines'
+        else:
+            raise TypeError(f"Model of type {model.__class__} is not supported.")
+        node = {'transform_type': transform_type}
+        return yamlutil.custom_tree_to_tagged_tree(node, ctx)
+
+
+class SphericalCartesianType(GWCSTransformType):
+    name = "spherical_cartesian"
+    types = [SphericalToCartesian, CartesianToSpherical]
+    version = "1.0.0"
+
+    @classmethod
+    def from_tree_transform(cls, node, ctx):
+        transform_type = node['transform_type']
+        if transform_type == 'spherical_to_cartesian':
+            return SphericalToCartesian()
+        elif transform_type == 'cartesian_to_spherical':
+            return CartesianToSpherical()
+        else:
+            raise TypeError(f"Unknown model_type {transform_type}")
+
+    @classmethod
+    def to_tree_transform(cls, model, ctx):
+        if isinstance(model, SphericalToCartesian):
+            transform_type = 'spherical_to_cartesian'
+        elif isinstance(model, CartesianToSpherical):
+            transform_type = 'cartesian_to_spherical'
         else:
             raise TypeError(f"Model of type {model.__class__} is not supported.")
         node = {'transform_type': transform_type}

--- a/gwcs/tags/tests/test_transforms.py
+++ b/gwcs/tags/tests/test_transforms.py
@@ -19,9 +19,13 @@ sell_zemax = sp.SellmeierZemax(65, 35, 0, 0, [0.58339748, 0.46085267, 3.8915394]
 snell = sp.Snell3D()
 todircos = geometry.ToDirectionCosines()
 fromdircos = geometry.FromDirectionCosines()
+tocart = geometry.SphericalToCartesian()
+tospher = geometry.CartesianToSpherical()
 
 transforms = [todircos,
               fromdircos,
+              tospher,
+              tocart,
               snell,
               sell_glass,
               sell_zemax,

--- a/gwcs/tests/conftest.py
+++ b/gwcs/tests/conftest.py
@@ -13,6 +13,7 @@ from astropy.time import Time
 from .. import coordinate_frames as cf
 from .. import spectroscopy as sp
 from .. import wcs
+from .. import geometry
 
 # frames
 detector_1d = cf.CoordinateFrame(name='detector', axes_order=(0,), naxes=1, axes_type="detector")
@@ -271,3 +272,13 @@ def gwcs_3d_galactic_spectral():
     owcs.pixel_shape = (10, 20, 30)
 
     return owcs
+
+
+@pytest.fixture
+def spher_to_cart():
+    return geometry.SphericalToCartesian()
+
+
+@pytest.fixture
+def cart_to_spher():
+    return geometry.CartesianToSpherical()

--- a/gwcs/tests/test_geometry.py
+++ b/gwcs/tests/test_geometry.py
@@ -1,0 +1,94 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from itertools import product, permutations
+
+import numpy as np
+import pytest
+from astropy import units as u
+
+from .. import geometry
+
+
+_INV_SQRT2 = 1.0 / np.sqrt(2.0)
+
+
+def test_spherical_cartesian_inverse():
+    t = geometry.SphericalToCartesian()
+    assert type(t.inverse) == geometry.CartesianToSpherical
+
+    t = geometry.CartesianToSpherical()
+    assert type(t.inverse) == geometry.SphericalToCartesian
+
+
+@pytest.mark.parametrize(
+    'testval,unit',
+    product(
+        [
+            (45.0, -90.0, (0.0, 0.0, -1.0)),
+            (45.0, -45.0, (0.5, 0.5, -_INV_SQRT2)),
+            (45, 0.0, (_INV_SQRT2, _INV_SQRT2, 0.0)),
+            (45.0, 45, (0.5, 0.5, _INV_SQRT2)),
+            (45.0, 90.0, (0.0, 0.0, 1.0)),
+            (135.0, -90.0, (0.0, 0.0, -1.0)),
+            (135.0, -45.0, (-0.5, 0.5, -_INV_SQRT2)),
+            (135.0, 0.0, (-_INV_SQRT2, _INV_SQRT2, 0.0)),
+            (135.0, 45.0, (-0.5, 0.5, _INV_SQRT2)),
+            (135.0, 90.0, (0.0, 0.0, 1.0)),
+            (225.0, -90.0, (0.0, 0.0, -1.0)),
+            (225.0, -45.0, (-0.5, -0.5, -_INV_SQRT2)),
+            (225.0, 0.0, (-_INV_SQRT2, -_INV_SQRT2, 0.0)),
+            (225.0, 45.0, (-0.5, -0.5, _INV_SQRT2)),
+            (225.0, 90.0, (0.0, 0.0, 1.0)),
+            (315.0, -90.0, (0.0, 0.0, -1.0)),
+            (315.0, -45.0, (0.5, -0.5, -_INV_SQRT2)),
+            (315.0, 0.0, (_INV_SQRT2, -_INV_SQRT2, 0.0)),
+            (315.0, 45.0, (0.5, -0.5, _INV_SQRT2)),
+            (315.0, 90.0, (0.0, 0.0, 1.0)),
+        ],
+        [1, 1 * u.deg, 3600.0 * u.arcsec, np.pi / 180.0 * u.rad]
+    )
+)
+def test_spherical_to_cartesian(spher_to_cart, testval, unit):
+    ounit = 1 if unit == 1 else u.dimensionless_unscaled
+    phi, theta, expected = testval
+    xyz = spher_to_cart(phi * unit, theta * unit)
+    if unit != 1:
+        assert xyz[0].unit == u.dimensionless_unscaled
+    assert u.allclose(xyz, u.Quantity(expected, ounit), atol=1e-15 * ounit)
+
+
+@pytest.mark.parametrize(
+    'phi,theta,unit',
+    list(product(
+        45.0 * np.arange(8),
+        [-90, -55, 0, 25, 90],
+        [1, 1 * u.deg, 3600.0 * u.arcsec, np.pi / 180.0 * u.rad]
+    ))
+)
+def test_spher2cart_roundrip(spher_to_cart, cart_to_spher, phi, theta, unit):
+    ounit = 1 if unit == 1 else u.deg
+    assert u.allclose(
+        cart_to_spher(*spher_to_cart(phi * unit, theta * unit)),
+        (phi * ounit, theta * ounit),
+        atol=1e-15 * ounit
+    )
+
+
+@pytest.mark.parametrize('unit1, unit2', [(u.deg, 1), (1, u.deg)])
+def test_spherical_to_cartesian_mixed_Q(spher_to_cart, unit1, unit2):
+    with pytest.raises(TypeError) as arg_err:
+        spher_to_cart(135.0 * unit1, 45.0 * unit2)
+    assert (arg_err.value.args[0] == "All arguments must be of the same type "
+            "(i.e., quantity or not).")
+
+
+@pytest.mark.parametrize(
+    'x, y, z',
+    list(set(
+        tuple(permutations([1 * u.m, 1, 1])) + tuple(permutations([1 * u.m, 1 * u.m, 1]))
+    ))
+)
+def test_cartesian_to_spherical_mixed_Q(cart_to_spher, x, y, z):
+    with pytest.raises(TypeError) as arg_err:
+        cart_to_spher(x, y, z)
+    assert (arg_err.value.args[0] == "All arguments must be of the same type "
+            "(i.e., quantity or not).")


### PR DESCRIPTION
This PR adds two new models to the `geometry` module to perform coordinate transformations between spherical (on a unit sphere) and Cartesian coordinates.