### PR TITLE
MNT: Ignore import error in pytest collection

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,7 @@ norecursedirs = build docs/_build
 doctest_plus = enabled
 asdf_schema_tests_enabled = true
 asdf_schema_root = gwcs/schemas
-addopts = --doctest-rst
+addopts = --doctest-rst --doctest-ignore-import-errors
 
 
 [flake8]


### PR DESCRIPTION
This is an automated update made by the `batchpr` tool :robot: to future-proof test collection behavior `pytest-doctestplus` - feel free to close if it doesn't look good or isn't relevant! You can report issues to @pllim.