### PR TITLE
Fix deprecated "ndarray from ragged nested sequences"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,10 @@
+os: linux
+dist: xenial
 language: python
 
-os: linux
 
 # Setting sudo to false opts in to Travis-CI container-based builds.
 sudo: false
-
-# The apt packages below are needed for sphinx builds, which can no longer
-# be installed with sudo apt-get.
-addons:
-    apt:
-        packages:
-            - graphviz
-            - texlive-latex-extra
-            - dvipng
 
 python:
   - 3.7
@@ -23,15 +15,13 @@ env:
         # The following versions are the 'default' for tests, unless
         # overidden underneath. They are defined here in order to save having
         # to repeat them for all configurations.
-        - NUMPY_VERSION=1.16
-        - ASDF_GIT='git+https://github.com/spacetelescope/asdf.git#egg=asdf'
-        #- CONDA_DEPENDENCIES='scipy'
-        #- ASTROPY_GIT='git+https://github.com/astropy/astropy.git@v3.1.x'
-        - ASTROPY_GIT='git+https://github.com/astropy/astropy.git#egg=astropy
-        - PIP_DEPENDENCIES=".[all]"
+        - NUMPY_VERSION="1.16"
+        - ASDF_GIT="git+https://github.com/spacetelescope/asdf.git#egg=asdf"
+        - ASTROPY_GIT="git+https://github.com/astropy/astropy.git#egg=astropy"
+        - PIP_DEPENDENCIES=.[test]
+        - TEST_COMMAND=pytest
 
-matrix:
-
+jobs:
     # Don't wait for allowed failures
     fast_finish: true
 
@@ -39,66 +29,55 @@ matrix:
 
         # Do a security check
         - env:
-            - TEST_COMMAND="bandit -r gwcs -c .bandit.yaml"
-            - PIP_DEPENDENCIES="bandit"
+            TEST_COMMAND="bandit -r gwcs -c .bandit.yaml"
+            PIP_DEPENDENCIES=bandit
 
         # Do a coverage test.
-        - python: 3.7
+        - python: "3.7"
           env:
-            - TEST_COMMAND='pytest --cov-config=gwcs/tests/coveragerc --cov=gwcs'
-            - PIP_DEPENDENCIES='.[test] coveralls pytest-cov'
+            TEST_COMMAND="pytest --cov-config=gwcs/tests/coveragerc --cov=gwcs"
+            PIP_DEPENDENCIES=".[test] coveralls pytest-cov"
 
         # Check for sphinx doc build warnings - we do this first because it
         # may run for a long time
-        - python: 3.7
+        - python: "3.8"
+          env: 
+            PIP_DEPENDENCIES=".[docs]"
+            TEST_COMMAND="make --directory=docs html"
+          addons:
+            apt:
+              packages:
+                - graphviz
+                - texlive-latex-extra
+                - dvipng
 
-          env: #PIP_DEPENDENCIES="$ASTROPY_GIT $ASDF_GIT sphinx sphinx-automodapi sphinx-rtd-theme stsci-rtd-theme sphinx-astropy -sphinx-asdf"
-               PIP_DEPENDENCIES=".[docs]"
-               TEST_COMMAND="make --directory=docs html"
-
-        - python: 3.6
+        - python: "3.6"
           env:
-            - NUMPY_VERSION=1.17
-            - PIP_DEPENDENCIES='.[test]'
-            - TEST_COMMAND="pytest"
+            NUMPY_VERSION="1.17"
 
-        - python: 3.7
+        - python: "3.7"
           env:
-            - NUMPY_VERSION=1.17
-            - PIP_DEPENDENCIES='.[test]'
-            - TEST_COMMAND="pytest"
+            NUMPY_VERSION="1.17"
 
-        - python: 3.8
+        - python: "3.8"
           env:
-            - NUMPY_VERSION=1.17
-            - PIP_DEPENDENCIES='.[test]'
-            - TEST_COMMAND="pytest"
+            NUMPY_VERSION="1.17"
 
         # Do a PEP8 test with flake8
-        - python: 3.6
+        - python: "3.8"
           env:
-            - TEST_COMMAND="flake8 gwcs --count"
-            - PIP_DEPENDENCIES="flake8"
+            TEST_COMMAND="flake8 gwcs --count"
+            PIP_DEPENDENCIES=flake8
 
-        - python: 3.6
+        - python: "3.8"
           env:
-            - TEST_COMMAND='flake8 gwcs --count --max-line-length=110'
-            - PIP_DEPENDENCIES="flake8"
-
-        - python: 3.7
-          env:
-            - PIP_DEPENDENCIES="-r requirements-dev.txt .[test]"
+            PIP_DEPENDENCIES="-r requirements-dev.txt .[test]"
 
 
     allow_failures:
-        - python: 3.6
+        - python: "3.8"
           env:
-            - TEST_COMMAND='flake8 gwcs --count --max-line-length=110'
-            - PIP_DEPENDENCIES="flake8"
-
-        - python: 3.7
-          env:
-            - PIP_DEPENDENCIES="-r requirements-dev.txt .[test]"
+            PIP_DEPENDENCIES="-r requirements-dev.txt .[test]"
 
 install:
   - pip install numpy~=$NUMPY_VERSION

--- a/gwcs/wcs.py
+++ b/gwcs/wcs.py
@@ -123,12 +123,12 @@ class WCS(GWCSAPIMixin):
         except ValueError:
             raise CoordinateFrameError("Frame {0} is not in the available frames".format(to_frame))
         if to_ind < from_ind:
-            transforms = np.array(self._pipeline[to_ind: from_ind])[:, 1].tolist()
+            transforms = np.array(self._pipeline[to_ind: from_ind], dtype="object")[:, 1].tolist()
             transforms = [tr.inverse for tr in transforms[::-1]]
         elif to_ind == from_ind:
             return None
         else:
-            transforms = np.array(self._pipeline[from_ind: to_ind])[:, 1].copy()
+            transforms = np.array(self._pipeline[from_ind: to_ind], dtype="object")[:, 1].copy()
         return functools.reduce(lambda x, y: x | y, transforms)
 
     def set_transform(self, from_frame, to_frame, transform):

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,14 +19,15 @@ upload-dir = docs/_build/html
 show-response = 1
 
 [tool:pytest]
-minversion = 3.1
+minversion = 3.6
 testpaths = gwcs docs
 norecursedirs = build docs/_build
 doctest_plus = enabled
 asdf_schema_tests_enabled = true
 asdf_schema_root = gwcs/schemas
 addopts = --doctest-rst
-
+filterwarnings =
+    ignore:Models in math_functions:astropy.utils.exceptions.AstropyUserWarning
 
 [flake8]
 # E265: # has no space after

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ DOCS_REQUIRE = [
 ]
 
 TESTS_REQUIRE = [
-    'pytest',
+    'pytest>=4.6,<6',
     'pytest-doctestplus',
     'scipy',
 ]


### PR DESCRIPTION
Fixes the `numpy` deprecation warning seen in `numpy 1.19`:

```
gwcs/tests/test_wcs.py::test_get_transform
  /Users/jdavies/dev/gwcs/gwcs/wcs.py:131: VisibleDeprecationWarning: Creating an ndarray from ragged nested sequences (which is a list-or-tuple of lists-or-tuples-or ndarrays with different lengths or shapes) is deprecated. If you meant to do this, you must specify 'dtype=object' when creating the ndarray
    transforms = np.array(self._pipeline[from_ind: to_ind])[:, 1].copy()
```

and ignores the following warning from `astropy.modeling` that we've seen for a while now in testing:

```
gwcs/spectroscopy.py::gwcs.spectroscopy.AnglesFromGratingEquation3D
gwcs/spectroscopy.py::gwcs.spectroscopy.WavelengthFromGratingEquation
  /Users/jdavies/miniconda3/envs/gwcs/lib/python3.8/site-packages/astropy/modeling/math_functions.py:48: AstropyUserWarning: Models in math_functions are experimental.
    warnings.warn("Models in math_functions are experimental.", AstropyUserWarning)
```