### PR TITLE
make bounding-box optional

### DIFF
--- a/gwcs/coordinate_frames.py
+++ b/gwcs/coordinate_frames.py
@@ -54,7 +54,19 @@ STANDARD_REFERENCE_POSITION = ["GEOCENTER", "BARYCENTER", "HELIOCENTER",
 
 
 def get_ctype_from_ucd(ucd):
-    """ Return the FITS ``CTYPE`` corresponding to a UCD1 value."""
+    """
+    Return the FITS ``CTYPE`` corresponding to a UCD1 value.
+
+    Parameters
+    ----------
+    ucd : str
+        UCD string, for example one of ```WCS.world_axis_physical_types``.
+
+    Returns
+    -------
+    CTYPE : str
+        The corresponding FITS ``CTYPE`` value or an empty string.
+    """
     return UCD1_TO_CTYPE.get(ucd, "")
 
 

--- a/gwcs/tests/test_wcs.py
+++ b/gwcs/tests/test_wcs.py
@@ -500,7 +500,17 @@ def test_to_fits_sip():
     fitsvalx, fitsvaly = fitssip.all_pix2world(xflat+1, yflat+1, 1)
     gwcsvalx, gwcsvaly = miriwcs(xflat, yflat)
     assert_allclose(gwcsvalx, fitsvalx, atol=1e-10, rtol=0)
-    assert_allclose(gwcsvaly, fitsvaly, atol=1e-10, rtol=0)    
+    assert_allclose(gwcsvaly, fitsvaly, atol=1e-10, rtol=0)
     fits_inverse_valx, fits_inverse_valy = fitssip.all_world2pix(fitsvalx, fitsvaly, 1)
     assert_allclose(xflat, fits_inverse_valx - 1, atol=0.1, rtol=0)
     assert_allclose(yflat, fits_inverse_valy - 1, atol=0.1, rtol=0)
+
+    mirisip = miriwcs.to_fits_sip(bounding_box=None, max_inv_pix_error=0.1)
+    fitssip = astwcs.WCS(mirisip)
+    fitsvalx, fitsvaly = fitssip.all_pix2world(xflat+1, yflat+1, 1)
+    assert_allclose(gwcsvalx, fitsvalx, atol=1e-10, rtol=0)
+    assert_allclose(gwcsvaly, fitsvaly, atol=1e-10, rtol=0)
+
+    with pytest.raises(ValueError):
+        miriwcs.bounding_box = None
+        mirisip = miriwcs.to_fits_sip(bounding_box=None, max_inv_pix_error=0.1)

--- a/gwcs/wcs.py
+++ b/gwcs/wcs.py
@@ -703,13 +703,12 @@ class WCS(GWCSAPIMixin):
 
         transform = self.forward_transform
         # Determine reference points.
-        if bounding_box is not None:
-            (xmin, xmax), (ymin, ymax) = bounding_box
-        else:
-            try:
-                (xmin, xmax), (ymin, ymax) = self.bounding_box
-            except KeyError:
-                raise TypeError("A bounding_box is needed to proceed.")
+        if bounding_box is None and self.bounding_box is None:
+            raise ValueError("A bounding_box is needed to proceed.")
+        if bounding_box is None:
+            bounding_box = self.bounding_box
+
+        (xmin, xmax), (ymin, ymax) = bounding_box
         crpix1 = (xmax - xmin) // 2
         crpix2 = (ymax - ymin) // 2
         crval1, crval2 = transform(crpix1, crpix2)

--- a/gwcs/wcs.py
+++ b/gwcs/wcs.py
@@ -5,7 +5,7 @@ import numpy as np
 import numpy.linalg as npla
 from astropy.modeling.core import Model # , fix_inputs
 from astropy.modeling import utils as mutils
-from astropy.modeling.models import (Shift, Polynomial2D, Sky2Pix_TAN, 
+from astropy.modeling.models import (Shift, Polynomial2D, Sky2Pix_TAN,
                                      RotateCelestial2Native)
 from astropy.modeling.fitting import LinearLSQFitter
 import astropy.io.fits as fits
@@ -641,8 +641,8 @@ class WCS(GWCSAPIMixin):
         new_pipeline.extend(self.pipeline[1:])
         return self.__class__(new_pipeline)
 
-    def to_fits_sip(self, bounding_box, max_pix_error=0.25, degree=None,
-                    max_inv_pix_error=0.25, inv_degree=None, 
+    def to_fits_sip(self, bounding_box=None, max_pix_error=0.25, degree=None,
+                    max_inv_pix_error=0.25, inv_degree=None,
                     npoints=32, verbose=False):
         """
         Construct a SIP-based approximation to the WCS in the form of a FITS header
@@ -654,7 +654,8 @@ class WCS(GWCSAPIMixin):
 
         Parameters
         ----------
-        bounding_box : a pair of tuples, each consisting of two numbers
+        bounding_box : tuple, optional
+            A pair of tuples, each consisting of two numbers
             Represents the range of pixel values in both dimensions
             ((xmin, xmax), (ymin, ymax))
         max_pix_error : float, optional
@@ -702,7 +703,13 @@ class WCS(GWCSAPIMixin):
 
         transform = self.forward_transform
         # Determine reference points.
-        (xmin, xmax), (ymin, ymax) = bounding_box
+        if bounding_box is not None:
+            (xmin, xmax), (ymin, ymax) = bounding_box
+        else:
+            try:
+                (xmin, xmax), (ymin, ymax) = self.bounding_box
+            except KeyError:
+                raise TypeError("A bounding_box is needed to proceed.")
         crpix1 = (xmax - xmin) // 2
         crpix2 = (ymax - ymin) // 2
         crval1, crval2 = transform(crpix1, crpix2)
@@ -755,7 +762,7 @@ class WCS(GWCSAPIMixin):
         detd = cdmat[0][0] * cdmat[1][1] - cdmat[0][1] * cdmat[1][0]
         Ud = ( cdmat[1][1] * undist_xd - cdmat[0][1] * undist_yd) / detd
         Vd = (-cdmat[1][0] * undist_xd + cdmat[0][0] * undist_yd) / detd
-  
+
         if max_inv_pix_error:
             fit_inv_poly_u, fit_inv_poly_v, max_inv_resid = _fit_2D_poly(ntransform,
                                                             npoints, None,
@@ -848,7 +855,7 @@ def _make_sampling_grid(npoints, bounding_box):
     u = x - crpix1
     v = y - crpix2
     return u, v
- 
+
 def _compute_distance_residual(undist_x, undist_y, fit_poly_x, fit_poly_y):
     """
     Compute the distance residuals and return the rms and maximum values.


### PR DESCRIPTION
This is a simple PR which implements what we discussed already - making the bounding-box optional in `to_fits_sip`. 
There's also a docstring update to an unrelated function.