### PR TITLE
Enable Compound Bounding Box support 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,8 @@ Bug Fixes
 - Updated code in ``region.py`` with latest improvements and bug fixes
   from ``stsci.skypac.regions.py`` [#382]
 
+- Enabled ``CompoundBoundingBox`` support for wcs. [#375]
+
 
 New Features
 ^^^^^^^^^^^^
@@ -52,7 +54,7 @@ API Changes
 - Modified interface to ``wcs_from_points`` function to better match analogous function
   in astropy. [#349]
 
-- ``Model._BoundingBox`` was renamed to ``Model.ModelBoundingBox`. [#376, #377]
+- ``Model._BoundingBox`` was renamed to ``Model.ModelBoundingBox``. [#376, #377]
 
 0.16.1 (2020-12-20)
 -------------------

--- a/gwcs/wcs.py
+++ b/gwcs/wcs.py
@@ -24,6 +24,7 @@ from .wcstools import grid_from_bounding_box
 
 try:
     from astropy.modeling.bounding_box import ModelBoundingBox as Bbox
+    from astropy.modeling.bounding_box import CompoundBoundingBox
     new_bbox = True
 except ImportError:
     from astropy.modeling.utils import _BoundingBox as Bbox
@@ -1313,6 +1314,7 @@ class WCS(GWCSAPIMixin):
         Return the range of acceptable values for each input axis.
         The order of the axes is `~gwcs.coordinate_frames.CoordinateFrame.axes_order`.
         """
+
         frames = self.available_frames
         transform_0 = self.get_transform(frames[0], frames[1])
         try:
@@ -1353,7 +1355,10 @@ class WCS(GWCSAPIMixin):
             try:
                 # Make sure the dimensions of the new bbox are correct.
                 if new_bbox:
-                    bbox = Bbox.validate(transform_0, value, order='F')
+                    if isinstance(value, CompoundBoundingBox):
+                        bbox = CompoundBoundingBox.validate(transform_0, value, order='F')
+                    else:
+                        bbox = Bbox.validate(transform_0, value, order='F')
                 else:
                     Bbox.validate(transform_0, value)
             except Exception:
@@ -1372,6 +1377,16 @@ class WCS(GWCSAPIMixin):
                     transform_0.bounding_box = [value[ind] for ind in axes_ind][::-1]
 
         self.set_transform(frames[0], frames[1], transform_0)
+
+    def attach_compound_bounding_box(self, cbbox, selector_args):
+        if new_bbox:
+            frames = self.available_frames
+            transform_0 = self.get_transform(frames[0], frames[1])
+
+            self.bounding_box = CompoundBoundingBox.validate(transform_0, cbbox, selector_args=selector_args,
+                                                             order='F')
+        else:
+            raise NotImplementedError('Compound bounding box is not supported for your version of astropy')
 
     def _get_axes_indices(self):
         try:


### PR DESCRIPTION
Enables support for the refactored bounding box and compound bounding box features in PRs [astropy/astropy#11930](https://github.com/astropy/astropy/pull/11930), [astropy/astropy#11931](https://github.com/astropy/astropy/pull/11931), and [astropy/astropy#11942](https://github.com/astropy/astropy/pull/11942).

This should be merged only after the astropy PRs have been merged and astropy 5.0 is released.

The CI job with dev dependencies should pass before the astropy release is out.