### PR TITLE
Fix how requested SIP fit accuracy and actual residuals are reported

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ Bug Fixes
 
 - Pin astropy min version to 5.0.4. [#404]
 
+- Corrected the reported requested forward SIP accuracy and reported fit
+  residuals by ``to_fits_sip()`` and ``to_fits()``. [#413]
+
 - Fixed a bug due to which the check for divercence in ``_fit_2D_poly()`` and
   hence in ``to_fits()`` and ``to_fits_sip()`` was ignored. [#414]
 


### PR DESCRIPTION
Fixes #412 

I think the issue is only in how requested and actual fit accuracy is reported by `_fit_2D_poly()` for the forward SIP fit because for this particular case, accuracy is specified in pixel units but the fit is happening in the intermediate WCS plane (after CD transformation) so fit accuracies need to be converted back to pixels for reporting purposes.