### PR TITLE
WCS should be able to use asdf references when serialized

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,9 @@ New Features
 - Updated versions of schemas for gwcs objects based on latest versions of
   transform schemas in asdf-standard. [#307]
 
+- Added a ``WCS.steps`` attribute and a ``wcs.Step`` class to allow serialization
+  to ASDF to use references. [#317]
+
 Bug Fixes
 ^^^^^^^^^
 

--- a/gwcs/tags/wcs.py
+++ b/gwcs/tags/wcs.py
@@ -7,7 +7,7 @@ from ..gwcs_types import GWCSType
 from ..coordinate_frames import (Frame2D, CoordinateFrame, CelestialFrame,
                                  SpectralFrame, TemporalFrame, CompositeFrame,
                                  StokesFrame)
-from ..wcs import WCS
+from ..wcs import WCS, Step
 
 
 _REQUIRES = ['astropy']
@@ -25,33 +25,15 @@ class WCSType(GWCSType):
 
     @classmethod
     def from_tree(cls, node, ctx):
-
-        steps = [(x['frame'], x.get('transform')) for x in node['steps']]
         name = node['name']
-
+        steps = [(x.frame, x.transform) for x in node['steps']]
         return WCS(steps, name=name)
 
     @classmethod
     def to_tree(cls, gwcsobj, ctx):
-        def get_frame(frame_name):
-            frame = getattr(gwcsobj, frame_name)
-            if frame is None:
-                return frame_name
-            return frame
-
-        frames = gwcsobj.available_frames
-        steps = []
-        for i in range(len(frames) - 1):
-            frame_name = frames[i]
-            frame = get_frame(frame_name)
-            transform = gwcsobj.get_transform(frames[i], frames[i + 1])
-            steps.append(StepType({'frame': frame, 'transform': transform}))
-        frame_name = frames[-1]
-        frame = get_frame(frame_name)
-        steps.append(StepType({'frame': frame}))
-
         return {'name': gwcsobj.name,
-                'steps': yamlutil.custom_tree_to_tagged_tree(steps, ctx)}
+                'steps': gwcsobj.steps
+                }
 
     @classmethod
     def assert_equal(cls, old, new):
@@ -68,6 +50,16 @@ class StepType(dict, GWCSType):
     name = "step"
     requires = _REQUIRES
     version = '1.1.0'
+    types = [Step]
+
+    @classmethod
+    def from_tree(cls, node, ctx):
+        return Step(frame=node['frame'], transform=node.get('transform', None))
+
+    @classmethod
+    def to_tree(cls, step, ctx):
+        return {'frame': step.frame,
+                'transform': step.transform}
 
 
 class FrameType(GWCSType):

--- a/gwcs/wcs.py
+++ b/gwcs/wcs.py
@@ -59,6 +59,10 @@ class WCS(GWCSAPIMixin):
         self._initialize_wcs(forward_transform, input_frame, output_frame)
         self._pixel_shape = None
 
+    @property
+    def steps(self):
+        return [Step(*step) for step in self._pipeline]
+
     def _initialize_wcs(self, forward_transform, input_frame, output_frame):
         if forward_transform is not None:
             if isinstance(forward_transform, Model):
@@ -912,3 +916,28 @@ def _store_2D_coefficients(hdr, poly_model, coeff_prefix, keeplinear=False):
         for j in range(0, degree + 1):
             if (i + j) > mindeg and (i + j < degree + 1):
                 hdr[f'{coeff_prefix}_{i}_{j}'] = getattr(poly_model, f'c{i}_{j}').value
+
+
+class Step:
+    """
+    Represents a ``step`` in the WCS pipeline.
+
+    Parameters
+    ----------
+    frame : `~gwcs.coordinate_frames.CoordinateFrame`
+        A gwcs coordinate frame object.
+    transform : `~astropy.modeling.core.Model` or None
+        A transform from this step's frame to next step's frame.
+        The transform of the last step should be ``None``.
+    """
+    def __init__(self, frame, transform=None):
+        self._frame = frame
+        self._transform = transform
+
+    @property
+    def frame(self):
+        return self._frame
+
+    @property
+    def transform(self):
+        return self._transform


### PR DESCRIPTION
The `WCS` tag was instantiating a `StepType` for each step in a WCS pipeline it serializes the WCS object to asdf. The reason for this is there was no corresponding `Step` class.
Removing the `StepType` class and using a yaml array of dict objects would work but would be backwards incompatible, i.e. won't be able to deserialize old files. This PR adds the missing `Step` class and adds `WCS.steps` property.