### PR TITLE
Add dummy actions workflow to kick-start actions runs on PRs

### DIFF
--- a/.github/workflows/dummy.yml
+++ b/.github/workflows/dummy.yml
@@ -1,0 +1,17 @@
+name: dummy
+
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - '*'
+  pull_request:
+
+jobs:
+  dummy:
+    name: Dummy job to jump-start actions
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dummy step
+        run: echo foo


### PR DESCRIPTION
This is just a no-op workflow whose presence will allow the workflow that replaces Travis to run in its own PR.