### PR TITLE
add a UCD1 to CTYPE mapping

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,7 @@ New Features
 
 - Added ``to_fits_sip`` method to generate FITS header with SIP keywords [#286]
 
+- Added ``get_ctype_from_ucd`` function. [#288]
 
 0.12.0 (2019-12-24)
 -------------------

--- a/gwcs/coordinate_frames.py
+++ b/gwcs/coordinate_frames.py
@@ -54,7 +54,7 @@ STANDARD_REFERENCE_POSITION = ["GEOCENTER", "BARYCENTER", "HELIOCENTER",
 
 
 def get_ctype_from_ucd(ucd):
-    """ Return CTYPE string corresponding to a UCD1 value."""
+    """ Return the FITS ``CTYPE`` corresponding to a UCD1 value."""
     return UCD1_TO_CTYPE.get(ucd, "")
 
 

--- a/gwcs/coordinate_frames.py
+++ b/gwcs/coordinate_frames.py
@@ -18,11 +18,44 @@ __all__ = ['Frame2D', 'CelestialFrame', 'SpectralFrame', 'CompositeFrame',
            'CoordinateFrame', 'TemporalFrame']
 
 
+UCD1_TO_CTYPE = {
+    'pos.eq.ra': 'RA',
+    'pos.eq.dec': 'DEC',
+    'pos.galactic.lon': 'GLON',
+    'pos.galactic.lat': 'GLAT',
+    'pos.ecliptic.lon': 'ELON',
+    'pos.ecliptic.lat': 'ELAT',
+    'pos.bodyrc.lon': 'TLON',
+    'pos.bodyrc.lat': 'TLAT',
+    'custom:pos.helioprojective.lat': 'HPLT',
+    'custom:pos.helioprojective.lon': 'HPLN',
+    'custom:pos.heliographic.stonyhurst.lon': 'HGLN',
+    'custom:pos.heliographic.stonyhurst.lat': 'HGLT',
+    'custom:pos.heliographic.carrington.lon': 'CRLN',
+    'custom:pos.heliographic.carrington.lat': 'CRLT',
+    'em.freq': 'FREQ',
+    'em.energy': 'ENER',
+    'em.wavenumber': 'WAVN',
+    'em.wl': 'WAVE',
+    'spect.dopplerVeloc.radio': 'VRAD',
+    'spect.dopplerVeloc.opt': 'VOPT',
+    'src.redshift': 'ZOPT',
+    'spect.dopplerVeloc': 'VELO',
+    'custom:spect.doplerVeloc.beta': 'BETA',
+    'time': 'TIME',
+    }
+
+
 STANDARD_REFERENCE_FRAMES = [frame.upper() for frame in coord.builtin_frames.__all__]
 
 STANDARD_REFERENCE_POSITION = ["GEOCENTER", "BARYCENTER", "HELIOCENTER",
                                "TOPOCENTER", "LSR", "LSRK", "LSRD",
                                "GALACTIC_CENTER", "LOCAL_GROUP_CENTER"]
+
+
+def get_ctype_from_ucd(ucd):
+    """ Return CTYPE string corresponding to a UCD1 value."""
+    return UCD1_TO_CTYPE.get(ucd, "")
 
 
 class CoordinateFrame:
@@ -474,7 +507,6 @@ class TemporalFrame(CoordinateFrame):
 
         else:
             return time.Time(dt, **kwargs)
-
 
     def coordinate_to_quantity(self, *coords):
         if isinstance(coords[0], time.Time):


### PR DESCRIPTION
This is implemented as a function because it includes the straightforward cases only. When ucd is, e.g. `time` more information may be needed to determine the correct CTYPE.