### PR TITLE
Update docs link from badge in readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,7 @@ GWCS - Generalized World Coordinate System
     :alt: CI Status
     
 .. image:: https://readthedocs.org/projects/docs/badge/?version=latest
-    :target: https://docs.readthedocs.io/en/latest/?badge=latest
+    :target: https://gwcs.readthedocs.io/en/latest/
     :alt: Documentation Status
 
 .. image:: https://codecov.io/gh/spacetelescope/gwcs/branch/master/graph/badge.svg?token=JtHal6Jbta


### PR DESCRIPTION
The current readme has a link to the docs for RTD (not GWCS), this points to the GWCS docs.