### PR TITLE
fix jwst ci job

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -80,7 +80,7 @@ commands =
     warnings: -W error \
     xdist: -n auto \
     pyargs: {toxinidir}/docs --pyargs gwcs \
-    jwst: --pyargs jwst --ignore-glob=timeconversion --ignore-glob=associations \
+    jwst: --pyargs jwst --ignore-glob=timeconversion --ignore-glob=associations --ignore-glob=scripts\
     romancal: --pyargs romancal \
     cov: --cov=. --cov-config=setup.cfg --cov-report=term-missing --cov-report=xml \
     {posargs}


### PR DESCRIPTION
jwst ignores the `scripts` directory for pytest
https://github.com/spacetelescope/jwst/blob/4285c4efb95bc368f36456e9e106e6aba6abd597/setup.cfg#L152
this PR replicates that ignore to address CI failures seen for: 
https://github.com/spacetelescope/gwcs/pull/443