### PR TITLE
Allow custom degree range for SIP approximation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,8 @@ New Features
 - Added an option to `to_fits_sip()` to be able to specify the reference
   point (``crpix``) of the FITS WCS. [#337]
 
+- Added support for providing custom range of degrees in ``to_fits_sip``. [#339]
+
 Bug Fixes
 ^^^^^^^^^
 
@@ -16,6 +18,9 @@ Bug Fixes
 
 - Allow sub-pixel sampling of the WCS model when computing SIP approximation in
   ``to_fits_sip()``. [#338]
+
+- Fixed a bug in ``to_fits_sip`` due to which ``inv_degree`` was ignored. [#339]
+
 
 0.15.0 (2020-11-13)
 -------------------


### PR DESCRIPTION
This PR has the following improvements and bug fixes in `to_fits_sip`:

- Allow caller to provide a custom custom range of polynomial degrees to be considered for fitting. This will allow to greately simply code in [`jwst.assign_wcs` ](https://github.com/spacetelescope/jwst/blob/9926ca917726908958539f8a8331396749380789/jwst/assign_wcs/assign_wcs_step.py#L96-L114) by eliminating second fit.
- Removes fitting for 0th degree SIP;
- Improves documentation for `degree`;
- Fixes a bug due to which `inv_degree` was ignored.