### PR TITLE
Fix a bug in polygon fill for zero-width bounding boxes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,11 @@
 0.13.1 (Unreleased)
 
+Bug Fixes
+^^^^^^^^^
+
+- Fix a bug in polygon fill for zero-width bounding boxes. [#293]
+
+
 0.13.0 (2020-03-26)
 -------------------
 New Features

--- a/gwcs/region.py
+++ b/gwcs/region.py
@@ -157,6 +157,9 @@ class Polygon(Region):
         # 2. Currently it uses intersection of the scan line with edges. If this is
         # too slow it should use the 1/m increment (replace 3 above) (or the increment
         # should be removed from the GET entry).
+        if self._bbox[2] <= 0:
+            return data
+
         y = np.min(list(self._GET.keys()))
         AET = []
         scline = self._scan_line_range[-1]
@@ -311,6 +314,9 @@ class Edge:
         u = self._stop - self._start
         v = edge._stop - edge._start
         w = self._start - edge._start
+        eps = 1e2 * np.finfo(np.float).eps
+        if np.allclose(np.cross(u, v), 0, rtol=0, atol=eps):
+            return np.array(self._start)
         D = np.cross(u, v)
         return np.cross(v, w) / D * u + self._start
 

--- a/gwcs/tests/test_region.py
+++ b/gwcs/tests/test_region.py
@@ -74,6 +74,14 @@ def test_polygon1():
     assert_equal(mask, pol1)
 
 
+def test_polygon_zero_width_bbox():
+    vert = [(1, 1), (1, 3), (1, 6), (1, 1)]
+    pol = region.Polygon('1', vert)
+    mask = np.zeros((9, 9), dtype=np.int)
+    mask = pol.scan(mask)
+    assert not np.any(mask)
+
+
 def test_create_mask_two_polygons():
     vertices = {1: [[2, 1], [3, 5], [6, 6], [3, 8], [0, 4], [2, 1]],
                 2: [[10, 0], [30, 0], [30, 30], [10, 30], [10, 0]]}


### PR DESCRIPTION
This fixes a crash when bounding box of the polygon is of zero width.
This PR mirrors the PRs from `stsci.skypac`: https://github.com/spacetelescope/stsci.skypac/pull/52 and https://github.com/spacetelescope/stsci.skypac/pull/55