### PR TITLE
Update schemas that reference transform-1.1.0 to reference transform-1.2.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,4 +1,10 @@
-0.13.1 (Unreleased)
+0.14.0 (Unreleased)
+-------------------
+New Features
+^^^^^^^^^^^^
+
+- Updated versions of schemas for gwcs objects based on latest versions of
+  transform schemas in asdf-standard. [#307]
 
 Bug Fixes
 ^^^^^^^^^

--- a/gwcs/schemas/stsci.edu/gwcs/direction_cosines-1.1.0.yaml
+++ b/gwcs/schemas/stsci.edu/gwcs/direction_cosines-1.1.0.yaml
@@ -1,0 +1,38 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://stsci.edu/schemas/gwcs/direction_cosines-1.1.0"
+tag: "tag:stsci.edu:gwcs/direction_cosines-1.1.0"
+
+title: >
+  Convert coordinates between vector and direction cosine form.
+
+description: |
+  This schema is for transforms which convert to and from direction cosines.
+
+examples:
+  -
+    - Convert direction cosines to vectors.
+
+    - |
+
+        !<tag:stsci.edu:gwcs/direction_cosines-1.1.0>
+          transform_type: from_direction_cosines
+
+  -
+    - Convert vectors to directional cosines.
+
+    - |
+        !<tag:stsci.edu:gwcs/direction_cosines-1.1.0>
+          transform_type: to_direction_cosines
+
+allOf:
+  - $ref:  "tag:stsci.edu:asdf/transform/transform-1.2.0"
+  - object:
+    properties:
+      transform_type:
+        description: |
+          The type of transform/class to initialize.
+        type: string
+        enum: [to_direction_cosines, from_direction_cosines]
+    required: [transform_type]

--- a/gwcs/schemas/stsci.edu/gwcs/grating_equation-1.1.0.yaml
+++ b/gwcs/schemas/stsci.edu/gwcs/grating_equation-1.1.0.yaml
@@ -1,0 +1,52 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://stsci.edu/schemas/gwcs/grating_equation-1.1.0"
+tag: "tag:stsci.edu:gwcs/grating_equation-1.1.0"
+
+title: >
+  A grating equation model.
+description: |
+  Supports two models:
+   - Given incident angle and wavelength compute the refraction/difraction angle.
+   - Given an incident angle and a refraction angle compute the wavelength.
+
+examples:
+  -
+    - AnglesFromGratingEquation3D model.
+
+    - |
+        !<tag:stsci.edu:gwcs/grating_equation-1.1.0>
+          groove_density: 2700.0
+          order: 2.0
+          output: angle
+
+  -
+    - WavelengthFromGratingEquation model.
+
+    - |
+        !<tag:stsci.edu:gwcs/grating_equation-1.1.0>
+          groove_density: 2700.0
+          order: 2.0
+          output: wavelength
+
+allOf:
+  - $ref: "tag:stsci.edu:asdf/transform/transform-1.2.0"
+  - type: object
+    properties:
+      groove_density:
+        description: |
+          The groove density of the grating
+        anyOf:
+          - type: number
+          - $ref: "tag:stsci.edu:asdf/unit/quantity-1.1.0"
+      order:
+        description: |
+          Spectral order
+        type: number
+      output:
+        type: string
+        description: |
+          indicates which quantity the grating equation is solved for.
+        enum: [wavelength, angle]
+    required: [groove_density, order, output]

--- a/gwcs/schemas/stsci.edu/gwcs/label_mapper-1.1.0.yaml
+++ b/gwcs/schemas/stsci.edu/gwcs/label_mapper-1.1.0.yaml
@@ -1,0 +1,130 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://stsci.edu/schemas/gwcs/label_mapper-1.1.0"
+tag: "tag:stsci.edu:gwcs/label_mapper-1.1.0"
+title: >
+  Represents a mapping from a coordinate value to a label.
+description: |
+  A label mapper instance maps inputs to a label.  It is used together
+  with
+  [regions_selector](ref:regions_selector-1.1.0). The
+  [label_mapper](ref:label_mapper-1.1.0)
+  returns the label corresponding to given inputs. The
+  [regions_selector](ref:regions_selector-1.1.0)
+  returns the transform corresponding to this label. This maps inputs
+  (e.g. pixels on a detector) to transforms uniquely.
+
+examples:
+  -
+    - Map array indices are to labels.
+
+    - |
+        !<tag:stsci.edu:gwcs/label_mapper-1.1.0>
+          mapper: !core/ndarray-1.0.0
+            data:
+            - [1, 0, 2]
+            - [1, 0, 2]
+            - [1, 0, 2]
+            datatype: int64
+            shape: [3, 3]
+            no_label: 0
+
+  -
+    - Map numbers dictionary to transforms which return labels.
+
+    - |
+        !<tag:stsci.edu:gwcs/label_mapper-1.1.0>
+          atol: 1.0e-08
+          inputs: [x, y]
+          inputs_mapping: !transform/remap_axes-1.3.0
+              mapping: [0]
+              n_inputs: 2
+          mapper: !!omap
+            - !!omap
+              labels: [-1.67833272, -1.9580548, -1.118888]
+            - !!omap
+              models:
+              - !transform/shift-1.2.0 {offset: 6.0}
+              - !transform/shift-1.2.0 {offset: 2.0}
+              - !transform/shift-1.2.0 {offset: 4.0}
+          no_label: 0
+
+  -
+    - Map a number within a range of numbers to transforms which return labels.
+
+    - |
+        !<tag:stsci.edu:gwcs/label_mapper-1.1.0>
+          mapper: !!omap
+          - !!omap
+            labels:
+            - [3.2, 4.1]
+            - [2.67, 2.98]
+            - [1.95, 2.3]
+          - !!omap
+            models:
+            - !transform/shift-1.2.0 {offset: 6.0}
+            - !transform/shift-1.2.0 {offset: 2.0}
+            - !transform/shift-1.2.0 {offset: 4.0}
+          inputs: [x, y]
+          inputs_mapping: !transform/remap_axes-1.3.0
+            mapping: [0]
+            n_inputs: 2
+
+allOf:
+  - $ref: "tag:stsci.edu:asdf/transform/transform-1.2.0"
+  - type: object
+    properties:
+      mapper:
+        description: |
+          A mapping of inputs to labels.
+          In the general case this is a `astropy.modeling.core.Model`.
+
+          It could be a numpy array with the shape of the detector/observation.
+          Pixel values are of type integer or string and represent
+          region labels. Pixels which are not within any region have value ``no_label``.
+
+          It could be a dictionary which maps tuples to labels or floating point numbers to labels.
+
+        anyOf:
+          - $ref: "tag:stsci.edu:asdf/core/ndarray-1.0.0"
+          - $ref: "tag:stsci.edu:asdf/transform/transform-1.2.0"
+          - type: object
+            properties:
+              labels:
+                type: array
+                items:
+                  anyOf:
+                    - type: number
+                    - type: array
+                      items:
+                        type: number
+                      minLength: 2
+                      maxLength: 2
+              models:
+                type: array
+                items:
+                  $ref: "tag:stsci.edu:asdf/transform/transform-1.2.0"
+
+      inputs:
+        type: array
+        items:
+          type: string
+        description: |
+          Names of inputs.
+      inputs_mapping:
+        $ref: "tag:stsci.edu:asdf/transform/transform-1.2.0"
+        description: |
+          [mapping](https://asdf-standard.readthedocs.io/en/latest/generated/stsci.edu/asdf/transform/remap_axes-1.3.0.html)
+      atol:
+        type: number
+        description: |
+          absolute tolerance to compare keys in mapper.
+      no_label:
+        description: |
+          Fill in value for missing output.
+        anyOf:
+          - type: number
+          - type: string
+
+    required: [mapper]

--- a/gwcs/schemas/stsci.edu/gwcs/regions_selector-1.1.0.yaml
+++ b/gwcs/schemas/stsci.edu/gwcs/regions_selector-1.1.0.yaml
@@ -1,0 +1,104 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://stsci.edu/schemas/gwcs/regions_selector-1.1.0"
+tag: "tag:stsci.edu:gwcs/regions_selector-1.1.0"
+title: >
+  Represents a discontinuous transform.
+description: |
+  Maps regions to transgorms and evaluates the transforms with the corresponding inputs.
+
+examples:
+  -
+    - Create a regions_selector schema for 2 regions, labeled "1" and "2".
+    - |
+        !<tag:stsci.edu:gwcs/regions_selector-1.1.0>
+          inputs: [x, y]
+          label_mapper: !<tag:stsci.edu:gwcs/label_mapper-1.1.0>
+            mapper: !core/ndarray-1.0.0
+              datatype: int8
+              data:
+              - [0, 1, 1, 0, 2, 0]
+              - [0, 1, 1, 0, 2, 0]
+              - [0, 1, 1, 0, 2, 0]
+              - [0, 1, 1, 0, 2, 0]
+              - [0, 1, 1, 0, 2, 0]
+              datatype: int64
+              shape: [5, 6]
+          no_label: 0
+          outputs: [ra, dec, lam]
+          selector: !!omap
+          - !!omap
+            labels: [1, 2]
+          - !!omap
+            transforms:
+            - !transform/compose-1.2.0
+              forward:
+              - !transform/remap_axes-1.3.0
+                mapping: [0, 1, 1]
+              - !transform/concatenate-1.2.0
+                forward:
+                - !transform/concatenate-1.2.0
+                  forward:
+                  - !transform/shift-1.2.0 {offset: 1.0}
+                  - !transform/shift-1.2.0 {offset: 2.0}
+                - !transform/shift-1.2.0 {offset: 3.0}
+            - !transform/compose-1.2.0
+              forward:
+              - !transform/remap_axes-1.3.0
+                mapping: [0, 1, 1]
+              - !transform/concatenate-1.2.0
+                forward:
+                - !transform/concatenate-1.2.0
+                  forward:
+                  - !transform/scale-1.2.0 {factor: 2.0}
+                  - !transform/scale-1.2.0 {factor: 3.0}
+                - !transform/scale-1.2.0 {factor: 3.0}
+          undefined_transform_value: .nan
+
+
+allOf:
+  - $ref: "tag:stsci.edu:asdf/transform/transform-1.2.0"
+  - type: object
+    properties:
+      label_mapper:
+        description: |
+          An instance of
+          [label_mapper-1.1.0](ref:label_mapper-1.1.0)
+        $ref: "./label_mapper-1.1.0"
+      inputs:
+        description: |
+          Names of inputs.
+        type: array
+        items:
+          type: string
+      outputs:
+        description: |
+          Names of outputs.
+        type: array
+        items:
+          type: string
+      selector:
+        description: |
+          A mapping of regions to trransforms.
+        type: object
+        properties:
+          labels:
+            description: |
+              An array of unique region labels.
+            type: array
+            items:
+              type:
+                - integer
+                - string
+          transforms:
+            description: |
+              A transform for each region. The order should match the order of labels.
+            type: array
+            items:
+              $ref: "tag:stsci.edu:asdf/transform/transform-1.2.0"
+      undefined_transform_value:
+        description: |
+          Value to be returned if there's no transform defined for the inputs.
+        type: number
+    required: [label_mapper, inputs, outputs, selector]

--- a/gwcs/schemas/stsci.edu/gwcs/sellmeier_glass-1.1.0.yaml
+++ b/gwcs/schemas/stsci.edu/gwcs/sellmeier_glass-1.1.0.yaml
@@ -1,0 +1,38 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://stsci.edu/schemas/gwcs/sellmeier_glass-1.1.0"
+tag: "tag:stsci.edu:gwcs/sellmeier_glass-1.1.0"
+title: Sellmeier equation for glass
+
+description: |
+  Sellmeier equation for glass.
+
+  $$ n(\\lambda)^2 = 1 + \\frac{(B1 * \\lambda^2 )}{(\\lambda^2 - C1)} +
+     \\frac{(B2 * \\lambda^2 )}{(\\lambda^2 - C2)} +
+     \\frac{(B3 * \\lambda^2 )}{(\\lambda^2 - C3)} $$
+
+allOf:
+  - $ref: "tag:stsci.edu:asdf/transform/transform-1.2.0"
+  - type: object
+    properties:
+      B_coef:
+        description: |
+          B coefficients in Sellmeier equation.
+        anyOf:
+          - type: array
+          - $ref: "tag:stsci.edu:asdf/core/ndarray-1.0.0"
+        items:
+          type: number
+        minItems: 3
+        maxItems: 3
+      C_coef:
+        description: |
+          C coefficients in Sellmeier equation.
+        anyOf:
+          - type: array
+          - $ref: "tag:stsci.edu:asdf/core/ndarray-1.0.0"
+        items:
+          type: number
+        minItems: 3
+        maxItems: 3

--- a/gwcs/schemas/stsci.edu/gwcs/sellmeier_zemax-1.1.0.yaml
+++ b/gwcs/schemas/stsci.edu/gwcs/sellmeier_zemax-1.1.0.yaml
@@ -1,0 +1,72 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://stsci.edu/schemas/gwcs/sellmeier_zemax-1.1.0"
+tag: "tag:stsci.edu:gwcs/sellmeier_zemax-1.1.0"
+title: Sellmeier equation for glass used by Zemax
+
+description: |
+  Sellmeier equation for glass used by Zemax
+
+allOf:
+  - $ref: "tag:stsci.edu:asdf/transform/transform-1.2.0"
+  - type: object
+    properties:
+      B_coef:
+        description: |
+          B coefficients in Sellmeier equation.
+        anyOf:
+          - type: array
+          - $ref: "tag:stsci.edu:asdf/core/ndarray-1.0.0"
+        items:
+          type: number
+        minItems: 3
+        maxItems: 3
+      C_coef:
+        description: |
+          C coefficients in Sellmeier equation.
+        anyOf:
+          - type: array
+          - $ref: "tag:stsci.edu:asdf/core/ndarray-1.0.0"
+        items:
+          type: number
+        minItems: 3
+        maxItems: 3
+      D_coef:
+        description: |
+          Thermal D coefficients of the glass.
+        anyOf:
+          - type: array
+          - $ref: "tag:stsci.edu:asdf/core/ndarray-1.0.0"
+        items:
+          type: number
+        minItems: 3
+        maxItems: 3
+      E_coef:
+        description: |
+          Thermal E coefficients of the glass.
+        anyOf:
+          - type: array
+          - $ref: "tag:stsci.edu:asdf/core/ndarray-1.0.0"
+        items:
+          type: number
+        minItems: 3
+        maxItems: 3
+      ref_temperature:
+        description: |
+          Reference temperature of the glass in Kelvin.
+        type: number
+      ref_pressure:
+        description: |
+          Reference pressure of the glass in ATM.
+        type: number
+      temperature:
+        description: |
+          System temperature in Kelvin.
+        type: number
+      pressure:
+        description: |
+          System pressure in ATM.
+        type: number
+    required: [B_coef, C_coef, D_coef, E_coef, ref_temperature,
+               ref_pressure, temperature, pressure]

--- a/gwcs/schemas/stsci.edu/gwcs/snell3d-1.1.0.yaml
+++ b/gwcs/schemas/stsci.edu/gwcs/snell3d-1.1.0.yaml
@@ -1,0 +1,13 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://stsci.edu/schemas/gwcs/snell3d-1.1.0"
+tag: "tag:stsci.edu:gwcs/snell3d-1.1.0"
+title: Snell Law in 3D space
+
+description: |
+  Snell Law in 3D.
+  Inputs are index of refraction and direction cosines.
+  Outputs are direction cosines.
+
+$ref: "tag:stsci.edu:asdf/transform/transform-1.2.0"

--- a/gwcs/schemas/stsci.edu/gwcs/spherical_cartesian-1.1.0.yaml
+++ b/gwcs/schemas/stsci.edu/gwcs/spherical_cartesian-1.1.0.yaml
@@ -1,0 +1,44 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://stsci.edu/schemas/gwcs/spherical_cartesian-1.1.0"
+tag: "tag:stsci.edu:gwcs/spherical_cartesian-1.1.0"
+
+title: >
+  Convert coordinates between spherical and Cartesian coordinates.
+
+description: |
+  This schema is for transforms which convert between spherical coordinates
+  (on the unit sphere) and Cartesian coordinates.
+
+examples:
+  -
+    - Convert spherical coordinates to Cartesian coordinates.
+
+    - |
+
+        !<tag:stsci.edu:gwcs/spherical_cartesian-1.1.0>
+          transform_type: spherical_to_cartesian
+
+  -
+    - Convert Cartesian coordinates to spherical coordinates.
+
+    - |
+        !<tag:stsci.edu:gwcs/spherical_cartesian-1.1.0>
+          transform_type: cartesian_to_spherical
+
+allOf:
+  - $ref:  "tag:stsci.edu:asdf/transform/transform-1.2.0"
+  - object:
+    properties:
+      wrap_lon_at:
+        description: Angle at which to wrap the longitude angle.
+        type: integer
+        enum: [180, 360]
+        default: 360
+      transform_type:
+        description: The type of transform/class to initialize.
+        type: string
+        enum: [spherical_to_cartesian, cartesian_to_spherical]
+
+    required: [transform_type, wrap_lon_at]

--- a/gwcs/schemas/stsci.edu/gwcs/step-1.1.0.yaml
+++ b/gwcs/schemas/stsci.edu/gwcs/step-1.1.0.yaml
@@ -1,0 +1,32 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://stsci.edu/schemas/gwcs/step-1.1.0"
+tag: "tag:stsci.edu:gwcs/step-1.1.0"
+
+title: >
+  Describes a single step of a WCS transform pipeline.
+description: >
+examples: []
+
+type: object
+properties:
+  frame:
+    description: |
+      The frame of the inputs to the transform.
+    anyOf:
+      - type: string
+      - $ref: frame-1.0.0
+
+  transform:
+    description: |
+      The transform from this step to the next one.  The
+      last step in a WCS should not have a transform, but
+      exists only to describe the frames and units of the
+      final output axes.
+    anyOf:
+      - $ref: "tag:stsci.edu:asdf/transform/transform-1.2.0"
+      - type: 'null'
+    default: null
+
+required: [frame]

--- a/gwcs/schemas/stsci.edu/gwcs/wcs-1.1.0.yaml
+++ b/gwcs/schemas/stsci.edu/gwcs/wcs-1.1.0.yaml
@@ -1,0 +1,33 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://stsci.edu/schemas/gwcs/wcs-1.1.0"
+tag: "tag:stsci.edu:gwcs/wcs-1.1.0"
+
+title: >
+  A system for describing generalized world coordinate transformations.
+description: >
+  ASDF WCS is a way of specifying transformations (usually from
+  detector space to world coordinate space and back) by using the
+  transformations in the `transform-schema` module.
+type: object
+properties:
+  name:
+    description: |
+      A descriptive name for this WCS.
+    type: string
+
+  steps:
+    description: |
+      A list of steps in the forward transformation from detector to
+      world coordinates.
+      The inverse transformation is determined automatically by
+      reversing this list, and inverting each of the individual
+      transforms according to the rules described in
+      [inverse](https://asdf-standard.readthedocs.io/en/latest/generated/stsci.edu/asdf/transform/transform-1.2.0.html#inverse).
+    type: array
+    items:
+      $ref: step-1.1.0
+
+required: [name, steps]
+additionalProperties: true

--- a/gwcs/tags/geometry_models.py
+++ b/gwcs/tags/geometry_models.py
@@ -13,7 +13,7 @@ __all__ = ['DirectionCosinesType', 'SphericalCartesianType']
 class DirectionCosinesType(GWCSTransformType):
     name = "direction_cosines"
     types = [ToDirectionCosines, FromDirectionCosines]
-    version = "1.0.0"
+    version = "1.1.0"
 
     @classmethod
     def from_tree_transform(cls, node, ctx):
@@ -40,7 +40,7 @@ class DirectionCosinesType(GWCSTransformType):
 class SphericalCartesianType(GWCSTransformType):
     name = "spherical_cartesian"
     types = [SphericalToCartesian, CartesianToSpherical]
-    version = "1.0.0"
+    version = "1.1.0"
 
     @classmethod
     def from_tree_transform(cls, node, ctx):

--- a/gwcs/tags/selectortags.py
+++ b/gwcs/tags/selectortags.py
@@ -22,7 +22,7 @@ __all__ = ['LabelMapperType', 'RegionsSelectorType']
 class LabelMapperType(GWCSTransformType):
     name = "label_mapper"
     types = [LabelMapperArray, LabelMapperDict, LabelMapperRange, LabelMapper]
-    version = "1.0.0"
+    version = "1.1.0"
 
     @classmethod
     def from_tree_transform(cls, node, ctx):
@@ -107,7 +107,7 @@ class LabelMapperType(GWCSTransformType):
 class RegionsSelectorType(GWCSTransformType):
     name = "regions_selector"
     types = [RegionsSelector]
-    version = "1.0.0"
+    version = "1.1.0"
 
     @classmethod
     def from_tree_transform(cls, node, ctx):

--- a/gwcs/tags/spectroscopy_models.py
+++ b/gwcs/tags/spectroscopy_models.py
@@ -20,7 +20,7 @@ __all__ = ['GratingEquationType', 'SellmeierGlassType',
 class SellmeierGlassType(GWCSTransformType):
     name = "sellmeier_glass"
     types = [SellmeierGlass]
-    version = "1.0.0"
+    version = "1.1.0"
 
     @classmethod
     def from_tree_transform(cls, node, ctx):
@@ -36,7 +36,7 @@ class SellmeierGlassType(GWCSTransformType):
 class SellmeierZemaxType(GWCSTransformType):
     name = "sellmeier_zemax"
     types = [SellmeierZemax]
-    version = "1.0.0"
+    version = "1.1.0"
 
     @classmethod
     def from_tree_transform(cls, node, ctx):
@@ -61,7 +61,7 @@ class SellmeierZemaxType(GWCSTransformType):
 class Snell3DType(GWCSTransformType):
     name = "snell3d"
     types = [Snell3D]
-    version = "1.0.0"
+    version = "1.1.0"
 
     @classmethod
     def from_tree_transform(cls, node, ctx):
@@ -74,7 +74,7 @@ class Snell3DType(GWCSTransformType):
 
 class GratingEquationType(GWCSTransformType):
     name = "grating_equation"
-    version = '1.0.0'
+    version = '1.1.0'
     types = [AnglesFromGratingEquation3D,
              WavelengthFromGratingEquation]
 

--- a/gwcs/tags/wcs.py
+++ b/gwcs/tags/wcs.py
@@ -21,7 +21,7 @@ class WCSType(GWCSType):
     name = "wcs"
     requires = _REQUIRES
     types = [WCS]
-    version = '1.0.0'
+    version = '1.1.0'
 
     @classmethod
     def from_tree(cls, node, ctx):
@@ -67,7 +67,7 @@ class WCSType(GWCSType):
 class StepType(dict, GWCSType):
     name = "step"
     requires = _REQUIRES
-    version = '1.0.0'
+    version = '1.1.0'
 
 
 class FrameType(GWCSType):


### PR DESCRIPTION
I updated the schemas that referenced transform-1.1.0 to reference transform-1.2.0 (and any other new gwcs schema version references), in a new version for each. I also updated schemas that don't reference transform directly, but that do reference another gwcs schema that does, and updated the tags to point to the latest version of each schema. 