### PR TITLE
Replace Quantity with SpectralCoord

### DIFF
--- a/gwcs/coordinate_frames.py
+++ b/gwcs/coordinate_frames.py
@@ -435,6 +435,7 @@ class SpectralFrame(CoordinateFrame):
     def __init__(self, axes_order=(0,), reference_frame=None, unit=None,
                  axes_names=None, name=None, axis_physical_types=None,
                  reference_position=None):
+
         super(SpectralFrame, self).__init__(naxes=1, axes_type="SPECTRAL", axes_order=axes_order,
                                             axes_names=axes_names, reference_frame=reference_frame,
                                             unit=unit, name=name,
@@ -444,7 +445,7 @@ class SpectralFrame(CoordinateFrame):
     @property
     def _world_axis_object_classes(self):
         return {'spectral': (
-            u.Quantity,
+            coord.SpectralCoord,
             (),
             {'unit': self.unit[0]})}
 
@@ -452,13 +453,15 @@ class SpectralFrame(CoordinateFrame):
     def _world_axis_object_components(self):
         return [('spectral', 0, 'value')]
 
-    def coordinates(self, *args, equivalencies=[]):
-        if hasattr(args[0], 'unit'):
-            return args[0].to(self.unit[0], equivalencies=equivalencies)
-        if np.isscalar(args):
-            return args * self.unit[0]
+    def coordinates(self, *args):
+        # using SpectralCoord
+        if isinstance(args[0], coord.SpectralCoord):
+            return args[0].to(self.unit[0])
         else:
-            return args[0] * self.unit[0]
+            if hasattr(args[0], 'unit'):
+                return coord.SpectralCoord(*args).to(self.unit[0])
+            else:
+                return coord.SpectralCoord(*args, self.unit[0])
 
     def coordinate_to_quantity(self, *coords):
         if hasattr(coords[0], 'unit'):

--- a/gwcs/tests/test_api_slicing.py
+++ b/gwcs/tests/test_api_slicing.py
@@ -1,6 +1,5 @@
 import astropy.units as u
-from astropy.coordinates import Galactic, SkyCoord
-from astropy.units import Quantity
+from astropy.coordinates import Galactic, SkyCoord, SpectralCoord
 from astropy.wcs.wcsapi.sliced_low_level_wcs import SlicedLowLevelWCS
 from numpy.testing import assert_allclose, assert_equal
 
@@ -53,7 +52,7 @@ def test_ellipsis(gwcs_3d_galactic_spectral):
     assert isinstance(wcs.world_axis_object_classes['celestial'][2]['frame'], Galactic)
     assert wcs.world_axis_object_classes['celestial'][2]['unit'] == (u.deg, u.deg)
 
-    assert wcs.world_axis_object_classes['spectral'][0] is Quantity
+    assert wcs.world_axis_object_classes['spectral'][0] is SpectralCoord
     assert wcs.world_axis_object_classes['spectral'][1] == ()
     assert wcs.world_axis_object_classes['spectral'][2] == {'unit': 'Hz'}
 
@@ -175,7 +174,7 @@ def test_spectral_range(gwcs_3d_galactic_spectral):
     assert isinstance(wcs.world_axis_object_classes['celestial'][2]['frame'], Galactic)
     assert wcs.world_axis_object_classes['celestial'][2]['unit'] ==  (u.deg, u.deg)
 
-    assert wcs.world_axis_object_classes['spectral'][0] is Quantity
+    assert wcs.world_axis_object_classes['spectral'][0] is SpectralCoord
     assert wcs.world_axis_object_classes['spectral'][1] == ()
     assert wcs.world_axis_object_classes['spectral'][2] == {'unit': 'Hz'}
 
@@ -239,7 +238,7 @@ def test_celestial_slice(gwcs_3d_galactic_spectral):
     assert isinstance(wcs.world_axis_object_classes['celestial'][2]['frame'], Galactic)
     assert wcs.world_axis_object_classes['celestial'][2]['unit'] ==  (u.deg, u.deg)
 
-    assert wcs.world_axis_object_classes['spectral'][0] is Quantity
+    assert wcs.world_axis_object_classes['spectral'][0] is SpectralCoord
     assert wcs.world_axis_object_classes['spectral'][1] == ()
     assert wcs.world_axis_object_classes['spectral'][2] == {'unit': 'Hz'}
 
@@ -304,7 +303,7 @@ def test_celestial_range(gwcs_3d_galactic_spectral):
     assert isinstance(wcs.world_axis_object_classes['celestial'][2]['frame'], Galactic)
     assert wcs.world_axis_object_classes['celestial'][2]['unit'] ==  (u.deg, u.deg)
 
-    assert wcs.world_axis_object_classes['spectral'][0] is Quantity
+    assert wcs.world_axis_object_classes['spectral'][0] is SpectralCoord
     assert wcs.world_axis_object_classes['spectral'][1] == ()
     assert wcs.world_axis_object_classes['spectral'][2] == {'unit': 'Hz'}
 
@@ -372,7 +371,7 @@ def test_no_array_shape(gwcs_3d_galactic_spectral):
     assert isinstance(wcs.world_axis_object_classes['celestial'][2]['frame'], Galactic)
     assert wcs.world_axis_object_classes['celestial'][2]['unit'] ==  (u.deg, u.deg)
 
-    assert wcs.world_axis_object_classes['spectral'][0] is Quantity
+    assert wcs.world_axis_object_classes['spectral'][0] is SpectralCoord
     assert wcs.world_axis_object_classes['spectral'][1] == ()
     assert wcs.world_axis_object_classes['spectral'][2] == {'unit': 'Hz'}
 

--- a/gwcs/wcs.py
+++ b/gwcs/wcs.py
@@ -290,7 +290,7 @@ class WCS(GWCSAPIMixin):
             for each dimension.
         with_units : bool
             If ``True`` returns a `~astropy.coordinates.SkyCoord` or
-            `~astropy.units.Quantity` object, by using the units of
+            `~astropy.coordinates.SpectralCoord` object, by using the units of
             the output cooridnate frame.
             Optional, default=False.
         with_bounding_box : bool, optional
@@ -413,7 +413,7 @@ class WCS(GWCSAPIMixin):
 
         with_units : bool, optional
             If ``True`` returns a `~astropy.coordinates.SkyCoord` or
-            `~astropy.units.Quantity` object, by using the units of
+            `~astropy.coordinates.SpectralCoord` object, by using the units of
             the output cooridnate frame. Default is `False`.
 
         Other Parameters
@@ -490,7 +490,7 @@ class WCS(GWCSAPIMixin):
 
         with_units : bool, optional
             If ``True`` returns a `~astropy.coordinates.SkyCoord` or
-            `~astropy.units.Quantity` object, by using the units of
+            `~astropy.coordinates.SpectralCoord` object, by using the units of
             the output cooridnate frame. Default is `False`.
 
         tolerance : float, optional
@@ -1071,7 +1071,7 @@ class WCS(GWCSAPIMixin):
             Inputs in ``from_frame``, separate inputs for each dimension.
         output_with_units : bool
             If ``True`` - returns a `~astropy.coordinates.SkyCoord` or
-            `~astropy.units.Quantity` object.
+            `~astropy.coordinates.SpectralCoord` object.
         with_bounding_box : bool, optional
              If True(default) values in the result which correspond to any of the inputs being
              outside the bounding_box are set to ``fill_value``.


### PR DESCRIPTION
SpectralFrame.coordinates now returns a SpectralCoord instead of a quantity. The 'equivalencies' argument is removed.

There is a failing test because when you evaluate a wcs using 'with_units', it now returns a SpectralCoord, but using the HighLevelWCSWrapper still returns a Quantity. 