### PR TITLE
Allow users to specify reference point in to_fits_sip

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,16 @@
-0.16.0 (Unreleased)
+0.15.1 (Unreleased)
 -------------------
+New Features
+^^^^^^^^^^^^
+
+- Added an option to `to_fits_sip()` to be able to specify the reference
+  point (``crpix``) of the FITS WCS. [#337]
+
+Bug Fixes
+^^^^^^^^^
+
+- Fix a formula for estimating ``crpix`` in ``to_fits_sip()`` so that ``crpix``
+  is near the center of the bounding box. [#337]
 
 0.15.0 (2020-11-13)
 -------------------


### PR DESCRIPTION
This PR adds support for specifying custom ``crpix`` value  in the ``to_fits_sip()``. This may benefit situations when distortions are modeled away from the center of the bounding box currently used by `to_fits_sip()`. [enhancement]

This PR also fixes the issue of ``crpix`` computed at the center of the bounding box but not shifted by the bottom-left corner of the bounding box. [bug]

Finally, it forces computed ``NAXIS1,2`` values to be integers. [bug]