### PR TITLE
Fix a bug when using CoordinateFrame directly

### DIFF
--- a/gwcs/coordinate_frames.py
+++ b/gwcs/coordinate_frames.py
@@ -270,7 +270,6 @@ class CoordinateFrame:
 
     def coordinates(self, *args):
         """ Create world coordinates object"""
-        args = [args[i] for i in self.axes_order]
         coo = tuple([arg * un if not hasattr(arg, "to") else arg.to(un) for arg, un in zip(args, self.unit)])
         return coo
 

--- a/gwcs/coordinate_frames.py
+++ b/gwcs/coordinate_frames.py
@@ -278,6 +278,10 @@ class CoordinateFrame:
         Given a rich coordinate object return an astropy quantity object.
         """
         # NoOp leaves it to the model to handle
+        # If coords is a 1-tuple of quantity then return the element of the tuple
+        # This aligns the behavior with the other implementations
+        if not hasattr(coords, 'unit') and len(coords) == 1:
+            return coords[0]
         return coords
 
     @property

--- a/gwcs/tests/test_coordinate_systems.py
+++ b/gwcs/tests/test_coordinate_systems.py
@@ -86,6 +86,16 @@ def test_coordinates_composite(inputs):
     assert_allclose(result[1].value, inputs[2])
 
 
+def test_coordinates_composite_order():
+    time = cf.TemporalFrame(Time("2011-01-01T00:00:00"), name='time', unit=[u.s, ], axes_order=(0, ))
+    dist = cf.CoordinateFrame(name='distance', naxes=1,
+                              axes_type=["SPATIAL"], unit=[u.m, ], axes_order=(1, ))
+    frame = cf.CompositeFrame([time, dist])
+    result = frame.coordinates(0, 0)
+    assert result[0] == Time("2011-01-01T00:00:00")
+    assert u.allclose(result[1], 0*u.m)
+
+
 @pytest.mark.parametrize(('frame'), coord_frames)
 def test_celestial_attributes_length(frame):
     """

--- a/gwcs/tests/test_coordinate_systems.py
+++ b/gwcs/tests/test_coordinate_systems.py
@@ -148,6 +148,10 @@ def test_base_coordinate():
     assert_quantity_allclose(q1, 12 * u.deg)
     assert_quantity_allclose(q2, 3 * u.arcsec)
 
+    q1, q2 = frame.coordinate_to_quantity((12 * u.deg, 3 * u.arcsec))
+    assert_quantity_allclose(q1, 12 * u.deg)
+    assert_quantity_allclose(q2, 3 * u.arcsec)
+
 
 def test_temporal_relative():
     t = cf.TemporalFrame(reference_frame=Time("2018-01-01T00:00:00"), unit=u.s)

--- a/gwcs/tests/test_coordinate_systems.py
+++ b/gwcs/tests/test_coordinate_systems.py
@@ -107,7 +107,7 @@ def test_bare_baseframe():
     w = WCS(forward_transform=m.Tabular1D(points=np.arange(10)*u.pix,
                                           lookup_table=np.arange(10)*u.km),
             output_frame=frame,
-            input_frame=cf.CoordinateFrame(1, "PIXEL", (0,), unit=(u.pix,))
+            input_frame=cf.CoordinateFrame(1, "PIXEL", (0,), unit=(u.pix,), name="detector_frame")
             )
     assert u.allclose(w.world_to_pixel(0*u.km), 0)
 

--- a/gwcs/wcs.py
+++ b/gwcs/wcs.py
@@ -496,7 +496,6 @@ class WCS(GWCSAPIMixin):
     def output_frame(self):
         """Return the output coordinate frame."""
         if self._pipeline:
-            #frame = self._pipeline[-1][0]
             frame = self._pipeline[-1].frame
             if not isinstance(frame, str):
                 frame = frame.name
@@ -508,7 +507,6 @@ class WCS(GWCSAPIMixin):
     def input_frame(self):
         """Return the input coordinate frame."""
         if self._pipeline:
-            #frame = self._pipeline[0][0]
             frame = self._pipeline[0].frame
             if not isinstance(frame, str):
                 frame = frame.name


### PR DESCRIPTION
I don't see any reason why CoordinateFrame should apply axes_order, I believe that's a global thing not per-frame?