### PR TITLE
Fix incorrectly reported sipmxerr value

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,7 @@ Bug Fixes
 - Pin astropy min version to 5.0.4. [#404]
 
 - Corrected the reported requested forward SIP accuracy and reported fit
-  residuals by ``to_fits_sip()`` and ``to_fits()``. [#413]
+  residuals by ``to_fits_sip()`` and ``to_fits()``. [#413, #419]
 
 - Fixed a bug due to which the check for divercence in ``_fit_2D_poly()`` and
   hence in ``to_fits()`` and ``to_fits_sip()`` was ignored. [#414]

--- a/gwcs/wcs.py
+++ b/gwcs/wcs.py
@@ -1885,7 +1885,7 @@ class WCS(GWCSAPIMixin):
             hdr['B_ORDER'] = fit_poly_x.degree
             _store_2D_coefficients(hdr, sip_poly_x, 'A')
             _store_2D_coefficients(hdr, sip_poly_y, 'B')
-            hdr['sipmxerr'] = (max_resid / plate_scale, 'Max diff from GWCS (equiv pix).')
+            hdr['sipmxerr'] = (max_resid, 'Max diff from GWCS (equiv pix).')
 
             if max_inv_pix_error:
                 hdr['AP_ORDER'] = fit_inv_poly_u.degree
@@ -1926,7 +1926,7 @@ class WCS(GWCSAPIMixin):
                 mat_kind = 'CD'
                 del hdr['CDELT?']
 
-            hdr['sipmxerr'] = (max_resid / plate_scale, 'Max diff from GWCS (equiv pix).')
+            hdr['sipmxerr'] = (max_resid, 'Max diff from GWCS (equiv pix).')
 
         # Construct CD matrix while remapping input axes.
         # We do not update comments to typical comments for CD matrix elements


### PR DESCRIPTION
In https://github.com/spacetelescope/gwcs/pull/413 I made a mistake of dividing twice by pixel scale. I should have removed division in the main code after I "moved" it to `_fit_2D_poly()`. This causes reported error to be very large, see, e.g., https://github.com/spacetelescope/jwst/actions/runs/2772663091:

```
_______________________________ test_sip_approx ________________________________
69  [gw0] linux -- Python 3.9.13 /home/runner/work/jwst/jwst/.tox/devdeps/bin/python
70
71  tmpdir = local('/tmp/pytest-of-runner/pytest-0/popen-gw0/test_sip_approx0')
72
73      def test_sip_approx(tmpdir):
74          # some of the wcs info
75          true_wcs = {
76              'ctype1': 'RA---TAN-SIP',
77              'ctype2': 'DEC--TAN-SIP',
78              'crpix1': 1024.5,
79              'crpix2': 1024.5,
80              'crval1': 22.023517632518953,
81              'crval2': 11.998755402186378,
82              'cd1_1': -1.7436711450380403e-05,
83              'cd1_2': -2.0976403747938548e-08,
84              'cd2_1': -4.627876291461441e-08,
85              'cd2_2': 1.7519986436203685e-05,
86              'a_order': 3,
87              'b_order': 3,
88              'a_0_2': -1.5528350090319145e-06,
89              'a_0_3': 4.604566874451819e-13,
90              'a_1_1': -1.1606066126743262e-05,
91              'a_1_2': 1.712921174539815e-09,
92              'a_2_0': 1.9201266376054155e-06,
93              'a_2_1': -7.921594730915457e-11,
94              'a_3_0': 1.597813188317488e-09,
95              'b_0_2': -6.7579614793024975e-06,
96              'b_0_3': 1.6914674117189632e-09,
97              'b_1_1': 3.633049815338483e-06,
98              'b_1_2': -8.645733568868342e-11,
99              'b_2_0': 4.914642322124454e-06,
100             'b_2_1': 1.5704907984494963e-09,
101             'b_3_0': -2.9578595707610732e-12,
102             'sipmxerr': 3.9454753271710595e-11,
103             'sipiverr': 0.11035960854622291,
104             'ap_0_1': 4.186210141016899e-07,
105             'ap_0_2': 1.5494761945928307e-06,
106             'ap_0_3': 3.783699888145856e-11,
107             'ap_1_0': -7.690659272206018e-06,
108             'ap_1_1': 1.150139841138833e-05,
109             'ap_1_2': -1.499790481486753e-09,
110             'ap_2_0': -1.9018787403711958e-06,
111             'ap_2_1': -4.510078445255482e-11,
112             'ap_3_0': -1.6308694611892058e-09,
113             'bp_0_1': -7.464889026127811e-06,
114             'bp_0_2': 6.693371868309925e-06,
115             'bp_0_3': -1.5900922772608882e-09,
116             'bp_1_0': 4.365486723327096e-07,
117             'bp_1_1': -3.59966227309358e-06,
118             'bp_1_2': -4.470754675266111e-11,
119             'bp_2_0': -4.903683300590091e-06,
120             'bp_2_1': -1.711464083137801e-09,
121             'bp_3_0': 3.894833312782645e-11,
122             'ap_order': 3,
123             'bp_order': 3
124         }
125
126         hdu1 = create_hdul()
127         im = ImageModel(hdu1)
128     
129         pipe = AssignWcsStep()
130         result = pipe.call(im)
131
132         # check that result.meta.wcsinfo has correct
133         # values after SIP approx.
134         wcs_info = result.meta.wcsinfo.instance
135    
136         # make sure all expected keys are there
137         assert set(list(true_wcs.keys())).issubset(set((list(wcs_info.keys()))))
138    
139         # and make sure they match
140         for key in true_wcs:
141             if 'ctype' in key:
142                 assert true_wcs[key] == wcs_info[key]
143             else:
144 >               assert_allclose(true_wcs[key], wcs_info[key], rtol=2e-4, atol=1e-10)
145 E               AssertionError: 
146 E               Not equal to tolerance rtol=0.0002, atol=1e-10
147 E               
148 E               Mismatched elements: 1 / 1 (100%)
149 E               Max absolute difference: 7386.63136402
150 E               Max relative difference: 1.
151 E                x: array(3.945475e-11)
152 E                y: array(7386.631364)
```

So, as a result of #413, `sipmxerr` has changed from 3.945475e-11 (which was also bad considering requested accuracy by default is 0.25 pixels) to 7386.631364 pixels (!!!) This PR fixes this error and now reported SIP fit error will be around 0.129 which is expected given the requested accuracy. 