### PR TITLE
Revert "APE 14 says return for pixel_to_world should not be a tuple if 1D"

### DIFF
--- a/gwcs/api.py
+++ b/gwcs/api.py
@@ -296,10 +296,7 @@ class GWCSAPIMixin(BaseHighLevelWCS, BaseLowLevelWCS):
         Convert pixel values to world coordinates.
         """
         pixels = self._sanitize_pixel_inputs(*pixel_arrays)
-        result = self(*pixels, with_units=True)
-        if self.output_frame.naxes == 1:
-            return result[0]
-        return result
+        return self(*pixels, with_units=True)
 
     def array_index_to_world(self, *index_arrays):
         """


### PR DESCRIPTION
Reverts spacetelescope/gwcs#332 which caused the regression reported in #341.

A simple test with SpectralFrame shows the output of `pixel_to_world` works as expected without this change. @Cadair you must have run into a problem using a different Frame. Please file an issue with your failing example.