### PR TITLE
fix deprecation warning when wcs is initialized with a pipeline 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,8 @@ Bug Fixes
 - Fix issue where RuntimeWarning is raised when there are NaNs in coordinates
   in angle wrapping code [#367]
 
+- Fix deprecation warning when wcs is initialized with a pipeline [#368]
+
 New Features
 ^^^^^^^^^^^^
 - ``wcs_from_points`` now includes fitting for the inverse transform. [#349]

--- a/gwcs/tests/test_wcs.py
+++ b/gwcs/tests/test_wcs.py
@@ -1064,3 +1064,20 @@ def test_tabular_2d_quantity():
 
     bb = w.bounding_box
     assert all(u.allclose(u.Quantity(b), [0, 2] * u.pix) for b in bb)
+
+
+@pytest.mark.filterwarnings("error:.*Indexing a WCS.pipeline step is deprecated.*:DeprecationWarning")
+def test_initialize_wcs_with_list():
+    # test that you can initialize a wcs with a pipeline that is a list
+    # containing both Step() and (frame, transform) tuples
+
+    # make pipline consisting of tuples and Steps
+    shift1 = models.Shift(10 * u .pix) & models.Shift(2 * u.pix)
+    shift2 = models.Shift(3 * u.pix)
+    pipeline = [('detector', shift1), wcs.Step('extra_step', shift2)]
+
+    extra_step = ('extra_step', None)
+    pipeline.append(extra_step)
+
+    # make sure no warnings occur when creating wcs with this pipeline
+    wcs.WCS(pipeline)

--- a/gwcs/wcs.py
+++ b/gwcs/wcs.py
@@ -144,7 +144,14 @@ class WCS(GWCSAPIMixin):
         self._array_shape = None
         self._initialize_wcs(forward_transform, input_frame, output_frame)
         self._pixel_shape = None
-        self._pipeline = [Step(*step) for step in self._pipeline]
+
+        pipe = []
+        for step in self._pipeline:
+            if isinstance(step, Step):
+                pipe.append(Step(step.frame, step.transform))
+            else:
+                pipe.append(Step(*step))
+        self._pipeline = pipe
 
     def _initialize_wcs(self, forward_transform, input_frame, output_frame):
         if forward_transform is not None:
@@ -162,7 +169,10 @@ class WCS(GWCSAPIMixin):
                                   (output_frame, None)]
             elif isinstance(forward_transform, list):
                 for item in forward_transform:
-                    name, frame_obj = self._get_frame_name(item[0])
+                    if isinstance(item, Step):
+                        name, frame_obj = self._get_frame_name(item.frame)
+                    else:
+                        name, frame_obj = self._get_frame_name(item[0])
                     super(WCS, self).__setattr__(name, frame_obj)
                     #self._pipeline.append((name, item[1]))
                     self._pipeline = forward_transform


### PR DESCRIPTION
It wasn't a problem with initializing a wcs with a list of tuples of `(frame, transform)` - it happened because there were `wcs.Step()` items in the `forward_transform` list the wcs was being initialized with which gave that warning when trying to index them rather than accessing their `.frame` and `.transform` attributes.

Fixes #361