### PR TITLE
Remove references to the six package

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,10 @@
+0.18.1 (unreleased)
+-------------------
+Bug Fixes
+^^^^^^^^^
+
+- Remove references to the ``six`` package. [#402]
+
 0.18.0 (2021-12-22)
 -------------------
 Bug Fixes
@@ -6,12 +13,11 @@ Bug Fixes
 - Updated code in ``region.py`` with latest improvements and bug fixes
   from ``stsci.skypac.regions.py`` [#382]
 
-
 New Features
 ^^^^^^^^^^^^
 
 - Enabled ``CompoundBoundingBox`` support for wcs. [#375]
-  
+
 - Moved schemas to standalone package ``asdf-wcs-schemas``.
   Reworked the serialization code to use ASDF converters. [#388]
 

--- a/gwcs/gwcs_types.py
+++ b/gwcs/gwcs_types.py
@@ -6,8 +6,6 @@ All types are added automatically to ``_gwcs_types`` and the GWCSExtension.
 
 """
 
-import six
-
 from astropy.io.misc.asdf.tags.transform.basic import TransformType
 from asdf.types import ExtensionTypeMeta, CustomType
 from astropy.io.misc.asdf.types import AstropyTypeMeta
@@ -49,8 +47,7 @@ class GWCSTypeMeta(ExtensionTypeMeta):
         return cls
 
 
-@six.add_metaclass(GWCSTypeMeta)
-class GWCSType(CustomType):
+class GWCSType(CustomType, metaclass=GWCSTypeMeta):
     """
     This class represents types that have schemas and tags
     implemented within GWCS.
@@ -60,8 +57,7 @@ class GWCSType(CustomType):
     standard = 'gwcs'
 
 
-@six.add_metaclass(GWCSTransformTypeMeta)
-class GWCSTransformType(TransformType):
+class GWCSTransformType(TransformType, metaclass=GWCSTransformTypeMeta):
     """
     This class represents transform types that have schemas and tags
     implemented within GWCS.


### PR DESCRIPTION
The `six` package is referenced in by `gwcs.gwcs_types` but not listed as a requirement.  The next asdf release will no longer install `six` which breaks gwcs.