### PR TITLE
MNT: Do not use enable_deprecations_as_exceptions

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,11 +1,6 @@
 import os
 import pkg_resources
 
-from astropy.tests.helper import enable_deprecations_as_exceptions
-
-# Uncomment the following line to treat all DeprecationWarnings as
-# exceptions
-#enable_deprecations_as_exceptions()
 
 entry_points = []
 for entry_point in pkg_resources.iter_entry_points('pytest11'):


### PR DESCRIPTION
This pull request is to remove soon to be deprecated code; also see astropy/astropy#12633 .