### PR TITLE
remove usages of deprecated `codecov` package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,6 @@ test = [
     "ci-watson>=0.3.0",
     "pytest>=4.6.0",
     "pytest-astropy",
-    "codecov",
 ]
 
 [build-system]


### PR DESCRIPTION
the `codecov` package is now deprecated and has been yanked from PyPI