### PR TITLE
Remove .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "astropy-helpers"]
-	path = astropy_helpers
-	url = https://github.com/astropy/astropy-helpers.git


### PR DESCRIPTION
This file is no longer needed.  Followup to #249.