### PR TITLE
Represent the pipeline as a list of Step instances

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,10 @@ New Features
 - Added a ``WCS.steps`` attribute and a ``wcs.Step`` class to allow serialization
   to ASDF to use references. [#317]
 
+- ``wcs.pipeline`` now is a list of ``Step`` instances instead of
+  a (frame, transform) tuple. Use ``WCS.pipeline.transform`` and
+  ``WCS.pipeline.frame`` to access them. [#319]
+
 Bug Fixes
 ^^^^^^^^^
 

--- a/gwcs/tags/tests/test_wcs.py
+++ b/gwcs/tags/tests/test_wcs.py
@@ -148,10 +148,10 @@ def test_references(tmpdir):
     af = asdf.AsdfFile(tree)
     output_path = os.path.join(str(tmpdir), "test.asdf")
     af.write_to(output_path)
-    
+
     with asdf.open(output_path) as af:
         gw1 = af.tree['wcs1']
         gw2 = af.tree['wcs2']
-        assert gw1.steps[0].transform is gw1.steps[1].transform
-        assert gw2.steps[0].transform is gw2.steps[1].transform
-        assert gw2.steps[0].frame is gw2.steps[1].frame
+        assert gw1.pipeline[0].transform is gw1.pipeline[1].transform
+        assert gw2.pipeline[0].transform is gw2.pipeline[1].transform
+        assert gw2.pipeline[0].frame is gw2.pipeline[1].frame

--- a/gwcs/tags/wcs.py
+++ b/gwcs/tags/wcs.py
@@ -32,7 +32,7 @@ class WCSType(GWCSType):
     @classmethod
     def to_tree(cls, gwcsobj, ctx):
         return {'name': gwcsobj.name,
-                'steps': gwcsobj.steps
+                'steps': gwcsobj.pipeline
                 }
 
     @classmethod
@@ -40,10 +40,10 @@ class WCSType(GWCSType):
         from asdf.tests import helpers
         assert old.name == new.name # nosec
         assert len(old.available_frames) == len(new.available_frames) # nosec
-        for (old_frame, old_transform), (new_frame, new_transform) in zip(
+        for old_step, new_step in zip(
                 old.pipeline, new.pipeline):
-            helpers.assert_tree_match(old_frame, new_frame)
-            helpers.assert_tree_match(old_transform, new_transform)
+            helpers.assert_tree_match(old_step.frame, new_step.frame)
+            helpers.assert_tree_match(old_step.transform, new_step.transform)
 
 
 class StepType(dict, GWCSType):

--- a/gwcs/tests/test_api.py
+++ b/gwcs/tests/test_api.py
@@ -233,7 +233,7 @@ def test_high_level_wrapper(wcsobj, request):
 
     # Remove the bounding box because the type test is a little broken with the
     # bounding box.
-    del wcsobj._pipeline[0][1].bounding_box
+    del wcsobj._pipeline[0].transform.bounding_box
 
     hlvl = HighLevelWCSWrapper(wcsobj)
 

--- a/gwcs/tests/test_wcs.py
+++ b/gwcs/tests/test_wcs.py
@@ -67,10 +67,17 @@ def test_init_no_transform():
     Test initializing a WCS object without a forward_transform.
     """
     gw = wcs.WCS(output_frame='icrs')
-    assert gw._pipeline == [('detector', None), ('icrs', None)]
+    assert len(gw._pipeline) == 2
+    assert gw.pipeline[0].frame == "detector"
+    assert gw.pipeline[0][0] == "detector"
+    assert gw.pipeline[1].frame == "icrs"
+    assert gw.pipeline[1][0] == "icrs"
     assert np.in1d(gw.available_frames, ['detector', 'icrs']).all()
     gw = wcs.WCS(output_frame=icrs, input_frame=detector)
-    assert gw._pipeline == [('detector', None), ('icrs', None)]
+    assert gw._pipeline[0].frame == "detector"
+    assert gw._pipeline[0][0] == "detector"
+    assert gw._pipeline[1].frame == "icrs"
+    assert gw._pipeline[1][0] == "icrs"
     assert np.in1d(gw.available_frames, ['detector', 'icrs']).all()
     with pytest.raises(NotImplementedError):
         gw(1, 2)
@@ -110,6 +117,7 @@ def test_get_transform():
     tr_back = w.get_transform('icrs', 'detector')
     x, y = 1, 2
     fx, fy = tr_forward(1, 2)
+    assert_allclose(w.pipeline[0].transform(x, y), (fx, fy))
     assert_allclose(w.pipeline[0][1](x, y), (fx, fy))
     assert_allclose((x, y), tr_back(*w(x, y)))
     assert(w.get_transform('detector', 'detector') is None)


### PR DESCRIPTION
This PR builds on #317 and represents `WCS.pipeline` as a list of `Step` instances.
I think this makes the interface a little bit better and easier to work with for PRs like #299.
AFAIK it's fully backwards compatible, i.e. it reads old files where the pipeline is a list of 
(frame, transform) tuples. JWST regression tests are still running and that will be the final test.
@Cadair , @chris-simpson Any objections to this change?