### PR TITLE
insert_frame() method

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,4 +1,9 @@
 0.15.0 (Unreleased)
+-------------------
+New Features
+^^^^^^^^^^^^
+
+- Added ``insert_frame`` method to modify the pipeline of a ``WCS`` object. [#299]
 
 0.14.0 (2020-08-19)
 -------------------
@@ -20,7 +25,6 @@ Bug Fixes
 - Fix a bug in polygon fill for zero-width bounding boxes. [#293]
 
 - Add an optional parameter ``input_frame`` to ``wcstools.wcs_from_fiducial`. [#312]
-
 
 0.13.0 (2020-03-26)
 -------------------


### PR DESCRIPTION
Resolves #81 

This PR adds a new method to `gwcs.wcs.WCS` called `insert_frame()` that allows a new frame to be inserted into the pipeline of a `WCS` object. It takes 3 required arguments: an input frame, a transform, and an output frame. Exactly one of those frames must exist in the pipeline and only its name must be provided (if a `coordinate_frame` object is provided, only the name will be used).

Consider a pipeline `[ (A, a), (B, b), (C, None) ]` where capital letters are coordinate frames and lowercase letters are transforms.

If the input frame already exists, then the transform and output frame will be inserted directly after it, so `insert_frame(B, x, X)` will produce `[ (A, a), (B, x), (X, b), (C, None) ]`

If the output frame already exists, then the input frame and transform will be inserted directly before it, so `insert_frame(X, x, B)` will produce `[ (A, a), (X, x), (B, b), (C, None) ]`

A frame can of course be appended to the end with `w.insert_frame(w.output_frame, forward_transform, new_output_frame)`