### PR TITLE
Fix pixel scale formula used by iterative inverse

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,9 @@
 Bug Fixes
 ^^^^^^^^^
 
+- Fixed a bug in the estimate of pixel scale in the iterative inverse
+  code. [#423]
+
 
 0.18.2 (2022-09-07)
 -------------------

--- a/gwcs/tests/test_wcs.py
+++ b/gwcs/tests/test_wcs.py
@@ -605,8 +605,8 @@ class TestImaging(object):
         assert_allclose(footprint, fits_footprint)
 
     def test_inverse(self):
-        sky_coord = self.wcs(1, 2, with_units=True)
-        assert np.allclose(self.wcs.invert(sky_coord), (1, 2))
+        sky_coord = self.wcs(10, 20, with_units=True)
+        assert np.allclose(self.wcs.invert(sky_coord), (10, 20))
 
     def test_back_coordinates(self):
         sky_coord = self.wcs(1, 2, with_units=True)

--- a/gwcs/wcs.py
+++ b/gwcs/wcs.py
@@ -871,10 +871,8 @@ class WCS(GWCSAPIMixin):
         l2, phi2 = np.deg2rad(self.__call__(*(crpix + [-0.5, 0.5])))
         l3, phi3 = np.deg2rad(self.__call__(*(crpix + 0.5)))
         l4, phi4 = np.deg2rad(self.__call__(*(crpix + [0.5, -0.5])))
-        area = np.abs(0.5 * ((l4 - l2) * np.sin(phi1) +
-                             (l1 - l3) * np.sin(phi2) +
-                             (l2 - l4) * np.sin(phi3) +
-                             (l3 - l2) * np.sin(phi4)))
+        area = np.abs(0.5 * ((l4 - l2) * (np.sin(phi1) - np.sin(phi3)) +
+                             (l1 - l3) * (np.sin(phi2) - np.sin(phi4))))
         inv_pscale = 1 / np.rad2deg(np.sqrt(area))
 
         # form equation:


### PR DESCRIPTION
Fixes #416 

This PR correct the formula for estimating pixel scale in the code for the iterative computation of the inverse coordinate transformation.