### PR TITLE
Do not assume model bounding boxes can be cast to numpy arrays

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ env:
         # The following versions are the 'default' for tests, unless
         # overidden underneath. They are defined here in order to save having
         # to repeat them for all configurations.
-        - NUMPY_VERSION="1.16"
+        - NUMPY_VERSION="1.17"
         - ASDF_GIT="git+https://github.com/spacetelescope/asdf.git#egg=asdf"
         - ASTROPY_GIT="git+https://github.com/astropy/astropy.git#egg=astropy"
         - PIP_DEPENDENCIES=.[test]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,8 @@ Bug Fixes
 - Fix a formula for estimating ``crpix`` in ``to_fits_sip()`` so that ``crpix``
   is near the center of the bounding box. [#337]
 
+- ``bounding_box`` now works with tuple of ``Quantities``. [#331]
+
 0.15.0 (2020-11-13)
 -------------------
 New Features

--- a/gwcs/tests/test_wcs.py
+++ b/gwcs/tests/test_wcs.py
@@ -797,3 +797,26 @@ def test_iter_inv():
     xp, yp = e.value.best_solution.T
     assert np.allclose((x[1:], y[1:]), (xp[1:], yp[1:]))
     assert e.value.divergent[0] == 0
+
+
+def test_tabular_2d_quantity():
+    shape = (3, 3)
+    data = np.arange(np.product(shape)).reshape(shape) * u.m / u.s
+
+    # The integer location is at the centre of the pixel.
+    points_unit = u.pix
+    points = [(np.arange(size) - 0) * points_unit for size in shape]
+
+    kwargs = {
+        'bounds_error': False,
+        'fill_value': np.nan,
+        'method': 'nearest',
+    }
+
+    forward = models.Tabular2D(points, data, **kwargs)
+    input_frame = cf.CoordinateFrame(2, ("PIXEL", "PIXEL"), (0,1), unit=(u.pix, u.pix), name="detector")
+    output_frame = cf.CoordinateFrame(1, "CUSTOM", (0,), unit=(u.m/u.s,))
+    w = wcs.WCS(forward_transform=forward, input_frame=input_frame, output_frame=output_frame)
+
+    bb = w.bounding_box
+    assert all(u.allclose(u.Quantity(b), [0, 2] * u.pix) for b in bb)

--- a/gwcs/tests/test_wcs.py
+++ b/gwcs/tests/test_wcs.py
@@ -269,6 +269,14 @@ def test_bounding_box():
     with pytest.raises(ValueError):
         w.bounding_box = ((1, 5), (2, 6))
 
+    # Test that bounding_box with quantities can be assigned and evaluates
+    bb = ((1 * u.pix, 5 * u.pix), (2 * u.pix, 6 * u.pix))
+    trans = models.Shift(10 * u .pix) & models.Shift(2 * u.pix)
+    pipeline = [('detector', trans), ('sky', None)]
+    w = wcs.WCS(pipeline)
+    w.bounding_box = bb
+    assert_allclose(w(-1*u.pix, -1*u.pix), (np.nan, np.nan))
+
 
 def test_grid_from_bounding_box():
     bb = ((-1, 9.9), (6.5, 15))

--- a/gwcs/wcs.py
+++ b/gwcs/wcs.py
@@ -313,11 +313,11 @@ class WCS(GWCSAPIMixin):
 
         if self.bounding_box is not None:
             # Currently compound models do not attempt to combine individual model
-            # bounding boxes. Get the forward transform and assign the ounding_box to it
+            # bounding boxes. Get the forward transform and assign the bounding_box to it
             # before evaluating it. The order Model.bounding_box is reversed.
             axes_ind = self._get_axes_indices()
             if transform.n_inputs > 1:
-                transform.bounding_box = np.array(self.bounding_box)[axes_ind][::-1]
+                transform.bounding_box = [self.bounding_box[ind] for ind in axes_ind][::-1]
             else:
                 transform.bounding_box = self.bounding_box
         result = transform(*args, **kwargs)
@@ -1204,8 +1204,7 @@ class WCS(GWCSAPIMixin):
         except AttributeError:
             axes_order = np.arange(transform_0.n_inputs)
         # Model.bounding_box is in python order, need to reverse it first.
-        bb = np.array(bb[::-1])[np.array(axes_order)]
-        return tuple(tuple(item) for item in bb)
+        return tuple(bb[::-1][i] for i in axes_order)
 
     @bounding_box.setter
     def bounding_box(self, value):

--- a/gwcs/wcs.py
+++ b/gwcs/wcs.py
@@ -1219,6 +1219,7 @@ class WCS(GWCSAPIMixin):
         value : tuple or None
             Tuple of tuples with ("low", high") values for the range.
         """
+        print('IN SETTING BB', value)
         frames = self.available_frames
         transform_0 = self.get_transform(frames[0], frames[1])
         if value is None:
@@ -1235,7 +1236,8 @@ class WCS(GWCSAPIMixin):
                 transform_0.bounding_box = value
             else:
                 # The axes in bounding_box in modeling follow python order
-                transform_0.bounding_box = np.array(value)[axes_ind][::-1]
+                #transform_0.bounding_box = np.array(value)[axes_ind][::-1]
+                transform_0.bounding_box = [value[ind] for ind in axes_ind][::-1]
         self.set_transform(frames[0], frames[1], transform_0)
 
     def _get_axes_indices(self):

--- a/gwcs/wcs.py
+++ b/gwcs/wcs.py
@@ -1219,7 +1219,6 @@ class WCS(GWCSAPIMixin):
         value : tuple or None
             Tuple of tuples with ("low", high") values for the range.
         """
-        print('IN SETTING BB', value)
         frames = self.available_frames
         transform_0 = self.get_transform(frames[0], frames[1])
         if value is None:


### PR DESCRIPTION
When creating a 2D tabular forward transform using quantities for the LUT and the points the bounding box calculation would fail

Resolves #318