### PR TITLE
Make use of CoordinateFrame.reference_frame

### DIFF
--- a/gwcs/coordinate_frames.py
+++ b/gwcs/coordinate_frames.py
@@ -280,6 +280,8 @@ class CoordinateFrame:
     def coordinates(self, *args):
         """ Create world coordinates object"""
         coo = tuple([arg * un if not hasattr(arg, "to") else arg.to(un) for arg, un in zip(args, self.unit)])
+        if self.reference_frame is not None:
+            return coord.SkyCoord(*args, unit=self.unit, frame=self.reference_frame)
         return coo
 
     def coordinate_to_quantity(self, *coords):


### PR DESCRIPTION
If `CoordinateFrame` has a `reference_frame` attached, use it to return a `SkyCoord` object from `CoordinateFrame.coordiantes`. This is similar to the way `CelestialFrame` works, and I think the right way to allow definition of a general `CoordinateFrame` that still returns a `SkyCoord`.