### PR TITLE
Fix NaN assignment in coordinate_frames

### DIFF
--- a/gwcs/coordinate_frames.py
+++ b/gwcs/coordinate_frames.py
@@ -629,10 +629,10 @@ class StokesProfile(str):
         indexes = np.asanyarray(indexes, dtype=int)
         out = np.empty_like(indexes, dtype=object)
 
-        out[nans] = np.nan
-
         for profile, index in cls.profiles.items():
             out[indexes == index] = profile
+
+        out[nans] = np.nan
 
         if out.size == 1 and not nans:
             return StokesProfile(out.item())


### PR DESCRIPTION
Fixes #280. 
This puts the NaN assignment for the output array *after* the assignment of the profiles, so that it overrides any wrong assignment of NaNs converted to ints in `np.asanyarray(…, dtype=int)`.
