### PR TITLE
Synchronize array and pixel shapes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,10 @@
 Bug Fixes
 ^^^^^^^^^
 
+- Synchronize ``array_shape`` and ``pixel_shape`` attributes of WCS
+  objects. [#439]
+
+
 0.18.3 (2022-12-23)
 -------------------
 Bug Fixes

--- a/gwcs/api.py
+++ b/gwcs/api.py
@@ -170,11 +170,17 @@ class GWCSAPIMixin(BaseHighLevelWCS, BaseLowLevelWCS):
         The shape should be given in ``(row, column)`` order (the convention
         for arrays in Python).
         """
-        return self._array_shape
+        if self._pixel_shape is None:
+            return None
+        else:
+            return self._pixel_shape[::-1]
 
     @array_shape.setter
     def array_shape(self, value):
-        self._array_shape = value
+        if value is None:
+            self._pixel_shape = None
+        else:
+            self._pixel_shape = value[::-1]
 
     @property
     def pixel_bounds(self):

--- a/gwcs/tests/test_api.py
+++ b/gwcs/tests/test_api.py
@@ -327,6 +327,11 @@ def test_array_shape(wcsobj):
     wcsobj.array_shape = (2040, 1020)
     assert_array_equal(wcsobj.array_shape, (2040, 1020))
 
+    assert wcsobj.array_shape == wcsobj.pixel_shape[::-1]
+
+    wcsobj.pixel_shape = (1111, 2222)
+    assert wcsobj.array_shape == (2222, 1111)
+
 
 @wcs_objs
 def test_pixel_bounds(wcsobj):

--- a/gwcs/wcs.py
+++ b/gwcs/wcs.py
@@ -141,7 +141,6 @@ class WCS(GWCSAPIMixin):
         self._available_frames = []
         self._pipeline = []
         self._name = name
-        self._array_shape = None
         self._initialize_wcs(forward_transform, input_frame, output_frame)
         self._pixel_shape = None
 


### PR DESCRIPTION
Closes #373 

Currently `array_shape` and `pixel_shape` attributes can be modified independently but according to the documentation, based on their meaning, these values are related. This PR enforces this relationship.