### PR TITLE
Cartesian2Spherical crashes for ndarray inputs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,7 +3,8 @@
 New Features
 ^^^^^^^^^^^^
 
-- Added two new transforms - ``SphericalToCartesian`` and ``CartesianToSpherical``. [#275, #284]
+- Added two new transforms - ``SphericalToCartesian`` and
+  ``CartesianToSpherical``. [#275, #284, #285]
 
 
 0.12.0 (2019-12-24)

--- a/gwcs/geometry.py
+++ b/gwcs/geometry.py
@@ -148,6 +148,9 @@ class CartesianToSpherical(Model):
     """
     _separable = False
 
+    _input_units_strict = True
+    _input_units_allow_dimensionless = True
+
     n_inputs = 3
     n_outputs = 2
 
@@ -195,8 +198,9 @@ class CartesianToSpherical(Model):
 
         h = np.hypot(x, y)
         lon = np.rad2deg(np.arctan2(y, x))
-        if h == 0.0:
-            lon *= 0.0
+
+        if isinstance(h, np.ndarray):
+            lon[h == 0] *= 0
 
         if self._wrap_lon_at != 180:
             lon = np.mod(lon, 360.0 * u.deg if nquant else 360.0)

--- a/gwcs/geometry.py
+++ b/gwcs/geometry.py
@@ -70,7 +70,6 @@ class SphericalToCartesian(Model):
     """
     _separable = False
 
-    _input_units_strict = True
     _input_units_allow_dimensionless = True
 
     n_inputs = 2
@@ -148,7 +147,6 @@ class CartesianToSpherical(Model):
     """
     _separable = False
 
-    _input_units_strict = True
     _input_units_allow_dimensionless = True
 
     n_inputs = 3
@@ -197,15 +195,12 @@ class CartesianToSpherical(Model):
                             "(i.e., quantity or not).")
 
         h = np.hypot(x, y)
+        lat = np.rad2deg(np.arctan2(z, h))
         lon = np.rad2deg(np.arctan2(y, x))
-
-        if isinstance(h, np.ndarray):
-            lon[h == 0] *= 0
+        lon[h == 0] *= 0
 
         if self._wrap_lon_at != 180:
             lon = np.mod(lon, 360.0 * u.deg if nquant else 360.0)
-
-        lat = np.rad2deg(np.arctan2(z, h))
 
         return lon, lat
 


### PR DESCRIPTION
Current implementation of `Cartesian2Spherical` crashes for `ndarray` inputs (test of a comparison of an array to a number). This PR fixes this bug and adds test to cover this situation.