### PR TITLE
Fix a bug in the check for divergence in _fit_2D_poly

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ Bug Fixes
 
 - Pin astropy min version to 5.0.4. [#404]
 
+- Fixed a bug due to which the check for divercence in ``_fit_2D_poly()`` and
+  hence in ``to_fits()`` and ``to_fits_sip()`` was ignored. [#414]
+
 New Features
 ^^^^^^^^^^^^
 

--- a/gwcs/wcs.py
+++ b/gwcs/wcs.py
@@ -2791,6 +2791,8 @@ def _fit_2D_poly(ntransform, npoints, degree, max_error,
                                                fit_poly_y(xin, yin))
         if max_resid > prev_max_error:
             raise RuntimeError('Failed to achieve required error tolerance')
+        prev_max_error = max_resid
+
         if verbose:
             print(f'Degree = {deg}, max_resid = {max_resid}')
         if max_resid < max_error:
@@ -2804,6 +2806,7 @@ def _fit_2D_poly(ntransform, npoints, degree, max_error,
                 if verbose:
                     print('terminating condition met')
                 break
+
     return fit_poly_x, fit_poly_y, max_resid
 
 


### PR DESCRIPTION
`prev_max_error` was not updated ever and `if max_resid > prev_max_error:` was always `False`. This effectively turned off checking for divergence.