### PR TITLE
Disable tests that require remote data

### DIFF
--- a/gwcs/tests/test_utils.py
+++ b/gwcs/tests/test_utils.py
@@ -25,6 +25,7 @@ def test_wrong_projcode2():
         gwutils.create_projection_transform("TAM")
 
 
+@pytest.mark.remote_data
 def test_fits_transform():
     hdr = fits.Header.fromfile(get_pkg_data_filename('data/simple_wcs2.hdr'))
     gw1 = gwutils.make_fitswcs_transform(hdr)

--- a/gwcs/tests/test_wcs.py
+++ b/gwcs/tests/test_wcs.py
@@ -254,6 +254,7 @@ def test_grid_from_bounding_box_step():
         grid_from_bounding_box(bb, step=(1, 2, 1))
 
 
+@pytest.mark.remote_data
 def test_wcs_from_points():
     np.random.seed(0)
     hdr = fits.Header.fromtextfile(get_pkg_data_filename("data/acs.hdr"), endcard=False)
@@ -386,6 +387,7 @@ def test_high_level_api():
     assert_allclose(z1, xv)
 
 
+@pytest.mark.remote_data
 class TestImaging(object):
     def setup_class(self):
         hdr = fits.Header.fromtextfile(get_pkg_data_filename("data/acs.hdr"), endcard=False)


### PR DESCRIPTION
In some test environments, remote data are not available. This is f.e. the case during the build of Debian packages. Therefore, tests that require remote data should be marked as such so that they can be easily disabled.