### PR TITLE
Bugfix for asdf-astropy related test

### DIFF
--- a/gwcs/converters/tests/test_wcs.py
+++ b/gwcs/converters/tests/test_wcs.py
@@ -12,8 +12,8 @@ from astropy import units as u  # noqa: E402
 from astropy import time  # noqa: E402
 
 import asdf  # noqa: E402
-from asdf_astropy.converters.transform.tests.test_transform import (  # noqa: E402
-     assert_models_equal)
+from asdf_astropy.testing.helpers import (  # noqa: E402
+     assert_model_equal)
 
 from ... import coordinate_frames as cf  # noqa: E402
 from ... import wcs  # noqa: E402
@@ -56,7 +56,7 @@ def _assert_wcs_equal(a, b):
     assert len(a.available_frames) == len(b.available_frames) # nosec
     for a_step, b_step in zip(a.pipeline, b.pipeline):
         _assert_frame_equal(a_step.frame, b_step.frame)
-        assert_models_equal(a_step.transform, b_step.transform)
+        assert_model_equal(a_step.transform, b_step.transform)
 
 
 def assert_wcs_roundtrip(wcs, tmpdir, version=None):

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,7 @@ install_requires =
     numpy
     scipy
     asdf_wcs_schemas
-    asdf-astropy
+    asdf-astropy >= 0.2.0
 
 [options.extras_require]
 docs =


### PR DESCRIPTION
GWCS was importing directly from a test module in asdf-astropy. This module has been updated, breaking a GWCS test. This PR fixes that issue.