### PR TITLE
fix `CRDS_PATH` in CI when running downstream tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,11 +12,6 @@ on:
     # * is a special character in YAML so you have to quote this string
     - cron: '0 9 * * 1'
 
-env:
-  CRDS_PATH: $HOME/crds_cache
-  CRDS_CLIENT_RETRY_COUNT: 3
-  CRDS_CLIENT_RETRY_DELAY_SECONDS: 20
-
 jobs:
   check:
     name: ${{ matrix.toxenv }}
@@ -88,6 +83,7 @@ jobs:
             os: ubuntu-latest
             python-version: '3.x'
     steps:
+      - run: echo "HOME=$HOME" >> $GITHUB_ENV
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0

--- a/tox.ini
+++ b/tox.ini
@@ -74,6 +74,9 @@ deps =
 set_env =
     jwst: CRDS_SERVER_URL=https://jwst-crds.stsci.edu
     romancal: CRDS_SERVER_URL=https://roman-crds.stsci.edu
+    jwst,romancal: CRDS_PATH=$HOME/crds_cache
+    jwst,romancal: CRDS_CLIENT_RETRY_COUNT=3
+    jwst,romancal: CRDS_CLIENT_RETRY_DELAY_SECONDS=20
 commands_pre =
     pip freeze
 commands =


### PR DESCRIPTION
This fixes the issue where the downstream tests fail because the `CRDS_PATH` variable is not correctly passed to the `toxenv`: https://github.com/spacetelescope/gwcs/actions/runs/3766847233/jobs/6404085866