### PR TITLE
use OpenAstronomy reusable workflows and cache CRDS in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,21 +87,19 @@ jobs:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
           cache-dependency-path: pyproject.toml
-      - run: echo "CRDS_SERVER_URL=https://jwst-crds.stsci.edu" >> $GITHUB_ENV
-        if: contains( matrix.toxenv, '-jwst')
-      - run: echo "CRDS_SERVER_URL=https://roman-crds.stsci.edu" >> $GITHUB_ENV
-        if: contains(matrix.toxenv, '-roman')
-      - run: pip install crds
-        if: contains(matrix.toxenv, '-jwst') || contains(matrix.toxenv, '-roman')
+      - if: contains( matrix.toxenv, '-jwst')
+        run: echo "CRDS_SERVER_URL=https://jwst-crds.stsci.edu" >> $GITHUB_ENV
+      - if: contains(matrix.toxenv, '-roman')
+        run: echo "CRDS_SERVER_URL=https://roman-crds.stsci.edu" >> $GITHUB_ENV
+      - if: contains(matrix.toxenv, '-jwst') || contains(matrix.toxenv, '-roman')
+        run: pip install crds
       - run: echo "pmap=$(crds list --operational-context)" >> $GITHUB_OUTPUT
         id: crds-context
-      - uses: actions/cache@v3
+      - if: contains(matrix.toxenv, '-jwst') || contains(matrix.toxenv, '-roman')
+        uses: actions/cache@v3
         with:
           path: ${{ env.CRDS_PATH }}
           key: crds-${{ steps.crds-context.outputs.pmap }}
-        if: contains(matrix.toxenv, '-jwst') || contains(matrix.toxenv, '-roman')
-      - run: crds sync --contexts ${{ steps.crds-context.outputs.pmap }}
-        if: contains(matrix.toxenv, '-jwst') #|| contains(matrix.toxenv, '-roman')
       - run: pip install "tox>=4.0"
       - run: tox -e ${{ matrix.toxenv }}
       - if: contains(matrix.toxenv, '-cov')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,4 +96,3 @@ jobs:
       cache-key: crds-${{ needs.crds.outputs.context }}
       envs: |
         - linux: test-jwst-cov-xdist
-        - linux: test-romancal-cov-xdist

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,9 @@
-name: CI
+name: 'CI'
 
 on:
   push:
     branches:
-      - master
+      - 'master'
     tags:
       - '*'
   pull_request:
@@ -34,8 +34,49 @@ jobs:
       - run: pip install "tox>=4.0"
       - run: tox -e ${{ matrix.toxenv }}
   test:
-    name: ${{ matrix.toxenv }} (Python ${{ matrix.python-version }}, ${{ matrix.os }})
-    runs-on: ${{ matrix.os }}
+    uses: 'OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v1'
+    with:
+      envs: |
+        - linux: check-style
+        - linux: check-security
+        - linux: check-build
+        - linux: test
+          python-version: 3.9
+        - macos: test
+          python-version: 3.9
+        - linux: test
+          python-version: 3.10
+        - macos: test
+          python-version: 3.10
+        - linux: test
+          python-version: 3.11
+        - macos: test
+          python-version: 3.11
+        - linux: test-dev
+        - linux: test-pyargs
+          python-version: 3.11
+        - linux: test-cov
+          python-version: 3.11
+          coverage: codecov
+        - linux: test-numpy122
+          python-version: 3.10
+        - linux: test-numpy121
+          python-version: 3.10
+        - linux: test-numpy122
+          python-version: 3.9
+        - linux: test-numpy121
+          python-version: 3.9
+        - linux: test-numpy120
+          python-version: 3.9
+        - linux: test-numpy122
+          python-version: 3.8
+        - linux: test-numpy121
+          python-version: 3.8
+        - linux: test-numpy120
+          python-version: 3.8
+  downstream:
+    name: '${{ matrix.toxenv }} (Python ${{ matrix.python-version }}, ${{ matrix.os }})'
+    runs-on: '${{ matrix.runs-on }}'
     strategy:
       fail-fast: false
       matrix:
@@ -69,42 +110,3 @@ jobs:
             python-version: '3.9'
           - toxenv: test-jwst-xdist
             os: ubuntu-latest
-            python-version: '3.x'
-    #      - toxenv: test-romancal-xdist
-    #        os: ubuntu-latest
-    #        python-version: '3.x'
-    env:
-      CRDS_PATH: /home/runner/work/gwcs/crds_cache
-      CRDS_CLIENT_RETRY_COUNT: 3
-      CRDS_CLIENT_RETRY_DELAY_SECONDS: 20
-    steps:
-      - run: echo "HOME=$HOME" >> $GITHUB_ENV
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      - uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
-          cache: 'pip'
-          cache-dependency-path: pyproject.toml
-      - if: contains( matrix.toxenv, '-jwst')
-        run: echo "CRDS_SERVER_URL=https://jwst-crds.stsci.edu" >> $GITHUB_ENV
-      - if: contains(matrix.toxenv, '-roman')
-        run: echo "CRDS_SERVER_URL=https://roman-crds.stsci.edu" >> $GITHUB_ENV
-      - if: contains(matrix.toxenv, '-jwst') || contains(matrix.toxenv, '-roman')
-        run: pip install crds
-      - run: echo "pmap=$(crds list --operational-context)" >> $GITHUB_OUTPUT
-        id: crds-context
-      - if: contains(matrix.toxenv, '-jwst') || contains(matrix.toxenv, '-roman')
-        uses: actions/cache@v3
-        with:
-          path: ${{ env.CRDS_PATH }}
-          key: crds-${{ steps.crds-context.outputs.pmap }}
-      - run: pip install "tox>=4.0"
-      - run: tox -e ${{ matrix.toxenv }}
-      - if: contains(matrix.toxenv, '-cov')
-        uses: codecov/codecov-action@v3
-        with:
-          file: ./coverage.xml
-          flags: unit
-          fail_ci_if_error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,39 +55,41 @@ jobs:
           python-version: 3.11
           coverage: codecov
           pytest-results-summary: true
-  downstream:
-    name: '${{ matrix.toxenv }} (Python ${{ matrix.python-version }}, ${{ matrix.runs-on }})'
-    runs-on: '${{ matrix.runs-on }}'
-    strategy:
-      fail-fast: false
-      matrix:
-        toxenv: [ test ]
-        python-version: [ '3.9', '3.10', '3.11' ]
-        os: [ ubuntu-latest, macos-latest ]
-        include:
-          - toxenv: test-dev
-            os: ubuntu-latest
-            python-version: '3.x'
-          - toxenv: test-pyargs
-            os: ubuntu-latest
-            python-version: '3.11'
-          - toxenv: test-cov
-            os: ubuntu-latest
-            python-version: '3.11'
-          - toxenv: test-numpy122
-            os: ubuntu-latest
-            python-version: '3.10'
-          - toxenv: test-numpy121
-            os: ubuntu-latest
-            python-version: '3.10'
-          - toxenv: test-numpy122
-            os: ubuntu-latest
-            python-version: '3.9'
-          - toxenv: test-numpy121
-            os: ubuntu-latest
-            python-version: '3.9'
-          - toxenv: test-numpy120
-            os: ubuntu-latest
-            python-version: '3.9'
-          - toxenv: test-jwst-xdist
-            os: ubuntu-latest
+  crds:
+    name: retrieve current CRDS context
+    runs-on: ubuntu-latest
+    env:
+      OBSERVATORY: jwst
+      CRDS_PATH: /tmp/crds_cache
+      CRDS_SERVER_URL: https://jwst-crds.stsci.edu
+    steps:
+      - id: context
+        run: >
+          echo "pmap=$(
+          curl -s -X POST -d '{"jsonrpc": "1.0", "method": "get_default_context", "params": ["${{ env.OBSERVATORY }}"], "id": 1}' ${{ env.CRDS_SERVER_URL }}/json/ |
+          python -c "import sys, json; print(json.load(sys.stdin)['result'])"
+          )" >> $GITHUB_OUTPUT
+        # Get default CRDS_CONTEXT without installing crds client
+        # See https://hst-crds.stsci.edu/static/users_guide/web_services.html#generic-request
+      - id: path
+        run: echo "path=${{ env.CRDS_PATH }}" >> $GITHUB_OUTPUT
+      - id: server
+        run: echo "url=${{ env.CRDS_SERVER_URL }}" >> $GITHUB_OUTPUT
+    outputs:
+      context: ${{ steps.context.outputs.pmap }}
+      path: ${{ steps.path.outputs.path }}
+      server: ${{ steps.server.outputs.url }}
+  test_downstream:
+    uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@main
+    needs: [ crds ]
+    with:
+      setenv: |
+        CRDS_PATH: ${{ needs.crds.outputs.path }}
+        CRDS_SERVER_URL: ${{ needs.crds.outputs.server }}
+        CRDS_CLIENT_RETRY_COUNT: 3
+        CRDS_CLIENT_RETRY_DELAY_SECONDS: 20
+      cache-path: ${{ needs.crds.outputs.path }}
+      cache-key: crds-${{ needs.crds.outputs.context }}
+      envs: |
+        - linux: test-jwst-cov-xdist
+        - linux: test-romancal-cov-xdist

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,27 +14,15 @@ on:
 
 jobs:
   check:
-    name: ${{ matrix.toxenv }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        toxenv: [ check-style, check-security, check-build ]
-        python-version: [ '3.11' ]
-        os: [ ubuntu-latest ]
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      - uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
-          cache: 'pip'
-          cache-dependency-path: pyproject.toml
-      - run: pip install "tox>=4.0"
-      - run: tox -e ${{ matrix.toxenv }}
+    name: 
+    uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v1
+    with:
+      envs: |
+        - linux: check-style
+        - linux: check-security
+        - linux: check-build
   test:
-    uses: 'OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v1'
+    uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@main
     with:
       envs: |
         - linux: check-style
@@ -42,38 +30,31 @@ jobs:
         - linux: check-build
         - linux: test
           python-version: 3.9
-        - macos: test
+        - linux: test-numpy120
+          python-version: 3.9
+        - linux: test-numpy121
+          python-version: 3.9
+        - linux: test-numpy122
           python-version: 3.9
         - linux: test
           python-version: 3.10
-        - macos: test
+        - linux: test-numpy121
+          python-version: 3.10
+        - linux: test-numpy122
           python-version: 3.10
         - linux: test
           python-version: 3.11
+          pytest-results-summary: true
         - macos: test
           python-version: 3.11
+          pytest-results-summary: true
         - linux: test-dev
         - linux: test-pyargs
           python-version: 3.11
         - linux: test-cov
           python-version: 3.11
           coverage: codecov
-        - linux: test-numpy122
-          python-version: 3.10
-        - linux: test-numpy121
-          python-version: 3.10
-        - linux: test-numpy122
-          python-version: 3.9
-        - linux: test-numpy121
-          python-version: 3.9
-        - linux: test-numpy120
-          python-version: 3.9
-        - linux: test-numpy122
-          python-version: 3.8
-        - linux: test-numpy121
-          python-version: 3.8
-        - linux: test-numpy120
-          python-version: 3.8
+          pytest-results-summary: true
   downstream:
     name: '${{ matrix.toxenv }} (Python ${{ matrix.python-version }}, ${{ matrix.runs-on }})'
     runs-on: '${{ matrix.runs-on }}'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
         - linux: test-numpy120
           python-version: 3.8
   downstream:
-    name: '${{ matrix.toxenv }} (Python ${{ matrix.python-version }}, ${{ matrix.os }})'
+    name: '${{ matrix.toxenv }} (Python ${{ matrix.python-version }}, ${{ matrix.runs-on }})'
     runs-on: '${{ matrix.runs-on }}'
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,10 @@ on:
     # * is a special character in YAML so you have to quote this string
     - cron: '0 9 * * 1'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check:
     name: 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,9 +29,6 @@ jobs:
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@main
     with:
       envs: |
-        - linux: check-style
-        - linux: check-security
-        - linux: check-build
         - linux: test
           python-version: 3.9
         - linux: test-numpy120

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,16 +1,16 @@
-name: Publish to PyPI
+name: 'Publish to PyPI'
 
 on:
   release:
-    types: [released]
+    types: [ 'released' ]
 
 jobs:
   publish:
-    uses: spacetelescope/action-publish_to_pypi/.github/workflows/workflow.yml@master
+    uses: 'spacetelescope/action-publish_to_pypi/.github/workflows/workflow.yml@master'
     with:
       test: false
       build_platform_wheels: false # Set to true if your package contains a C extension
     secrets:
-      user: ${{ secrets.PYPI_USERNAME_STSCI_MAINTAINER }}
-      password: ${{ secrets.PYPI_PASSWORD_STSCI_MAINTAINER }} # WARNING: Do not hardcode secret values here! If you want to use a different user or password, you can override this secret by creating one with the same name in your Github repository settings.
-      test_password: ${{ secrets.PYPI_PASSWORD_STSCI_MAINTAINER_TEST }}
+      user: '${{ secrets.PYPI_USERNAME_STSCI_MAINTAINER }}'
+      password: '${{ secrets.PYPI_PASSWORD_STSCI_MAINTAINER }}' # WARNING: Do not hardcode secret values here! If you want to use a different user or password, you can override this secret by creating one with the same name in your Github repository settings.
+      test_password: '${{ secrets.PYPI_PASSWORD_STSCI_MAINTAINER_TEST }}'


### PR DESCRIPTION
this PR refactors the CI to hopefully make it more maintainable, and removes `crds sync` from the JWST job
<img width="627" alt="image" src="https://user-images.githubusercontent.com/16024299/236297651-a3134f23-1992-42ac-90fa-be2ab20fa9c9.png">
