### PR TITLE
Pin gwcs due to scipy issue

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,7 @@ install_requires =
     asdf >= 2.8.1
     astropy >= 5.1
     numpy
-    scipy
+    scipy < 1.10.0
     asdf_wcs_schemas
     asdf-astropy >= 0.2.0
 


### PR DESCRIPTION
Fixes #433 

Temporally fixes the issues with `scipy 1.10.0`. This should be unpinned when scipy/scipy#17717 makes it into a release