### PR TITLE
Fix 0/1-indexing bug in make_fitswcs_transform()

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,11 @@ New Features
 
 - Added ``get_ctype_from_ucd`` function. [#288]
 
+Bug Fixes
+^^^^^^^^^
+
+- Fixed an off by one issue in ``utils.make_fitswcs_transform``. [#290]
+
 0.12.0 (2019-12-24)
 -------------------
 New Features

--- a/gwcs/tests/test_utils.py
+++ b/gwcs/tests/test_utils.py
@@ -30,7 +30,7 @@ def test_fits_transform():
     hdr = fits.Header.fromfile(get_pkg_data_filename('data/simple_wcs2.hdr'))
     gw1 = gwutils.make_fitswcs_transform(hdr)
     w1 = fitswcs.WCS(hdr)
-    assert_allclose(gw1(1, 2), w1.wcs_pix2world(1, 2, 1), atol=10 ** -8)
+    assert_allclose(gw1(1, 2), w1.wcs_pix2world(1, 2, 0), atol=10 ** -8)
 
 
 def test_lon_pole():
@@ -61,12 +61,10 @@ def test_unknown_ctype():
     transform = gwutils.make_fitswcs_transform(wcsinfo)
     x = np.linspace(-5, 7, 10)
     y = np.linspace(-5, 7, 10)
-    expected = (np.array([-0.00079444, -0.0007463, -0.00069815, -0.00065, -0.00060185,
-                          -0.0005537, -0.00050556, -0.00045741, -0.00040926, -0.00036111]
-                         ),
-                np.array([-0.00075833, -0.00071019, -0.00066204, -0.00061389, -0.00056574,
-                          -0.00051759, -0.00046944, -0.0004213, -0.00037315, -0.000325]
-                         )
+    expected = (np.array([-0.00075833, -0.00071019, -0.00066204, -0.00061389, -0.00056574,
+                          -0.00051759, -0.00046944, -0.0004213 , -0.00037315, -0.000325]),
+                np.array([-0.00072222, -0.00067407, -0.00062593, -0.00057778, -0.00052963,
+                           -0.00048148, -0.00043333, -0.00038519, -0.00033704, -0.00028889])
                 )
     a, b = transform(x, y)
     assert_allclose(a, expected[0], atol=10**-8)

--- a/gwcs/utils.py
+++ b/gwcs/utils.py
@@ -375,7 +375,7 @@ def fitswcs_linear(header):
     # raise DimensionsError("WCSLinearTransform supports only 2 or 3 dimensions, "
     # "{0} given".format(wcsaxes))
 
-    translation_models = [astmodels.Shift(-shift, name='crpix' + str(i + 1))
+    translation_models = [astmodels.Shift(-(shift - 1), name='crpix' + str(i + 1))
                           for i, shift in enumerate(crpix)]
     translation = functools.reduce(lambda x, y: x & y, translation_models)
 


### PR DESCRIPTION
Since FITS CRPIXi values are 1-indexed and python/gWCS is 0-indexed, the Shifts introduced when constructing a gWCS object from FITS header keywords need to be 1 less than the CRPIX values. I've made that change and this now passes if `hdr` is a `fits.Header` object:

```
gw = gwcs.utils.make_fitswcs_transform(hdr)
w = astropy.wcs.WCS(hdr)
x, y = hdr['CRPIX1'], hdr['CRPIX2']
np.testing.assert_allclose(gw(x-1, y-1), w.all_pix2world(x, y, 1))
```