### PR TITLE
Improve stability of SIP fitting. Fix constant term - CRPIX - in SIP

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,9 @@ Bug Fixes
 - Fixed a bug in the estimate of pixel scale in the iterative inverse
   code. [#423]
 
+- Fixed constant term in the polynomial used for SIP fitting.
+  Improved stability and accuracy of the SIP fitting code. [#427]
+
 
 0.18.2 (2022-09-07)
 -------------------

--- a/gwcs/tests/test_wcs.py
+++ b/gwcs/tests/test_wcs.py
@@ -636,9 +636,9 @@ def test_to_fits_sip():
     af = asdf.open(get_pkg_data_filename('data/miriwcs.asdf'))
     miriwcs = af.tree['wcs']
     bounding_box = ((0, 1024), (0, 1024))
-    mirisip = miriwcs.to_fits_sip(bounding_box, max_inv_pix_error=0.1)
+    mirisip = miriwcs.to_fits_sip(bounding_box, max_inv_pix_error=0.1, verbose=True)
     fitssip = astwcs.WCS(mirisip)
-    fitsvalx, fitsvaly = fitssip.all_pix2world(xflat+1, yflat+1, 1)
+    fitsvalx, fitsvaly = fitssip.all_pix2world(xflat + 1, yflat + 1, 1)
     gwcsvalx, gwcsvaly = miriwcs(xflat, yflat)
     assert_allclose(gwcsvalx, fitsvalx, atol=1e-10, rtol=0)
     assert_allclose(gwcsvaly, fitsvaly, atol=1e-10, rtol=0)
@@ -648,7 +648,7 @@ def test_to_fits_sip():
 
     mirisip = miriwcs.to_fits_sip(bounding_box=None, max_inv_pix_error=0.1)
     fitssip = astwcs.WCS(mirisip)
-    fitsvalx, fitsvaly = fitssip.all_pix2world(xflat+1, yflat+1, 1)
+    fitsvalx, fitsvaly = fitssip.all_pix2world(xflat + 1, yflat + 1, 1)
     assert_allclose(gwcsvalx, fitsvalx, atol=4e-11, rtol=0)
     assert_allclose(gwcsvaly, fitsvaly, atol=4e-11, rtol=0)
 
@@ -699,7 +699,7 @@ def test_to_fits_sip_pc_normalization(gwcs_simple_imaging_units, matrix_type):
         crpix=None,
         projection='TAN',
         matrix_type=matrix_type,
-        verbose=False
+        verbose=True
     )
     fitssip = astwcs.WCS(fits_wcs)
 

--- a/gwcs/tests/utils.py
+++ b/gwcs/tests/utils.py
@@ -1,0 +1,59 @@
+import numpy as np
+
+from astropy.modeling.models import (
+    Shift, Polynomial2D, Pix2Sky_TAN, RotateNative2Celestial, Mapping
+)
+
+from astropy import coordinates as coord
+from astropy import units
+from astropy import wcs as fits_wcs
+
+from .. wcs import WCS
+from .. import coordinate_frames as cf
+
+
+def _gwcs_from_hst_fits_wcs(header, hdu=None):
+    # NOTE: this function ignores table distortions
+    def coeffs_to_poly(mat, degree):
+        pol = Polynomial2D(degree=degree)
+        for i in range(mat.shape[0]):
+            for j in range(mat.shape[1]):
+                if 0 < i + j <= degree:
+                    setattr(pol, f'c{i}_{j}', mat[i, j])
+        return pol
+
+    w = fits_wcs.WCS(header, hdu)
+    ny, nx = w.pixel_shape
+    x0, y0 = w.wcs.crpix - 1
+
+    cd = w.wcs.piximg_matrix
+
+    cfx, cfy = np.dot(cd, [w.sip.a.ravel(), w.sip.b.ravel()])
+    a = np.reshape(cfx, w.sip.a.shape)
+    b = np.reshape(cfy, w.sip.b.shape)
+    a[1, 0] = cd[0, 0]
+    a[0, 1] = cd[0, 1]
+    b[1, 0] = cd[1, 0]
+    b[0, 1] = cd[1, 1]
+
+    polx = coeffs_to_poly(a, w.sip.a_order)
+    poly = coeffs_to_poly(b, w.sip.b_order)
+
+    # construct GWCS:
+    det2sky = (
+        (Shift(-x0) & Shift(-y0)) | Mapping((0, 1, 0, 1)) | (polx & poly) |
+        Pix2Sky_TAN() | RotateNative2Celestial(*w.wcs.crval, 180)
+    )
+
+    detector_frame = cf.Frame2D(name="detector", axes_names=("x", "y"),
+                                unit=(units.pix, units.pix))
+    sky_frame = cf.CelestialFrame(
+        reference_frame=getattr(coord, w.wcs.radesys).__call__(),
+        name=w.wcs.radesys,
+        unit=(units.deg, units.deg)
+    )
+    pipeline = [(detector_frame, det2sky), (sky_frame, None)]
+    gw = WCS(pipeline)
+    gw.bounding_box = ((-0.5, nx - 0.5), (-0.5, ny - 0.5))
+
+    return gw


### PR DESCRIPTION
Closes #426
Closes #425

This PR addresses most of the issues in #425 and replaces #426. It has simplified the logic on when to raise errors or warnings, fixes (constrains) the first (constant) term in the SIP polynomials being fitted to distortions, and _most importantly_, it uses a different method for solving equations for the polynomial fit that in my testing seem to significantly outperform `astropy.modeling.fitting.LinearLSQFitter` in accuracy and stability ~(and possibly timing - not tested)~ and time/performance.