### PR TITLE
Add wrap_lon_at parameter to Spherical <-> Cartesian models

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,7 +3,7 @@
 New Features
 ^^^^^^^^^^^^
 
-- Added two new transforms - ``SphericalToCartesian`` and ``CartesianToSpherical``. [#275]
+- Added two new transforms - ``SphericalToCartesian`` and ``CartesianToSpherical``. [#275, #284]
 
 
 0.12.0 (2019-12-24)

--- a/gwcs/geometry.py
+++ b/gwcs/geometry.py
@@ -3,6 +3,7 @@
 Spectroscopy related models.
 """
 
+import numbers
 import numpy as np
 from astropy.modeling.core import Model
 from astropy import units as u
@@ -58,12 +59,18 @@ class FromDirectionCosines(Model):
         return ToDirectionCosines()
 
 
+def _is_int(n):
+    return isinstance(n, numbers.Integral) and not isinstance(n, bool)
+
+
 class SphericalToCartesian(Model):
     """
     Convert spherical coordinates on a unit sphere to cartesian coordinates.
     Spherical coordinates, when not provided as ``Quantity``, are assumed
-    to be in degrees with ``phi`` being the *azimuthal* angle ``[0, 360)``
-    and ``theta`` being the *elevation* angle ``[-90, 90]``.
+    to be in degrees with ``phi`` being the *azimuthal angle* ``[0, 360)``
+    (or ``[-180, 180)``) and ``theta`` being the *elevation angle*
+    ``[-90, 90]`` or the *inclination (polar) angle* in range
+    ``[0, 180]`` depending on the used definition.
 
     """
     _separable = False
@@ -74,13 +81,54 @@ class SphericalToCartesian(Model):
     n_inputs = 2
     n_outputs = 3
 
-    def __init__(self, **kwargs):
+    def __init__(self, wrap_phi_at=360, theta_def='elevation', **kwargs):
+        """
+        Parameters
+        ----------
+        wrap_phi_at : {180, 360}, optional
+            Specifies the range of the azimuthal angle. When ``wrap_phi_at`` is
+            180, azimuthal angle will have a range of ``[-180, 180)`` and
+            when ``wrap_phi_at`` is 360 (default), the azimuthal angle will have
+            a range of ``[0, 360)``
+
+        theta_def : {'elevation', 'inclination', 'polar'}, optional
+            Specifies the definition used for the ``theta``: 'elevation' from
+            the reference plane or 'inclination' (or 'polar') angle measured
+            from the pole.
+
+        """
         super().__init__(**kwargs)
+        self.wrap_phi_at = wrap_phi_at
+        self.theta_def = theta_def
         self.inputs = ('phi', 'theta')
         self.outputs = ('x', 'y', 'z')
 
-    @staticmethod
-    def evaluate(phi, theta):
+    @property
+    def wrap_phi_at(self):
+        return self._wrap_phi_at
+
+    @wrap_phi_at.setter
+    def wrap_phi_at(self, wrap_angle):
+        if not _is_int(wrap_angle):
+            raise TypeError("'wrap_phi_at' must be an integer number: 180 or 360")
+        if wrap_angle not in [180, 360]:
+            raise ValueError("Allowed 'wrap_phi_at' values are 180 and 360")
+        self._wrap_phi_at = wrap_angle
+
+    @property
+    def theta_def(self):
+        return self._theta_def
+
+    @theta_def.setter
+    def theta_def(self, theta_def):
+        if not isinstance(theta_def, str):
+            raise TypeError("'theta_def' must be a string.")
+        if theta_def not in ['elevation', 'inclination', 'polar']:
+            raise ValueError("Allowed 'theta_def' values are: 'elevation', "
+                             "'inclination', or 'polar'.")
+        self._theta_def = theta_def
+
+    def evaluate(self, phi, theta):
         if isinstance(phi, u.Quantity) != isinstance(theta, u.Quantity):
             raise TypeError("All arguments must be of the same type "
                             "(i.e., quantity or not).")
@@ -88,15 +136,24 @@ class SphericalToCartesian(Model):
         phi = np.deg2rad(phi)
         theta = np.deg2rad(theta)
 
-        cs = np.cos(theta)
+        if self._theta_def == 'elevation':
+            cs = np.cos(theta)
+            si = np.sin(theta)
+        else:
+            cs = np.sin(theta)
+            si = np.cos(theta)
+
         x = cs * np.cos(phi)
         y = cs * np.sin(phi)
-        z = np.sin(theta)
+        z = si
 
         return x, y, z
 
     def inverse(self):
-        return CartesianToSpherical()
+        return CartesianToSpherical(
+            wrap_phi_at=self._wrap_phi_at,
+            theta_def=self._theta_def
+        )
 
     @property
     def input_units(self):
@@ -107,8 +164,9 @@ class CartesianToSpherical(Model):
     """
     Convert cartesian coordinates to spherical coordinates on a unit sphere.
     Spherical coordinates are assumed to be in degrees with ``phi`` being
-    the *azimuthal* angle ``[0, 360)`` and ``theta`` being the *elevation*
-    angle ``[-90, 90]``.
+    the *azimuthal angle* ``[0, 360)`` (or ``[-180, 180)``) and ``theta``
+    being the *elevation angle* ``[-90, 90]`` or the *inclination (polar)
+    angle* in range ``[0, 180]`` depending on the used definition.
 
     """
     _separable = False
@@ -116,26 +174,75 @@ class CartesianToSpherical(Model):
     n_inputs = 3
     n_outputs = 2
 
-    def __init__(self, **kwargs):
+    def __init__(self, wrap_phi_at=360, theta_def='elevation', **kwargs):
+        """
+        Parameters
+        ----------
+        wrap_phi_at : {180, 360}, optional
+            Specifies the range of the azimuthal angle. When ``wrap_phi_at`` is
+            180, azimuthal angle will have a range of ``[-180, 180)`` and
+            when ``wrap_phi_at`` is 360 (default), the azimuthal angle will have
+            a range of ``[0, 360)``
+
+        theta_def : {'elevation', 'inclination', 'polar'}, optional
+            Specifies the definition used for the ``theta``: 'elevation' from
+            the reference plane or 'inclination' (or 'polar') angle measured
+            from the pole.
+
+        """
         super().__init__(**kwargs)
+        self.wrap_phi_at = wrap_phi_at
+        self.theta_def = theta_def
         self.inputs = ('x', 'y', 'z')
         self.outputs = ('phi', 'theta')
 
-    @staticmethod
-    def evaluate(x, y, z):
+    @property
+    def wrap_phi_at(self):
+        return self._wrap_phi_at
+
+    @wrap_phi_at.setter
+    def wrap_phi_at(self, wrap_angle):
+        if not _is_int(wrap_angle):
+            raise TypeError("'wrap_phi_at' must be an integer number: 180 or 360")
+        if wrap_angle not in [180, 360]:
+            raise ValueError("Allowed 'wrap_phi_at' values are 180 and 360")
+        self._wrap_phi_at = wrap_angle
+
+    @property
+    def theta_def(self):
+        return self._theta_def
+
+    @theta_def.setter
+    def theta_def(self, theta_def):
+        if not isinstance(theta_def, str):
+            raise TypeError("'theta_def' must be a string.")
+        if theta_def not in ['elevation', 'inclination', 'polar']:
+            raise ValueError("Allowed 'theta_def' values are: 'elevation', "
+                             "'inclination', or 'polar'.")
+        self._theta_def = theta_def
+
+    def evaluate(self, x, y, z):
         nquant = [isinstance(i, u.Quantity) for i in (x, y, z)].count(True)
         if nquant in [1, 2]:
             raise TypeError("All arguments must be of the same type "
                             "(i.e., quantity or not).")
 
         h = np.hypot(x, y)
-        phi = np.mod(
-            np.rad2deg(np.arctan2(y, x)),
-            360.0 * u.deg if nquant else 360.0
-        )
+        phi = np.rad2deg(np.arctan2(y, x))
+        if h == 0.0:
+            phi *= 0.0
+
+        if self._wrap_phi_at != 180:
+            phi = np.mod(phi, 360.0 * u.deg if nquant else 360.0)
+
         theta = np.rad2deg(np.arctan2(z, h))
+        if self._theta_def != 'elevation':
+            theta = (90.0 * u.deg if nquant else 90.0) - theta
 
         return phi, theta
 
     def inverse(self):
-        return SphericalToCartesian()
+        return SphericalToCartesian(
+            wrap_phi_at=self._wrap_phi_at,
+            theta_def=self._theta_def
+        )

--- a/gwcs/geometry.py
+++ b/gwcs/geometry.py
@@ -11,6 +11,14 @@ from astropy import units as u
 __all__ = ['ToDirectionCosines', 'FromDirectionCosines',
            'SphericalToCartesian', 'CartesianToSpherical']
 
+# allowable values for angle theta definition in spherical<->Cartesian
+# transformations:
+_THETA_NAMES = ['latitude', 'colatitude', 'altitude', 'elevation',
+                'inclination', 'polar']
+
+# theta definitions for which angle is measured from the "reference" plane:
+_LAT_LIKE = ['latitude', 'altitude', 'elevation']
+
 
 class ToDirectionCosines(Model):
     """
@@ -59,18 +67,14 @@ class FromDirectionCosines(Model):
         return ToDirectionCosines()
 
 
-def _is_int(n):
-    return isinstance(n, numbers.Integral) and not isinstance(n, bool)
-
-
 class SphericalToCartesian(Model):
     """
     Convert spherical coordinates on a unit sphere to cartesian coordinates.
     Spherical coordinates, when not provided as ``Quantity``, are assumed
-    to be in degrees with ``phi`` being the *azimuthal angle* ``[0, 360)``
-    (or ``[-180, 180)``) and ``theta`` being the *elevation angle*
-    ``[-90, 90]`` or the *inclination (polar) angle* in range
-    ``[0, 180]`` depending on the used definition.
+    to be in degrees with ``phi`` being the *azimuthal angle* (or *longitude*)
+    ``[0, 360)`` (or ``[-180, 180)``) and ``theta`` being the *elevation angle*
+    (or *latitude*) ``[-90, 90]`` or the *inclination (polar, colatitude) angle*
+    in range ``[0, 180]`` depending on the used definition.
 
     """
     _separable = False
@@ -81,52 +85,71 @@ class SphericalToCartesian(Model):
     n_inputs = 2
     n_outputs = 3
 
-    def __init__(self, wrap_phi_at=360, theta_def='elevation', **kwargs):
+    def __init__(self, wrap_phi_at=360, theta_def='latitude', **kwargs):
         """
         Parameters
         ----------
-        wrap_phi_at : {180, 360}, optional
-            Specifies the range of the azimuthal angle. When ``wrap_phi_at`` is
-            180, azimuthal angle will have a range of ``[-180, 180)`` and
-            when ``wrap_phi_at`` is 360 (default), the azimuthal angle will have
-            a range of ``[0, 360)``
+        wrap_phi_at : {360, 180}, optional
+            An **integer number** that specifies the range of the azimuthal
+            (longitude) angle. When ``wrap_phi_at`` is 180, azimuthal angle
+            will have a range of ``[-180, 180)`` and when ``wrap_phi_at``
+            is 360 (default), the azimuthal angle will have a range of
+            ``[0, 360)``.
 
-        theta_def : {'elevation', 'inclination', 'polar'}, optional
-            Specifies the definition used for the ``theta``: 'elevation' from
-            the reference plane or 'inclination' (or 'polar') angle measured
-            from the pole.
+        theta_def : {'latitude', 'colatitude', 'altitude', 'elevation', \
+                     'inclination', 'polar'}, optional
+            Specifies the definition used for the angle ``theta``:
+            either 'elevation' angle (synonyms: 'latitude', 'altitude') from
+            the reference plane or 'inclination' angle (synonyms: 'polar',
+            'colatitude') measured from the pole (zenith direction).
 
         """
         super().__init__(**kwargs)
-        self.wrap_phi_at = wrap_phi_at
-        self.theta_def = theta_def
         self.inputs = ('phi', 'theta')
         self.outputs = ('x', 'y', 'z')
+        self.wrap_phi_at = wrap_phi_at
+        self.theta_def = theta_def
 
     @property
     def wrap_phi_at(self):
+        """ An **integer number** that specifies the range of the azimuthal
+        (longitude) angle.
+
+        Allowed values are 180 and 360. When ``wrap_phi_at``
+        is 180, azimuthal angle will have a range of ``[-180, 180)`` and when
+        ``wrap_phi_at`` is 360 (default), the azimuthal angle will have a
+        range of ``[0, 360)``.
+
+        """
         return self._wrap_phi_at
 
     @wrap_phi_at.setter
     def wrap_phi_at(self, wrap_angle):
-        if not _is_int(wrap_angle):
-            raise TypeError("'wrap_phi_at' must be an integer number: 180 or 360")
-        if wrap_angle not in [180, 360]:
-            raise ValueError("Allowed 'wrap_phi_at' values are 180 and 360")
+        if not (isinstance(wrap_angle, numbers.Integral) and wrap_angle in [180, 360]):
+            raise ValueError("'wrap_phi_at' must be an integer number: 180 or 360")
         self._wrap_phi_at = wrap_angle
 
     @property
     def theta_def(self):
+        """ Definition used for the ``theta`` angle, i.e., latitude or colatitude.
+
+        When ``theta_def`` is either 'elevation', or 'latitude', or 'altitude',
+        angle ``theta_def`` is measured from the reference plane.
+        When ``theta_def`` is either 'inclination', or 'polar', or 'colatitude',
+        angle ``theta_def`` is measured from the pole (zenith direction).
+
+        """
         return self._theta_def
 
     @theta_def.setter
     def theta_def(self, theta_def):
-        if not isinstance(theta_def, str):
-            raise TypeError("'theta_def' must be a string.")
-        if theta_def not in ['elevation', 'inclination', 'polar']:
-            raise ValueError("Allowed 'theta_def' values are: 'elevation', "
-                             "'inclination', or 'polar'.")
+        if theta_def not in _THETA_NAMES:
+            raise ValueError(
+                "'theta_def' must be a string with one of the following "
+                "values: {:s}".format(','.join(map(repr, _THETA_NAMES)))
+            )
         self._theta_def = theta_def
+        self._is_theta_latitude = theta_def in _LAT_LIKE
 
     def evaluate(self, phi, theta):
         if isinstance(phi, u.Quantity) != isinstance(theta, u.Quantity):
@@ -136,7 +159,7 @@ class SphericalToCartesian(Model):
         phi = np.deg2rad(phi)
         theta = np.deg2rad(theta)
 
-        if self._theta_def == 'elevation':
+        if self._is_theta_latitude:
             cs = np.cos(theta)
             si = np.sin(theta)
         else:
@@ -163,10 +186,13 @@ class SphericalToCartesian(Model):
 class CartesianToSpherical(Model):
     """
     Convert cartesian coordinates to spherical coordinates on a unit sphere.
-    Spherical coordinates are assumed to be in degrees with ``phi`` being
-    the *azimuthal angle* ``[0, 360)`` (or ``[-180, 180)``) and ``theta``
-    being the *elevation angle* ``[-90, 90]`` or the *inclination (polar)
-    angle* in range ``[0, 180]`` depending on the used definition.
+    Output spherical coordinates are in degrees. When input cartesian
+    coordinates are quantities (``Quantity`` objects), output angles
+    will also be quantities in degrees. Angle ``phi`` is the *azimuthal angle*
+    (or *longitude*) ``[0, 360)`` (or ``[-180, 180)``) and angle ``theta``
+    is the *elevation angle* (or *latitude*) ``[-90, 90]`` or the *inclination
+    (polar, colatitude) angle* in range ``[0, 180]`` depending on the used
+    definition (see documentation for ``theta_def``).
 
     """
     _separable = False
@@ -174,52 +200,71 @@ class CartesianToSpherical(Model):
     n_inputs = 3
     n_outputs = 2
 
-    def __init__(self, wrap_phi_at=360, theta_def='elevation', **kwargs):
+    def __init__(self, wrap_phi_at=360, theta_def='latitude', **kwargs):
         """
         Parameters
         ----------
-        wrap_phi_at : {180, 360}, optional
-            Specifies the range of the azimuthal angle. When ``wrap_phi_at`` is
-            180, azimuthal angle will have a range of ``[-180, 180)`` and
-            when ``wrap_phi_at`` is 360 (default), the azimuthal angle will have
-            a range of ``[0, 360)``
+        wrap_phi_at : {360, 180}, optional
+            An **integer number** that specifies the range of the azimuthal
+            (longitude) angle. When ``wrap_phi_at`` is 180, azimuthal angle
+            will have a range of ``[-180, 180)`` and when ``wrap_phi_at``
+            is 360 (default), the azimuthal angle will have a range of
+            ``[0, 360)``.
 
-        theta_def : {'elevation', 'inclination', 'polar'}, optional
-            Specifies the definition used for the ``theta``: 'elevation' from
-            the reference plane or 'inclination' (or 'polar') angle measured
-            from the pole.
+        theta_def : {'latitude', 'colatitude', 'altitude', 'elevation', \
+                     'inclination', 'polar'}, optional
+            Specifies the definition used for the angle ``theta``:
+            either 'elevation' angle (synonyms: 'latitude', 'altitude') from
+            the reference plane or 'inclination' angle (synonyms: 'polar',
+            'colatitude') measured from the pole (zenith direction).
 
         """
         super().__init__(**kwargs)
-        self.wrap_phi_at = wrap_phi_at
-        self.theta_def = theta_def
         self.inputs = ('x', 'y', 'z')
         self.outputs = ('phi', 'theta')
+        self.wrap_phi_at = wrap_phi_at
+        self.theta_def = theta_def
 
     @property
     def wrap_phi_at(self):
+        """ An **integer number** that specifies the range of the azimuthal
+        (longitude) angle.
+
+        Allowed values are 180 and 360. When ``wrap_phi_at``
+        is 180, azimuthal angle will have a range of ``[-180, 180)`` and when
+        ``wrap_phi_at`` is 360 (default), the azimuthal angle will have a
+        range of ``[0, 360)``.
+
+        """
         return self._wrap_phi_at
 
     @wrap_phi_at.setter
     def wrap_phi_at(self, wrap_angle):
-        if not _is_int(wrap_angle):
-            raise TypeError("'wrap_phi_at' must be an integer number: 180 or 360")
-        if wrap_angle not in [180, 360]:
-            raise ValueError("Allowed 'wrap_phi_at' values are 180 and 360")
+        if not (isinstance(wrap_angle, numbers.Integral) and wrap_angle in [180, 360]):
+            raise ValueError("'wrap_phi_at' must be an integer number: 180 or 360")
         self._wrap_phi_at = wrap_angle
 
     @property
     def theta_def(self):
+        """ Definition used for the ``theta`` angle, i.e., latitude or colatitude.
+
+        When ``theta_def`` is either 'elevation', or 'latitude', or 'altitude',
+        angle ``theta_def`` is measured from the reference plane.
+        When ``theta_def`` is either 'inclination', or 'polar', or 'colatitude',
+        angle ``theta_def`` is measured from the pole (zenith direction).
+
+        """
         return self._theta_def
 
     @theta_def.setter
     def theta_def(self, theta_def):
-        if not isinstance(theta_def, str):
-            raise TypeError("'theta_def' must be a string.")
-        if theta_def not in ['elevation', 'inclination', 'polar']:
-            raise ValueError("Allowed 'theta_def' values are: 'elevation', "
-                             "'inclination', or 'polar'.")
+        if theta_def not in _THETA_NAMES:
+            raise ValueError(
+                "'theta_def' must be a string with one of the following "
+                "values: {:s}".format(','.join(map(repr, _THETA_NAMES)))
+            )
         self._theta_def = theta_def
+        self._is_theta_latitude = theta_def in _LAT_LIKE
 
     def evaluate(self, x, y, z):
         nquant = [isinstance(i, u.Quantity) for i in (x, y, z)].count(True)
@@ -236,7 +281,7 @@ class CartesianToSpherical(Model):
             phi = np.mod(phi, 360.0 * u.deg if nquant else 360.0)
 
         theta = np.rad2deg(np.arctan2(z, h))
-        if self._theta_def != 'elevation':
+        if not self._is_theta_latitude:
             theta = (90.0 * u.deg if nquant else 90.0) - theta
 
         return phi, theta

--- a/gwcs/schemas/stsci.edu/gwcs/spherical_cartesian-1.0.0.yaml
+++ b/gwcs/schemas/stsci.edu/gwcs/spherical_cartesian-1.0.0.yaml
@@ -35,13 +35,13 @@ allOf:
         description: Angle to which to wrap the azimuthal angle.
         type: integer
         enum: [180, 360]
-        default: 180
+        default: 360
       theta_def:
         description: |
           Definition for the theta angle: polar/inclination or elevation.
         type: string
-        enum: [elevation, inclination, polar]
-        default: elevation
+        enum: [latitude, colatitude, altitude, elevation, inclination, polar]
+        default: latitude
       transform_type:
         description: The type of transform/class to initialize.
         type: string

--- a/gwcs/schemas/stsci.edu/gwcs/spherical_cartesian-1.0.0.yaml
+++ b/gwcs/schemas/stsci.edu/gwcs/spherical_cartesian-1.0.0.yaml
@@ -31,20 +31,14 @@ allOf:
   - $ref:  "tag:stsci.edu:asdf/transform/transform-1.1.0"
   - object:
     properties:
-      wrap_phi_at:
-        description: Angle to which to wrap the azimuthal angle.
+      wrap_lon_at:
+        description: Angle at which to wrap the longitude angle.
         type: integer
         enum: [180, 360]
         default: 360
-      theta_def:
-        description: |
-          Definition for the theta angle: polar/inclination or elevation.
-        type: string
-        enum: [latitude, colatitude, altitude, elevation, inclination, polar]
-        default: latitude
       transform_type:
         description: The type of transform/class to initialize.
         type: string
         enum: [spherical_to_cartesian, cartesian_to_spherical]
 
-    required: [transform_type, wrap_phi_at, theta_def]
+    required: [transform_type, wrap_lon_at]

--- a/gwcs/schemas/stsci.edu/gwcs/spherical_cartesian-1.0.0.yaml
+++ b/gwcs/schemas/stsci.edu/gwcs/spherical_cartesian-1.0.0.yaml
@@ -31,9 +31,20 @@ allOf:
   - $ref:  "tag:stsci.edu:asdf/transform/transform-1.1.0"
   - object:
     properties:
-      transform_type:
+      wrap_phi_at:
+        description: Angle to which to wrap the azimuthal angle.
+        type: integer
+        enum: [180, 360]
+        default: 180
+      theta_def:
         description: |
-          The type of transform/class to initialize.
+          Definition for the theta angle: polar/inclination or elevation.
+        type: string
+        enum: [elevation, inclination, polar]
+        default: elevation
+      transform_type:
+        description: The type of transform/class to initialize.
         type: string
         enum: [spherical_to_cartesian, cartesian_to_spherical]
-    required: [transform_type]
+
+    required: [transform_type, wrap_phi_at, theta_def]

--- a/gwcs/tags/geometry_models.py
+++ b/gwcs/tags/geometry_models.py
@@ -45,12 +45,11 @@ class SphericalCartesianType(GWCSTransformType):
     @classmethod
     def from_tree_transform(cls, node, ctx):
         transform_type = node['transform_type']
-        wrap_phi_at = node['wrap_phi_at']
-        theta_def = node['theta_def']
+        wrap_lon_at = node['wrap_lon_at']
         if transform_type == 'spherical_to_cartesian':
-            return SphericalToCartesian(wrap_phi_at=wrap_phi_at, theta_def=theta_def)
+            return SphericalToCartesian(wrap_lon_at=wrap_lon_at)
         elif transform_type == 'cartesian_to_spherical':
-            return CartesianToSpherical(wrap_phi_at=wrap_phi_at, theta_def=theta_def)
+            return CartesianToSpherical(wrap_lon_at=wrap_lon_at)
         else:
             raise TypeError(f"Unknown model_type {transform_type}")
 
@@ -65,7 +64,6 @@ class SphericalCartesianType(GWCSTransformType):
 
         node = {
             'transform_type': transform_type,
-            'wrap_phi_at': model.wrap_phi_at,
-            'theta_def': model.theta_def
+            'wrap_lon_at': model.wrap_lon_at
         }
         return yamlutil.custom_tree_to_tagged_tree(node, ctx)

--- a/gwcs/tags/geometry_models.py
+++ b/gwcs/tags/geometry_models.py
@@ -45,10 +45,12 @@ class SphericalCartesianType(GWCSTransformType):
     @classmethod
     def from_tree_transform(cls, node, ctx):
         transform_type = node['transform_type']
+        wrap_phi_at = node['wrap_phi_at']
+        theta_def = node['theta_def']
         if transform_type == 'spherical_to_cartesian':
-            return SphericalToCartesian()
+            return SphericalToCartesian(wrap_phi_at=wrap_phi_at, theta_def=theta_def)
         elif transform_type == 'cartesian_to_spherical':
-            return CartesianToSpherical()
+            return CartesianToSpherical(wrap_phi_at=wrap_phi_at, theta_def=theta_def)
         else:
             raise TypeError(f"Unknown model_type {transform_type}")
 
@@ -60,5 +62,10 @@ class SphericalCartesianType(GWCSTransformType):
             transform_type = 'cartesian_to_spherical'
         else:
             raise TypeError(f"Model of type {model.__class__} is not supported.")
-        node = {'transform_type': transform_type}
+
+        node = {
+            'transform_type': transform_type,
+            'wrap_phi_at': model.wrap_phi_at,
+            'theta_def': model.theta_def
+        }
         return yamlutil.custom_tree_to_tagged_tree(node, ctx)

--- a/gwcs/tests/test_geometry.py
+++ b/gwcs/tests/test_geometry.py
@@ -1,5 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from itertools import product, permutations
+import io
+import asdf
 
 import numpy as np
 import pytest
@@ -20,7 +22,7 @@ def test_spherical_cartesian_inverse():
 
 
 @pytest.mark.parametrize(
-    'testval,unit',
+    'testval,unit,wrap_at,theta_def',
     product(
         [
             (45.0, -90.0, (0.0, 0.0, -1.0)),
@@ -44,31 +46,59 @@ def test_spherical_cartesian_inverse():
             (315.0, 45.0, (0.5, -0.5, _INV_SQRT2)),
             (315.0, 90.0, (0.0, 0.0, 1.0)),
         ],
-        [1, 1 * u.deg, 3600.0 * u.arcsec, np.pi / 180.0 * u.rad]
+        [1, 1 * u.deg, 3600.0 * u.arcsec, np.pi / 180.0 * u.rad],
+        [180, 360],
+        ['elevation', 'polar'],
     )
 )
-def test_spherical_to_cartesian(spher_to_cart, testval, unit):
+def test_spherical_to_cartesian(testval, unit, wrap_at, theta_def):
+    s2c = geometry.SphericalToCartesian(wrap_phi_at=wrap_at, theta_def=theta_def)
     ounit = 1 if unit == 1 else u.dimensionless_unscaled
     phi, theta, expected = testval
-    xyz = spher_to_cart(phi * unit, theta * unit)
+
+    if wrap_at == 180:
+        phi = np.mod(phi - 180.0, 360.0) - 180.0
+
+    if theta_def == 'polar':
+        theta = 90 - theta
+
+    xyz = s2c(phi * unit, theta * unit)
     if unit != 1:
         assert xyz[0].unit == u.dimensionless_unscaled
     assert u.allclose(xyz, u.Quantity(expected, ounit), atol=1e-15 * ounit)
 
 
 @pytest.mark.parametrize(
-    'phi,theta,unit',
+    'phi,theta,unit,wrap_at,theta_def',
     list(product(
         45.0 * np.arange(8),
-        [-90, -55, 0, 25, 90],
-        [1, 1 * u.deg, 3600.0 * u.arcsec, np.pi / 180.0 * u.rad]
+        [-90, -89, -55, 0, 25, 89, 90],
+        [1, 1 * u.deg, 3600.0 * u.arcsec, np.pi / 180.0 * u.rad],
+        [180, 360],
+        ['elevation', 'polar'],
     ))
 )
-def test_spher2cart_roundrip(spher_to_cart, cart_to_spher, phi, theta, unit):
+def test_spher2cart_roundrip(phi, theta, unit, wrap_at, theta_def):
+    s2c = geometry.SphericalToCartesian(wrap_phi_at=wrap_at, theta_def=theta_def)
+    c2s = geometry.CartesianToSpherical(wrap_phi_at=wrap_at, theta_def=theta_def)
     ounit = 1 if unit == 1 else u.deg
+
+    if wrap_at == 180:
+        phi = np.mod(phi - 180.0, 360.0) - 180.0
+
+    sl = slice(int(theta == 90 or theta == -90), 2)
+
+    if theta_def == 'polar':
+        theta = 90 - theta
+
+    assert s2c.wrap_phi_at == wrap_at
+    assert s2c.theta_def == theta_def
+    assert c2s.wrap_phi_at == wrap_at
+    assert c2s.theta_def == theta_def
+
     assert u.allclose(
-        cart_to_spher(*spher_to_cart(phi * unit, theta * unit)),
-        (phi * ounit, theta * ounit),
+        c2s(*s2c(phi * unit, theta * unit))[sl],
+        (phi * ounit, theta * ounit)[sl],
         atol=1e-15 * ounit
     )
 
@@ -92,3 +122,121 @@ def test_cartesian_to_spherical_mixed_Q(cart_to_spher, x, y, z):
         cart_to_spher(x, y, z)
     assert (arg_err.value.args[0] == "All arguments must be of the same type "
             "(i.e., quantity or not).")
+
+
+@pytest.mark.parametrize('wrap_at', ['1', 180., True, 180j, [180]])
+def test_c2s2c_wrong_wrap_type(spher_to_cart, cart_to_spher, wrap_at):
+    with pytest.raises(TypeError) as arg_err:
+        geometry.SphericalToCartesian(wrap_phi_at=wrap_at)
+    assert (arg_err.value.args[0] == "'wrap_phi_at' must be an integer number: "
+            "180 or 360")
+
+    with pytest.raises(TypeError) as arg_err:
+        spher_to_cart.wrap_phi_at = wrap_at
+    assert (arg_err.value.args[0] == "'wrap_phi_at' must be an integer number: "
+            "180 or 360")
+
+    with pytest.raises(TypeError) as arg_err:
+        geometry.SphericalToCartesian(wrap_phi_at=wrap_at)
+    assert (arg_err.value.args[0] == "'wrap_phi_at' must be an integer number: "
+            "180 or 360")
+
+    with pytest.raises(TypeError) as arg_err:
+        cart_to_spher.wrap_phi_at = wrap_at
+    assert (arg_err.value.args[0] == "'wrap_phi_at' must be an integer number: "
+            "180 or 360")
+
+
+@pytest.mark.parametrize('wrap_at', [-180, 0, 1])
+def test_c2s2c_wrong_wrap_val(spher_to_cart, cart_to_spher, wrap_at):
+    with pytest.raises(ValueError) as arg_err:
+        geometry.SphericalToCartesian(wrap_phi_at=wrap_at)
+    assert arg_err.value.args[0] == "Allowed 'wrap_phi_at' values are 180 and 360"
+
+    with pytest.raises(ValueError) as arg_err:
+        spher_to_cart.wrap_phi_at = wrap_at
+    assert arg_err.value.args[0] == "Allowed 'wrap_phi_at' values are 180 and 360"
+
+    with pytest.raises(ValueError) as arg_err:
+        geometry.SphericalToCartesian(wrap_phi_at=wrap_at)
+    assert arg_err.value.args[0] == "Allowed 'wrap_phi_at' values are 180 and 360"
+
+    with pytest.raises(ValueError) as arg_err:
+        cart_to_spher.wrap_phi_at = wrap_at
+    assert arg_err.value.args[0] == "Allowed 'wrap_phi_at' values are 180 and 360"
+
+
+@pytest.mark.parametrize('theta_def', [180., True, 180j, [180], np.int(1)])
+def test_c2s2c_wrong_theta_type(spher_to_cart, cart_to_spher, theta_def):
+    with pytest.raises(TypeError) as arg_err:
+        geometry.SphericalToCartesian(theta_def=theta_def)
+    assert arg_err.value.args[0] == "'theta_def' must be a string."
+
+    with pytest.raises(TypeError) as arg_err:
+        spher_to_cart.theta_def = theta_def
+    assert arg_err.value.args[0] == "'theta_def' must be a string."
+
+    with pytest.raises(TypeError) as arg_err:
+        geometry.SphericalToCartesian(theta_def=theta_def)
+    assert arg_err.value.args[0] == "'theta_def' must be a string."
+
+    with pytest.raises(TypeError) as arg_err:
+        cart_to_spher.theta_def = theta_def
+    assert arg_err.value.args[0] == "'theta_def' must be a string."
+
+
+@pytest.mark.parametrize('theta_def', ['ele', ''])
+def test_c2s2c_wrong_theta_value(spher_to_cart, cart_to_spher, theta_def):
+    with pytest.raises(ValueError) as arg_err:
+        geometry.SphericalToCartesian(theta_def=theta_def)
+    assert (arg_err.value.args[0] == "Allowed 'theta_def' values are: "
+            "'elevation', 'inclination', or 'polar'.")
+
+    with pytest.raises(ValueError) as arg_err:
+        spher_to_cart.theta_def = theta_def
+    assert (arg_err.value.args[0] == "Allowed 'theta_def' values are: "
+            "'elevation', 'inclination', or 'polar'.")
+
+    with pytest.raises(ValueError) as arg_err:
+        geometry.SphericalToCartesian(theta_def=theta_def)
+    assert (arg_err.value.args[0] == "Allowed 'theta_def' values are: "
+            "'elevation', 'inclination', or 'polar'.")
+
+    with pytest.raises(ValueError) as arg_err:
+        cart_to_spher.theta_def = theta_def
+    assert (arg_err.value.args[0] == "Allowed 'theta_def' values are: "
+            "'elevation', 'inclination', or 'polar'.")
+
+
+def test_cartesian_spherical_asdf(spher_to_cart, cart_to_spher):
+    # create file object
+    f = asdf.AsdfFile({'c2s': cart_to_spher, 's2c': spher_to_cart})
+
+    # write to...
+    buf = io.BytesIO()
+    f.write_to(buf)
+
+    # read back:
+    buf.seek(0)
+    f = asdf.open(buf)
+
+    # retreave transformations:
+    c2s = f['c2s']
+    s2c = f['s2c']
+
+    coords = [
+        (45.0, -90.0), (45.0, -45.0), (45, 0.0),
+        (45.0, 45), (45.0, 90.0), (135.0, -90.0),
+        (135.0, -45.0), (135.0, 0.0), (135.0, 45.0),
+        (135.0, 90.0), (225.0, -90.0), (225.0, -45.0),
+        (225.0, 0.0), (225.0, 45.0), (225.0, 90.0),
+        (315.0, -90.0), (315.0, -45.0), (315.0, 0.0),
+        (315.0, 45.0), (315.0, 90.0)
+    ]
+
+    for phi, th in coords:
+        xyz = s2c(phi, th)
+        assert xyz == spher_to_cart(phi, th)
+        phi2, th2 = c2s(*xyz)
+        assert phi2, th2 == cart_to_spher(*xyz)
+        assert np.allclose((phi, th), (phi2, th2))


### PR DESCRIPTION
This PR adds two new parameters to the `CartesianToSpherical` and `SphericalToCartesian` models to allow specification of the wrapping angle for the azimuthal angle (`[-180, 180]` or `[0, 360]`) and the convention used for the second spherical angle ('elevation', 'inclination').