### PR TITLE
Remove python 3.6 and python 3.7 from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,16 +33,6 @@ jobs:
             python-version: 3.9
             toxenv: py39
 
-          - name: Python 3.7
-            runs-on: ubuntu-latest
-            python-version: 3.7
-            toxenv: py37
-
-          - name: Python 3.6
-            runs-on: ubuntu-latest
-            python-version: 3.6
-            toxenv: py36
-
           - name: Python 3.8 with coverage
             runs-on: ubuntu-latest
             python-version: 3.8


### PR DESCRIPTION
Removes python 3.6 and python 3.7 from CI testing.