### PR TITLE
Fixes for Astropy wcsapi

### DIFF
--- a/gwcs/coordinate_frames.py
+++ b/gwcs/coordinate_frames.py
@@ -520,11 +520,14 @@ class TemporalFrame(CoordinateFrame):
         return self._convert_to_time(dt, unit=self.unit[0], **self._attrs)
 
     def _convert_to_time(self, dt, *, unit, **kwargs):
-        if isinstance(dt, time.Time) or isinstance(self.reference_frame.value, np.ndarray):
+        if (not isinstance(dt, time.TimeDelta) and
+                isinstance(dt, time.Time) or
+                isinstance(self.reference_frame.value, np.ndarray)):
             return time.Time(dt, **kwargs)
 
         if not hasattr(dt, 'unit'):
             dt = dt * unit
+
         return self.reference_frame + dt
 
     def coordinate_to_quantity(self, *coords):

--- a/gwcs/coordinate_frames.py
+++ b/gwcs/coordinate_frames.py
@@ -539,6 +539,8 @@ class TemporalFrame(CoordinateFrame):
         # Is already a quantity
         elif hasattr(coords[0], 'unit'):
             return coords[0]
+        if isinstance(coords[0], np.ndarray):
+            return coords[0] * self.unit[0]
         else:
             raise ValueError("Can not convert {} to Quantity".format(coords[0]))
 

--- a/gwcs/coordinate_frames.py
+++ b/gwcs/coordinate_frames.py
@@ -286,12 +286,15 @@ class CoordinateFrame:
         return self._axis_physical_types
 
     @property
-    def _world_axis_object_components(self):
-        raise NotImplementedError(f"This method is not implemented for {type(self)}")
+    def _world_axis_object_classes(self):
+        return {self._axes_type[0]: (
+            u.Quantity,
+            (),
+            {'unit': self.unit[0]})}
 
     @property
-    def _world_axis_object_classes(self):
-        raise NotImplementedError(f"This method is not implemented for {type(self)}")
+    def _world_axis_object_components(self):
+        return [(self._axes_type[0], 0, 'value')]
 
 
 class CelestialFrame(CoordinateFrame):

--- a/gwcs/tests/test_api.py
+++ b/gwcs/tests/test_api.py
@@ -173,10 +173,10 @@ def test_world_axis_object_components_1d(gwcs_1d_freq):
 
 def test_world_axis_object_components_4d(gwcs_4d_identity_units):
     waoc = gwcs_4d_identity_units.world_axis_object_components
-    assert waoc == [('celestial', 0, 'spherical.lon'),
-                    ('celestial', 1, 'spherical.lat'),
-                    ('spectral', 0, 'value'),
-                    ('temporal', 0, 'value')]
+    assert waoc[0:3] == [('celestial', 0, 'spherical.lon'),
+                         ('celestial', 1, 'spherical.lat'),
+                         ('spectral', 0, 'value')]
+    assert waoc[3][0:2] == ('temporal', 0)
 
 
 def test_world_axis_object_classes_2d(gwcs_2d_spatial_shift):

--- a/gwcs/tests/test_coordinate_systems.py
+++ b/gwcs/tests/test_coordinate_systems.py
@@ -4,7 +4,7 @@ import numpy as np
 from numpy.testing import assert_allclose
 
 import astropy.units as u
-from astropy.time import Time
+from astropy.time import Time, TimeDelta
 from astropy import coordinates as coord
 from astropy.tests.helper import assert_quantity_allclose
 
@@ -150,6 +150,7 @@ def test_temporal_relative():
 
     t = cf.TemporalFrame(reference_frame=Time("2018-01-01T00:00:00"))
     assert t.coordinates(10 * u.s) == Time("2018-01-01T00:00:00") + 10 * u.s
+    assert t.coordinates(TimeDelta(10, format='sec')) == Time("2018-01-01T00:00:00") + 10 * u.s
 
     a = t.coordinates((10, 20) * u.s)
     assert a[0] == Time("2018-01-01T00:00:00") + 10 * u.s

--- a/gwcs/tests/test_wcs.py
+++ b/gwcs/tests/test_wcs.py
@@ -432,7 +432,6 @@ def test_high_level_api():
     assert_allclose(wrapped_world_coord[1].value, lam)
     assert_allclose((world_coord[2] - time.reference_frame).to(u.s).value, t)
 
-
     x1, y1, z1, k1 = w.world_to_pixel(*world_coord)
     assert_allclose(x1, xv)
     assert_allclose(y1, yv)

--- a/gwcs/utils.py
+++ b/gwcs/utils.py
@@ -11,7 +11,7 @@ from astropy.modeling import core, projections
 from astropy.io import fits
 from astropy import coordinates as coords
 from astropy import units as u
-from astropy.time import Time
+from astropy.time import Time, TimeDelta
 
 
 # these ctype values do not include yzLN and yzLT pairs
@@ -462,7 +462,7 @@ def isnumerical(val):
         isnum = False
     elif isinstance(val, u.Quantity):
         isnum = False
-    elif isinstance(val, Time):
+    elif isinstance(val, (Time, TimeDelta)):
         isnum = False
     elif (isinstance(val, np.ndarray)
           and not np.issubdtype(val.dtype, np.floating)

--- a/gwcs/utils.py
+++ b/gwcs/utils.py
@@ -11,6 +11,7 @@ from astropy.modeling import core, projections
 from astropy.io import fits
 from astropy import coordinates as coords
 from astropy import units as u
+from astropy.time import Time
 
 
 # these ctype values do not include yzLN and yzLT pairs
@@ -460,6 +461,8 @@ def isnumerical(val):
     if isinstance(val, coords.SkyCoord):
         isnum = False
     elif isinstance(val, u.Quantity):
+        isnum = False
+    elif isinstance(val, Time):
         isnum = False
     elif (isinstance(val, np.ndarray)
           and not np.issubdtype(val.dtype, np.floating)


### PR DESCRIPTION
This fixes a few bugs in our APE 14 implementations:

* Don't treat `Time` as a numerical type
* Improve the implementation of TemporalFrame by copying core
* Implement `world_axis_object_components` and `world_axis_object_classes` for `CoordinateFrame`