### PR TITLE
Add support for separable axes in to_fits_tab and to_fits_sip. Add to_fits for general conversion to FITS WCS.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,18 +8,22 @@ Bug Fixes
 
 New Features
 ^^^^^^^^^^^^
--'wcs_from_points' now includes fitting for the inverse transform. [#349]
+- ``wcs_from_points`` now includes fitting for the inverse transform. [#349]
+
+- Generalized ``WCS.to_fits_sip`` to be able to create a 2D celestial FITS WCS
+  from celestial subspace of the ``WCS``. Also, now `WCS.to_fits_sip``
+  supports arbitrary order of output axes. [#357]
 
 API Changes
 ^^^^^^^^^^^
--Modified interface to `wcs_from_points` function to better match analogous function
- in astropy. [#349]
+- Modified interface to ``wcs_from_points`` function to better match analogous function
+  in astropy. [#349]
 
 0.16.1 (2020-12-20)
 -------------------
 Bug Fixes
 ^^^^^^^^^
--Fix a regression with ``pixel_to_world`` for output frames with one axis. [#342]
+- Fix a regression with ``pixel_to_world`` for output frames with one axis. [#342]
 
 0.16.0 (2020-12-18)
 -------------------

--- a/gwcs/tests/conftest.py
+++ b/gwcs/tests/conftest.py
@@ -6,6 +6,7 @@ import pytest
 import numpy as np
 
 import astropy.units as u
+from astropy.time import Time
 from astropy import coordinates as coord
 from astropy.modeling import models
 from astropy.time import Time
@@ -251,7 +252,7 @@ def gwcs_3d_galactic_spectral():
     #                       lat,wav,lon
     crpix1, crpix2, crpix3 = 29, 39, 44
     crval1, crval2, crval3 = 10, 20, 25
-    cdelt1, cdelt2, cdelt3 = -0.1, 0.5, 0.1
+    cdelt1, cdelt2, cdelt3 = -0.01, 0.5, 0.01
 
     shift = models.Shift(-crpix3) & models.Shift(-crpix1)
     scale = models.Multiply(cdelt3) & models.Multiply(cdelt1)
@@ -280,6 +281,207 @@ def gwcs_3d_galactic_spectral():
     owcs.pixel_shape = (10, 20, 30)
 
     return owcs
+
+
+@pytest.fixture(scope="function")
+def gwcs_1d_spectral():
+    """
+    A simple 1D spectral WCS.
+    """
+    wave_model = models.Shift(-5) | models.Multiply(3.7) | models.Shift(20)
+    wave_model.bounding_box = (7, 50)
+    wave_frame = cf.SpectralFrame(axes_order=(0, ), unit=u.Hz, axes_names=("Frequency",))
+
+    detector_frame = cf.CoordinateFrame(
+        name="detector", naxes=1, axes_order=(0, ),
+        axes_type=("pixel",), unit=(u.pix, )
+    )
+
+    owcs = wcs.WCS(forward_transform=wave_model, output_frame=wave_frame, input_frame=detector_frame)
+    owcs.array_shape = (44, )
+    owcs.pixel_shape = (44, )
+
+    return owcs
+
+
+@pytest.fixture(scope="function")
+def gwcs_spec_cel_time_4d():
+    """
+    A complex 4D mixed celestial + spectral + time WCS.
+    """
+    # spectroscopic frame:
+    wave_model = models.Shift(-5) | models.Multiply(3.7) | models.Shift(20)
+    wave_model.bounding_box = (7, 50)
+    wave_frame = cf.SpectralFrame(name='wave', unit=u.m, axes_order=(0,), axes_names=('lambda',))
+
+    # time frame:
+    time_model = models.Identity(1)  # models.Linear1D(10, 0)
+    time_frame = cf.TemporalFrame(Time("2010-01-01T00:00"), name='time', unit=u.s, axes_order=(3,))
+
+    # Values from data/acs.hdr:
+    crpix = (12, 13)
+    crval = (5.63, -72.05)
+    cd = [[1.291E-05, 5.9532E-06], [5.02215E-06, -1.2645E-05]]
+    aff = models.AffineTransformation2D(matrix=cd, name='rotation')
+    offx = models.Shift(-crpix[0], name='x_translation')
+    offy = models.Shift(-crpix[1], name='y_translation')
+    wcslin = models.Mapping((1, 0)) | (offx & offy) | aff
+    tan = models.Pix2Sky_TAN(name='tangent_projection')
+    n2c = models.RotateNative2Celestial(*crval, 180, name='sky_rotation')
+    cel_model = wcslin | tan | n2c
+    icrs = cf.CelestialFrame(reference_frame=coord.ICRS(), name='sky', axes_order=(2, 1))
+
+    wcs_forward = wave_model & cel_model & time_model
+
+    comp_frm = cf.CompositeFrame(frames=[wave_frame, icrs, time_frame], name='TEST 4D FRAME')
+
+    detector_frame = cf.CoordinateFrame(
+        name="detector", naxes=4, axes_order=(0, 1, 2, 3),
+        axes_type=("pixel", "pixel", "pixel", "pixel"),
+        unit=(u.pix, u.pix, u.pix, u.pix)
+    )
+
+    w = wcs.WCS(forward_transform=wcs_forward, output_frame=comp_frm, input_frame=detector_frame)
+
+    w.bounding_box = ((0, 63), (0, 127), (0, 255), (0, 9))
+    w.array_shape = (10, 256, 128, 64)
+    w.pixel_shape = (64, 128, 256, 10)
+    return w
+
+
+@pytest.fixture(scope="function")
+def gwcs_cube_with_separable_spectral():
+    # Values from data/acs.hdr:
+    crpix = (64, 32)
+    crval = (5.63056810618, -72.0545718428)
+    cd = [[1.29058667557984E-05, 5.95320245884555E-06],
+          [5.02215195623825E-06, -1.2645010396976E-05]]
+
+    aff = models.AffineTransformation2D(matrix=cd, name='rotation')
+    offx = models.Shift(-crpix[0], name='x_translation')
+    offy = models.Shift(-crpix[1], name='y_translation')
+
+    wcslin = (offx & offy) | aff
+    tan = models.Pix2Sky_TAN(name='tangent_projection')
+    n2c = models.RotateNative2Celestial(*crval, 180, name='sky_rotation')
+    icrs = cf.CelestialFrame(reference_frame=coord.ICRS(), name='sky', axes_order=(2, 1))
+    spec = cf.SpectralFrame(name='wave', unit=[u.m,], axes_order=(0,), axes_names=('lambda',))
+    comp_frm = cf.CompositeFrame(frames=[icrs, spec], name='TEST 3D FRAME WITH SPECTRAL AXIS')
+    wcs_forward = ((wcslin & models.Identity(1)) |
+                   (tan & models.Identity(1)) |
+                   (n2c & models.Identity(1)) |
+                   models.Mapping((2, 1, 0)))
+
+    detector_frame = cf.CoordinateFrame(name="detector", naxes=3,
+                                        axes_order=(0, 1, 2),
+                                        axes_type=("pixel", "pixel", "pixel"),
+                                        unit=(u.pix, u.pix, u.pix))
+
+    w = wcs.WCS(forward_transform=wcs_forward, output_frame=comp_frm,
+                input_frame=detector_frame)
+    w.bounding_box = ((0, 127), (0, 63), (0, 99))
+    w.array_shape = (100, 64, 128)
+    w.pixel_shape = (128, 64, 100)
+
+    return w
+
+
+@pytest.fixture(scope="function")
+def gwcs_cube_with_separable_time():
+    """
+    A mixed celestial + time WCS.
+    """
+    # time frame:
+    time_model = models.Identity(1)  # models.Linear1D(10, 0)
+    time_frame = cf.TemporalFrame(Time("2010-01-01T00:00"), name='time',
+                                  unit=u.s, axes_order=(0,))
+
+    # Values from data/acs.hdr:
+    crpix = (12, 13)
+    crval = (5.63, -72.05)
+    cd = [[1.291E-05, 5.9532E-06], [5.02215E-06, -1.2645E-05]]
+    aff = models.AffineTransformation2D(matrix=cd, name='rotation')
+    offx = models.Shift(-crpix[0], name='x_translation')
+    offy = models.Shift(-crpix[1], name='y_translation')
+    wcslin = models.Mapping((1, 0)) | (offx & offy) | aff
+    tan = models.Pix2Sky_TAN(name='tangent_projection')
+    n2c = models.RotateNative2Celestial(*crval, 180, name='sky_rotation')
+    cel_model = wcslin | tan | n2c
+    icrs = cf.CelestialFrame(reference_frame=coord.ICRS(), name='sky',
+                             axes_order=(2, 1))
+
+    wcs_forward = (cel_model & time_model) | models.Mapping((0, 2, 1))
+
+    comp_frm = cf.CompositeFrame(frames=[icrs, time_frame],
+                                 name='TEST 3D FRAME WITH TIME')
+
+    detector_frame = cf.CoordinateFrame(
+        name="detector", naxes=3, axes_order=(0, 1, 2),
+        axes_type=("pixel", "pixel", "pixel"), unit=(u.pix, u.pix, u.pix)
+    )
+
+    w = wcs.WCS(forward_transform=wcs_forward, output_frame=comp_frm,
+                input_frame=detector_frame)
+
+    w.bounding_box = ((0, 9), (0, 127), (0, 63))
+    w.array_shape = (10, 64, 128)
+    w.pixel_shape = (128, 64, 10)
+    return w
+
+
+@pytest.fixture(scope="function")
+def gwcs_7d_complex_mapping():
+    """
+    Useful features of this WCS (axes indices here are 0-based):
+        - includes two celestial axes: input (0, 1) maps to world (2 - RA, 1 - Dec)
+        - includes one separable frame with one axis: 4 -> 2
+        - includes one frame with 3 input and 4 output axes (1 degenerate),
+          with separable world axes (3, 5) and (0, 6).
+    """
+    offx = models.Shift(-64, name='x_translation')
+    offy = models.Shift(-32, name='y_translation')
+    cd = np.array([[1.2906, 0.59532], [0.50222, -1.2645]])
+    aff = models.AffineTransformation2D(matrix=1e-5 * cd, name='rotation')
+    aff2 = models.AffineTransformation2D(matrix=cd, name='rotation2')
+
+    wcslin = (offx & offy) | aff
+    tan = models.Pix2Sky_TAN(name='tangent_projection')
+    n2c = models.RotateNative2Celestial(5.630568, -72.0546, 180, name='skyrot')
+    icrs = cf.CelestialFrame(reference_frame=coord.ICRS(), name='sky', axes_order=(2, 1))
+    spec = cf.SpectralFrame(name='wave', unit=[u.m], axes_order=(4,), axes_names=('lambda',))
+    cmplx = cf.CoordinateFrame(
+        name="complex",
+        naxes=4,
+        axes_order=(3, 5, 0, 6),
+        axis_physical_types=(['em.wl', 'em.wl', 'time', 'time']),
+        axes_type=("SPATIAL", "SPATIAL", "TIME", "TIME"),
+        axes_names=("x", "y", "t", 'tau'),
+        unit=(u.m, u.m, u.second, u.second)
+    )
+
+    comp_frm = cf.CompositeFrame(frames=[icrs, spec, cmplx], name='TEST 7D')
+    wcs_forward = ((wcslin & models.Shift(-3.14) & models.Scale(2.7) & aff2) |
+                   (tan & models.Identity(1) & models.Identity(1) & models.Identity(2)) |
+                   (n2c & models.Identity(1) & models.Identity(1) & models.Identity(2)) |
+                   models.Mapping((3, 1, 0, 4, 2, 5, 3)))
+
+
+    detector_frame = cf.CoordinateFrame(
+        name="detector", naxes=6,
+        axes_order=(0, 1, 2, 3, 4, 5),
+        axes_type=("pixel", "pixel", "pixel", "pixel", "pixel", "pixel"),
+        unit=(u.pix, u.pix, u.pix, u.pix, u.pix, u.pix)
+    )
+
+    pipeline = [('detector', wcs_forward), (comp_frm, None)]
+    w = wcs.WCS(forward_transform=wcs_forward, output_frame=comp_frm,
+                input_frame=detector_frame)
+    w.bounding_box = ((0, 15), (0, 31), (0, 20), (0, 10), (0, 10), (0, 1))
+
+    w.array_shape = (2, 11, 11, 21, 32, 16)
+    w.pixel_shape = (16, 32, 21, 11, 11, 2)
+
+    return w
 
 
 @pytest.fixture

--- a/gwcs/tests/test_api_slicing.py
+++ b/gwcs/tests/test_api_slicing.py
@@ -243,8 +243,8 @@ def test_celestial_slice(gwcs_3d_galactic_spectral):
     assert wcs.world_axis_object_classes['spectral'][1] == ()
     assert wcs.world_axis_object_classes['spectral'][2] == {'unit': 'Hz'}
 
-    assert_allclose(wcs.pixel_to_world_values(39, 44), (12.4, 20, 25))
-    assert_allclose(wcs.array_index_to_world_values(44, 39), (12.4, 20, 25))
+    assert_allclose(wcs.pixel_to_world_values(39, 44), (10.24, 20, 25))
+    assert_allclose(wcs.array_index_to_world_values(44, 39), (10.24, 20, 25))
 
     assert_allclose(wcs.world_to_pixel_values(12.4, 20, 25), (39., 44.))
     assert_equal(wcs.world_to_array_index_values(12.4, 20, 25), (44, 39))

--- a/gwcs/tests/test_wcs.py
+++ b/gwcs/tests/test_wcs.py
@@ -749,6 +749,21 @@ def test_to_fits_mixed_4d(gwcs_spec_cel_time_4d):
     assert np.allclose(pts, pts2, rtol=1e-5, atol=1e-5)
 
 
+def test_to_fits_no_sip_used(gwcs_spec_cel_time_4d):
+    # gWCS:
+    w = gwcs_spec_cel_time_4d
+
+    # create FITS headers and -TAB headers
+    hdr, _ = w.to_fits(degree=3)
+
+    # check that FITS WCS is not using SIP
+    assert not hdr['?_ORDER']
+    assert not hdr['?P_ORDER']
+    assert not hdr['A_?_?']
+    assert not hdr['B_?_?']
+    assert not any(s.endswith('-SIP') for s in hdr['CTYPE?'].values())
+
+
 def test_to_fits_1D_round_trip(gwcs_1d_spectral):
     # gWCS:
     w = gwcs_1d_spectral


### PR DESCRIPTION
This PR expands and improves existing `to_sip_fits` in the following ways [by adding support for interpreting output frame in a `gwcs.WCS` object]:

1. Identify celestial axes when WCS object has more than 2 ~celestial~ axes;
2. Extract unit information for FITS' CUNIT;
3. Extract RADESYS information from output frame;
4. Allow arbitrary mapping of axes (i.e., input `x` and `y` axes could be axes 0 and 2 while output LON/RA and LAT/DEC could be 5 and 2 correspondingly in the `gwcs.WCS` object.

This flexibility will be used to separate all axes in a `gwcs.WCS` object into celestial and non-celestial axes and use `SIP` approximation, when possible, on celestial axes and `TAB` for the rest.
