### PR TITLE
Add function to test if a world point is contained in fwd transform's domain

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,9 @@ New Features
 - Added ``to_fits_tab`` method to generate FITS header and binary table
   extension following FITS WCS ``-TAB`` convension. [#295]
 
+- Added ``in_image`` function for testing whether a point in world coordinates
+  maps back to the domain of definition of the forward transformation. [#322]
+
 0.14.0 (2020-08-19)
 -------------------
 New Features


### PR DESCRIPTION
Added a function that tests if input world coordinate is contained within forward transformation's image and that it maps to the domain of definition of the forward transformation. In practical terms, this function tests that input world coordinate can be converted to input frame and that it is within the forward transformation's ``bounding_box`` when defined.