### PR TITLE
fix slicing_api tests

### DIFF
--- a/gwcs/tests/test_api_slicing.py
+++ b/gwcs/tests/test_api_slicing.py
@@ -63,7 +63,8 @@ def test_ellipsis(gwcs_3d_galactic_spectral):
     assert_allclose(wcs.world_to_pixel_values(10, 20, 25), (29., 39., 44.))
     assert_equal(wcs.world_to_array_index_values(10, 20, 25), (44, 39, 29))
 
-    assert str(wcs) == repr(wcs) == EXPECTED_ELLIPSIS_REPR.strip()
+    assert str(wcs) == EXPECTED_ELLIPSIS_REPR.strip()
+    assert repr(wcs) in EXPECTED_ELLIPSIS_REPR.strip()
 
     assert_equal(wcs.pixel_bounds, [(-1, 35), (-2, 45), (5, 50)])
 
@@ -121,7 +122,8 @@ def test_spectral_slice(gwcs_3d_galactic_spectral):
 
     assert_equal(wcs.pixel_bounds, [(-1, 35), (5, 50)])
 
-    assert str(wcs) == repr(wcs) == EXPECTED_SPECTRAL_SLICE_REPR.strip()
+    assert str(wcs) == EXPECTED_SPECTRAL_SLICE_REPR.strip()
+    assert repr(wcs) in EXPECTED_SPECTRAL_SLICE_REPR.strip()
 
 
 EXPECTED_SPECTRAL_RANGE_REPR = """
@@ -185,7 +187,8 @@ def test_spectral_range(gwcs_3d_galactic_spectral):
 
     assert_equal(wcs.pixel_bounds, [(-1, 35), (-6, 41), (5, 50)])
 
-    assert str(wcs) == repr(wcs) == EXPECTED_SPECTRAL_RANGE_REPR.strip()
+    assert str(wcs) == EXPECTED_SPECTRAL_RANGE_REPR.strip()
+    assert repr(wcs) in EXPECTED_SPECTRAL_RANGE_REPR.strip()
 
 
 EXPECTED_CELESTIAL_SLICE_REPR = """
@@ -248,7 +251,8 @@ def test_celestial_slice(gwcs_3d_galactic_spectral):
 
     assert_equal(wcs.pixel_bounds, [(-2, 45), (5, 50)])
 
-    assert str(wcs) == repr(wcs) == EXPECTED_CELESTIAL_SLICE_REPR.strip()
+    assert str(wcs) == EXPECTED_CELESTIAL_SLICE_REPR.strip()
+    assert repr(wcs) in EXPECTED_CELESTIAL_SLICE_REPR.strip()
 
 
 EXPECTED_CELESTIAL_RANGE_REPR = """
@@ -312,7 +316,8 @@ def test_celestial_range(gwcs_3d_galactic_spectral):
 
     assert_equal(wcs.pixel_bounds, [(-6, 30), (-2, 45), (5, 50)])
 
-    assert str(wcs) == repr(wcs) == EXPECTED_CELESTIAL_RANGE_REPR.strip()
+    assert str(wcs) == EXPECTED_CELESTIAL_RANGE_REPR.strip()
+    assert repr(wcs) in EXPECTED_CELESTIAL_RANGE_REPR.strip()
 
 
 EXPECTED_NO_SHAPE_REPR = """
@@ -377,7 +382,8 @@ def test_no_array_shape(gwcs_3d_galactic_spectral):
     assert_allclose(wcs.world_to_pixel_values(10, 20, 25), (29., 39., 44.))
     assert_equal(wcs.world_to_array_index_values(10, 20, 25), (44, 39, 29))
 
-    assert str(wcs) == repr(wcs) == EXPECTED_NO_SHAPE_REPR.strip()
+    assert str(wcs) == EXPECTED_NO_SHAPE_REPR.strip()
+    assert repr(wcs) in EXPECTED_NO_SHAPE_REPR.strip()
 
 
 # Testing the WCS object having some physical types as None/Unknown
@@ -442,4 +448,5 @@ def test_ellipsis_none_types(gwcs_3d_galactic_spectral):
 
     assert_equal(wcs.pixel_bounds, [(-1, 35), (-2, 45), (5, 50)])
 
-    assert str(wcs) == repr(wcs) == EXPECTED_ELLIPSIS_REPR_NONE_TYPES.strip()
+    assert str(wcs) == EXPECTED_ELLIPSIS_REPR_NONE_TYPES.strip()
+    assert repr(wcs) in EXPECTED_ELLIPSIS_REPR_NONE_TYPES.strip()


### PR DESCRIPTION
`SlicedLowLevelWCS.__repr__` has changed in astropy 4.1 to include printing of the object which makes the tests in gwcs which compare the output or `repr` fail.
Instead of comparing the output the tests now check that the desired output text is in the repr.