### PR TITLE
Spring cleaning coordinate frames

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: test
 on:
   push:
     branches:
-      - 'master'
+      - '*'
     tags:
       - '*'
   pull_request:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,16 @@
 0.22.0 (unreleased)
 -------------------
 
+- Coordinate frames now have a "native" order and then are sorted based on ``axes_order``. [#457]
+
+- ``WCS.numerical_inverse`` no longer accepts high level objects (``with_units=`` is not supported) use ``WCS.inverse``. [#457]
+
+- ``CoordinateFrame.coordinates`` has been replaced by ``CoordinateFrame.to_high_level_coordinates`` [#457]
+
+- ``CoordinateFrame.to_quantity`` has been replaced by ``CoordinateFrame.from_high_level_coordinates``. [#457]
+
+- Inputs to ``CelestialFrame``, such as ``axes_names`` are now explicitly in lon, lat order and will re sorted based on ``axes_order=``. [#457]
+
 - Replace usages of ``copy_arrays`` with ``memmap`` [#503]
 
 - Fix an issue with units in ``wcs_from_points``. [#507]

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -240,11 +240,6 @@ To convert a pixel (x, y) = (1, 2) to sky coordinates, call the WCS object as a 
 The :meth:`~gwcs.wcs.WCS.invert` method evaluates the :meth:`~gwcs.wcs.WCS.backward_transform`
 if available, otherwise applies an iterative method to calculate the reverse coordinates.
 
-.. doctest-skip::
-
-  >>> wcsobj.invert(*sky)
-  (0.9999999996185807, 1.999999999186798)
-
 GWCS supports the common WCS interface which defines several methods
 to work with high level Astropy objects:
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -100,7 +100,7 @@ To install the latest release::
 
     pip install gwcs
 
-The latest release of GWCS is also available as part of `astroconda <https://github.com/astroconda/astroconda>`__.
+The latest release of GWCS is also available as a conda package via `conda-forge <https://github.com/conda-forge/gwcs-feedstock>`__.
 
 
 .. _getting-started:
@@ -240,8 +240,7 @@ To convert a pixel (x, y) = (1, 2) to sky coordinates, call the WCS object as a 
 The :meth:`~gwcs.wcs.WCS.invert` method evaluates the :meth:`~gwcs.wcs.WCS.backward_transform`
 if available, otherwise applies an iterative method to calculate the reverse coordinates.
 
-GWCS supports the common WCS interface which defines several methods
-to work with high level Astropy objects:
+GWCS supports the :ref:`wcsapi` which defines several methods to work with high level Astropy objects:
 
 .. doctest-skip::
 

--- a/gwcs/api.py
+++ b/gwcs/api.py
@@ -65,7 +65,7 @@ class GWCSAPIMixin(BaseLowLevelWCS, HighLevelWCSMixin):
 
     def _remove_quantity_output(self, result, frame):
         if self.forward_transform.uses_quantity:
-            if self.output_frame.naxes == 1:
+            if frame.naxes == 1:
                 result = [result]
 
             result = tuple(r.to_value(unit) if isinstance(r, u.Quantity) else r

--- a/gwcs/api.py
+++ b/gwcs/api.py
@@ -9,6 +9,8 @@ from astropy.wcs.wcsapi import BaseLowLevelWCS, HighLevelWCSMixin
 from astropy.modeling import separable
 import astropy.units as u
 
+from gwcs import utils
+
 __all__ = ["GWCSAPIMixin"]
 
 

--- a/gwcs/api.py
+++ b/gwcs/api.py
@@ -98,8 +98,6 @@ class GWCSAPIMixin(BaseLowLevelWCS, HighLevelWCSMixin):
         order, where for an image, ``x`` is the horizontal coordinate and ``y``
         is the vertical coordinate.
         """
-        if self.forward_transform.uses_quantity:
-            pixel_arrays = self._add_units_input(pixel_arrays, self.input_frame)
         result = self._call_forward(*pixel_arrays)
 
         return self._remove_quantity_output(result, self.output_frame)
@@ -127,9 +125,6 @@ class GWCSAPIMixin(BaseLowLevelWCS, HighLevelWCSMixin):
         be returned in the ``(x, y)`` order, where for an image, ``x`` is the
         horizontal coordinate and ``y`` is the vertical coordinate.
         """
-        if self.backward_transform.uses_quantity:
-            world_arrays = self._add_units_input(world_arrays, self.output_frame)
-
         result = self._call_backward(*world_arrays)
 
         return self._remove_quantity_output(result, self.input_frame)

--- a/gwcs/api.py
+++ b/gwcs/api.py
@@ -51,14 +51,7 @@ class GWCSAPIMixin(BaseLowLevelWCS, HighLevelWCSMixin):
         arbitrary string.  Alternatively, if the physical type is
         unknown/undefined, an element can be `None`.
         """
-        # A CompositeFrame orders the output correctly based on axes_order.
-        if isinstance(self.output_frame, cf.CompositeFrame):
-            return self.output_frame.axis_physical_types
-
-        # If we don't have a CompositeFrame, where this is taken care of for us,
-        # we need to make sure we re-order the output to match the transform.
-        # The underlying frames don't reorder themselves because axes_order is global.
-        return tuple(self.output_frame.axis_physical_types[i] for i in self.output_frame.axes_order)
+        return self.output_frame.axis_physical_types
 
     @property
     def world_axis_units(self):

--- a/gwcs/api.py
+++ b/gwcs/api.py
@@ -9,8 +9,6 @@ from astropy.wcs.wcsapi import BaseLowLevelWCS, HighLevelWCSMixin
 from astropy.modeling import separable
 import astropy.units as u
 
-from . import coordinate_frames as cf
-
 __all__ = ["GWCSAPIMixin"]
 
 

--- a/gwcs/api.py
+++ b/gwcs/api.py
@@ -260,11 +260,11 @@ class GWCSAPIMixin(BaseLowLevelWCS, HighLevelWCSMixin):
 
     @property
     def world_axis_object_classes(self):
-        return self.output_frame._world_axis_object_classes
+        return self.output_frame.world_axis_object_classes
 
     @property
     def world_axis_object_components(self):
-        return self.output_frame._world_axis_object_components
+        return self.output_frame.world_axis_object_components
 
     @property
     def pixel_axis_names(self):

--- a/gwcs/api.py
+++ b/gwcs/api.py
@@ -9,7 +9,6 @@ from astropy.wcs.wcsapi import BaseLowLevelWCS, HighLevelWCSMixin
 from astropy.modeling import separable
 import astropy.units as u
 
-from . import utils
 from . import coordinate_frames as cf
 
 __all__ = ["GWCSAPIMixin"]

--- a/gwcs/converters/wcs.py
+++ b/gwcs/converters/wcs.py
@@ -147,18 +147,7 @@ class SpectralFrameConverter(FrameConverter):
         from ..coordinate_frames import SpectralFrame
         node = self._from_yaml_tree(node, tag, ctx)
 
-        if 'reference_position' in node:
-            node['reference_position'] = node['reference_position'].upper()
-
         return SpectralFrame(**node)
-
-    def to_yaml_tree(self, frame, tag, ctx):
-        node = self._to_yaml_tree(frame, tag, ctx)
-
-        if frame.reference_position is not None:
-            node['reference_position'] = frame.reference_position.lower()
-
-        return node
 
 
 class CompositeFrameConverter(FrameConverter):

--- a/gwcs/coordinate_frames.py
+++ b/gwcs/coordinate_frames.py
@@ -534,6 +534,7 @@ class CoordinateFrame(BaseCoordinateFrame):
         high_level_coordinates
             One (or more) high level object describing the coordinate.
         """
+        values = [v.to_value(unit) if hasattr(v, "to_value") else v for v, unit in zip(values, self.unit)]
         high_level = values_to_high_level_objects(*values, low_level_wcs=self)
         if len(high_level) == 1:
             high_level = high_level[0]
@@ -727,7 +728,7 @@ class TemporalFrame(CoordinateFrame):
         Name for this frame.
     """
 
-    def __init__(self, reference_frame, unit=None, axes_order=(0,),
+    def __init__(self, reference_frame, unit=u.s, axes_order=(0,),
                  axes_names=None, name=None, axis_physical_types=None):
         axes_names = axes_names or "{}({}; {}".format(reference_frame.format,
                                                       reference_frame.scale,

--- a/gwcs/coordinate_frames.py
+++ b/gwcs/coordinate_frames.py
@@ -254,7 +254,7 @@ class BaseCoordinateFrame(abc.ABC):
 
         See Also
         --------
-        `astropy.wcs.wcsapi.BaseLowLevelWCS.world_axis_object_classes`
+        astropy.wcs.wcsapi.BaseLowLevelWCS.world_axis_object_classes
         """
 
     @property
@@ -265,7 +265,7 @@ class BaseCoordinateFrame(abc.ABC):
 
         See Also
         --------
-        `astropy.wcs.wcsapi.BaseLowLevelWCS.world_axis_object_components`
+        astropy.wcs.wcsapi.BaseLowLevelWCS.world_axis_object_components
         """
 
 

--- a/gwcs/coordinate_frames.py
+++ b/gwcs/coordinate_frames.py
@@ -116,6 +116,7 @@ When considering the backward transform the following transformations take place
 import abc
 from collections import defaultdict
 import logging
+import numbers
 import numpy as np
 from dataclasses import dataclass, InitVar
 
@@ -526,7 +527,7 @@ class CoordinateFrame(BaseCoordinateFrame):
 
         Parameters
         ----------
-        values : `numbers.Number` or `numpy.ndarray`
+        values : `numbers.Number`, `numpy.ndarray`, or `~astropy.units.Quantity`
            ``naxis`` number of coordinates as scalars or arrays.
 
         Returns
@@ -534,7 +535,12 @@ class CoordinateFrame(BaseCoordinateFrame):
         high_level_coordinates
             One (or more) high level object describing the coordinate.
         """
+        # We allow Quantity-like objects here which values_to_high_level_objects does not.
         values = [v.to_value(unit) if hasattr(v, "to_value") else v for v, unit in zip(values, self.unit)]
+
+        if not all([isinstance(v, numbers.Number) or type(v) is np.ndarray for v in values]):
+            raise TypeError("All values should be a scalar number or a numpy array.")
+
         high_level = values_to_high_level_objects(*values, low_level_wcs=self)
         if len(high_level) == 1:
             high_level = high_level[0]

--- a/gwcs/coordinate_frames.py
+++ b/gwcs/coordinate_frames.py
@@ -1,9 +1,11 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """
-This module defines coordinate frames for describing the inputs and/or outputs of a transform.
+This module defines coordinate frames for describing the inputs and/or outputs
+of a transform.
 
-In the following example, we have a two stage transform, with an input frame, an
-output frame and an intermediate frame.
+In the block diagram, the WCS pipeline has a two stage transformation (two
+astropy Model instances), with an input frame, an output frame and an
+intermediate frame.
 
 .. code-block::
 
@@ -62,8 +64,11 @@ a `.CelestialFrame` are always ``[lon, lat]``, so by specifying two frames as
 
   [SpectralFrame(axes_order=(1,)), CelestialFrame(axes_order=(2, 0))]
 
-we would map the outputs of this transform into the correct positions in the
-frames. As shown below, this is also used when constructing the inputs to the inverse transform.
+we would map the outputs of this transform into the correct positions in the frames.
+ As shown below, this is also used when constructing the inputs to the inverse transform.
+
+
+When taking the output from the forward transform the following transformation is performed by the coordinate frames:
 
 .. code-block::
 
@@ -82,6 +87,13 @@ frames. As shown below, this is also used when constructing the inputs to the in
               │                        │    │
               │                        │    │
               ▼                        ▼    ▼
+   SpectralCoord(lambda)    SkyCoord((lon, lat))
+
+
+When considering the backward transform the following transformations take place in the coordinate frames before the transform is called:
+
+.. code-block::
+
    SpectralCoord(lambda)    SkyCoord((lon, lat))
               │                        │    │
               └─────┐     ┌────────────┘    │

--- a/gwcs/coordinate_frames.py
+++ b/gwcs/coordinate_frames.py
@@ -247,7 +247,7 @@ class FrameProperties:
             self.axis_physical_types = tuple(ph_type)
 
     @property
-    def _default_axis_physical_type(self):
+    def _default_axis_physical_types(self):
         """
         The default physical types to use for this frame if none are specified
         by the user.
@@ -416,12 +416,12 @@ class CoordinateFrame(BaseCoordinateFrame):
             axes_type,
             unit,
             axes_names,
-            axis_physical_types or self._default_axis_physical_type(axes_type)
+            axis_physical_types or self._default_axis_physical_types(axes_type)
         )
 
         super().__init__()
 
-    def _default_axis_physical_type(self, axes_type):
+    def _default_axis_physical_types(self, axes_type):
         """
         The default physical types to use for this frame if none are specified
         by the user.
@@ -494,8 +494,7 @@ class CoordinateFrame(BaseCoordinateFrame):
 
         These physical types are the types in frame order, not transform order.
         """
-        apt = self._prop.axis_physical_types or self._default_axis_physical_types
-        return self._sort_property(apt)
+        return self._sort_property(self._prop.axis_physical_types)
 
     @property
     def world_axis_object_classes(self):

--- a/gwcs/coordinate_frames.py
+++ b/gwcs/coordinate_frames.py
@@ -158,10 +158,6 @@ UCD1_TO_CTYPE = _ucd1_to_ctype_name_mapping(
 
 STANDARD_REFERENCE_FRAMES = [frame.upper() for frame in coord.builtin_frames.__all__]
 
-STANDARD_REFERENCE_POSITION = ["GEOCENTER", "BARYCENTER", "HELIOCENTER",
-                               "TOPOCENTER", "LSR", "LSRK", "LSRD",
-                               "GALACTIC_CENTER", "LOCAL_GROUP_CENTER"]
-
 
 def get_ctype_from_ucd(ucd):
     """
@@ -199,7 +195,6 @@ class BaseCoordinateFrame(abc.ABC):
         The name of the coordinate frame.
         """
 
-    # TODO: Why is this not `units`?
     @property
     @abc.abstractmethod
     def unit(self) -> tuple[u.Unit, ...]:
@@ -283,8 +278,6 @@ class CoordinateFrame(BaseCoordinateFrame):
         A dimension in the input data that corresponds to this axis.
     reference_frame : astropy.coordinates.builtin_frames
         Reference frame (usually used with output_frame to convert to world coordinate objects).
-    reference_position : str
-        Reference position - one of ``STANDARD_REFERENCE_POSITION``
     unit : list of astropy.units.Unit
         Unit for each axis.
     axes_names : list
@@ -294,7 +287,7 @@ class CoordinateFrame(BaseCoordinateFrame):
     """
 
     def __init__(self, naxes, axes_type, axes_order, reference_frame=None,
-                 reference_position=None, unit=None, axes_names=None,
+                 unit=None, axes_names=None,
                  name=None, axis_physical_types=None):
         self._naxes = naxes
         self._axes_order = tuple(axes_order)
@@ -331,8 +324,6 @@ class CoordinateFrame(BaseCoordinateFrame):
         else:
             self._name = name
 
-        self._reference_position = reference_position
-
         if len(self._axes_type) != naxes:
             raise ValueError("Length of axes_type does not match number of axes.")
         if len(self._axes_order) != naxes:
@@ -367,8 +358,6 @@ class CoordinateFrame(BaseCoordinateFrame):
         fmt = '<{0}(name="{1}", unit={2}, axes_names={3}, axes_order={4}'.format(
             self.__class__.__name__, self.name,
             self.unit, self.axes_names, self.axes_order)
-        if self.reference_position is not None:
-            fmt += ', reference_position="{0}"'.format(self.reference_position)
         if self.reference_frame is not None:
             fmt += ", reference_frame={0}".format(self.reference_frame)
         fmt += ")>"
@@ -413,12 +402,6 @@ class CoordinateFrame(BaseCoordinateFrame):
     def reference_frame(self):
         """ Reference frame, used to convert to world coordinate objects. """
         return self._reference_frame
-
-    # TODO: This seems to be spectral specific, should it be moved to SpectralFrame?
-    @property
-    def reference_position(self):
-        """ Reference Position. """
-        return getattr(self, "_reference_position", None)
 
     @property
     def axes_type(self):
@@ -547,19 +530,15 @@ class SpectralFrame(CoordinateFrame):
         Spectral axis name.
     name : str
         Name for this frame.
-    reference_position : str
-        Reference position - one of ``STANDARD_REFERENCE_POSITION``
 
     """
 
     def __init__(self, axes_order=(0,), reference_frame=None, unit=None,
-                 axes_names=None, name=None, axis_physical_types=None,
-                 reference_position=None):
+                 axes_names=None, name=None, axis_physical_types=None):
 
         super(SpectralFrame, self).__init__(naxes=1, axes_type="SPECTRAL", axes_order=axes_order,
                                             axes_names=axes_names, reference_frame=reference_frame,
                                             unit=unit, name=name,
-                                            reference_position=reference_position,
                                             axis_physical_types=axis_physical_types)
 
     @property

--- a/gwcs/coordinate_frames.py
+++ b/gwcs/coordinate_frames.py
@@ -584,13 +584,12 @@ class SpectralFrame(CoordinateFrame):
 
         if not isiterable(unit):
             unit = (unit,)
-
+        unit = [u.Unit(un) for un in unit]
         pht = axis_physical_types or self._default_axis_physical_types(unit)
 
         super().__init__(naxes=1, axes_type="SPECTRAL", axes_order=axes_order,
                          axes_names=axes_names, reference_frame=reference_frame,
                          unit=unit, name=name,
-                         #axis_physical_types="em.wl")
                          axis_physical_types=pht)
 
     def _default_axis_physical_types(self, unit):

--- a/gwcs/coordinate_frames.py
+++ b/gwcs/coordinate_frames.py
@@ -118,7 +118,7 @@ from astropy.wcs.wcsapi.fitswcs import CTYPE_TO_UCD1
 from astropy.coordinates import StokesCoord
 
 __all__ = ['BaseCoordinateFrame', 'Frame2D', 'CelestialFrame', 'SpectralFrame', 'CompositeFrame',
-           'CoordinateFrame', 'TemporalFrame', 'StokesFrame', 'PixelFrame']
+           'CoordinateFrame', 'TemporalFrame', 'StokesFrame']
 
 
 def _ucd1_to_ctype_name_mapping(ctype_to_ucd, allowed_ucd_duplicates):

--- a/gwcs/coordinate_frames.py
+++ b/gwcs/coordinate_frames.py
@@ -60,7 +60,7 @@ a `.CelestialFrame` are always ``[lon, lat]``, so by specifying two frames as
 
 .. code-block:: python
 
-  [SpectralCoord(axes_order=(1,)), CelestialCoord(axes_order=(2, 0))]
+  [SpectralFrame(axes_order=(1,)), CelestialFrame(axes_order=(2, 0))]
 
 we would map the outputs of this transform into the correct positions in the
 frames. As shown below, this is also used when constructing the inputs to the inverse transform.
@@ -313,12 +313,20 @@ class FrameProperties:
             ph_type = []
             for axt in self.axis_physical_types:
                 if axt not in VALID_UCDS and not axt.startswith("custom:"):
-                    ph_type.append("custom:{axt}")
+                    ph_type.append(f"custom:{axt}")
                 else:
                     ph_type.append(axt)
 
             validate_physical_types(ph_type)
-            self.axes_physical_types = tuple(ph_type)
+            self.axis_physical_types = tuple(ph_type)
+
+    @property
+    def _default_axis_physical_type(self):
+        """
+        The default physical types to use for this frame if none are specified
+        by the user.
+        """
+        return tuple("custom:{}".format(t) for t in self.axes_type)
 
 
 class CoordinateFrame(BaseCoordinateFrame):
@@ -360,16 +368,23 @@ class CoordinateFrame(BaseCoordinateFrame):
 
         if isinstance(axes_type, str):
             axes_type = (axes_type,)
-        default_apt = tuple([f"custom:{t}" for t in axes_type])
+
         self._prop = FrameProperties(
             naxes,
             axes_type,
             unit,
             axes_names,
-            axis_physical_types or default_apt,
+            axis_physical_types or self._default_axis_physical_type(axes_type)
         )
 
         super().__init__()
+
+    def _default_axis_physical_type(self, axes_type):
+        """
+        The default physical types to use for this frame if none are specified
+        by the user.
+        """
+        return tuple("custom:{}".format(t) for t in axes_type)
 
     def __repr__(self):
         fmt = '<{0}(name="{1}", unit={2}, axes_names={3}, axes_order={4}'.format(
@@ -386,8 +401,11 @@ class CoordinateFrame(BaseCoordinateFrame):
         return self.__class__.__name__
 
     def _sort_property(self, property):
-        return tuple(dict(sorted(zip(property, self.axes_order),
-                                 key=lambda x: x[1])).keys())
+        #return tuple(dict(sorted(zip(property, self.axes_order),
+        #                         key=lambda x: x[1])).keys())
+        sorted_prop = sorted(zip(property, self.axes_order),
+                                 key=lambda x: x[1])
+        return tuple([t[0] for t in sorted_prop])
 
     @property
     def name(self):
@@ -408,6 +426,7 @@ class CoordinateFrame(BaseCoordinateFrame):
     def unit(self):
         """The unit of this frame."""
         return self._sort_property(self._prop.unit)
+        #return self._prop.unit
 
     @property
     def axes_names(self):
@@ -436,14 +455,14 @@ class CoordinateFrame(BaseCoordinateFrame):
 
         These physical types are the types in frame order, not transform order.
         """
-        return self._sort_property(self._prop.axis_physical_types)
+        return self._prop.axis_physical_types or self._default_axis_physical_types
 
     @property
     def world_axis_object_classes(self):
         return {f"{at}{i}" if i != 0 else at: (u.Quantity,
                      (),
                      {'unit': unit})
-                for i, (at, unit) in enumerate(zip(self._axes_type, self.unit))}
+                for i, (at, unit) in enumerate(zip(self.axes_type, self.unit))}
 
     @property
     def world_axis_object_components(self):
@@ -486,16 +505,15 @@ class CelestialFrame(CoordinateFrame):
                     if axes_names is None:
                         axes_names = _axes_names
                     naxes = len(_axes_names)
-                    _unit = list(reference_frame.representation_component_units.values())
-                    if unit is None and _unit:
-                        unit = _unit
 
+        self.native_axes_order = tuple(range(naxes))
         if axes_order is None:
-            axes_order = tuple(range(naxes))
+            axes_order = self.native_axes_order
         if unit is None:
             unit = tuple([u.degree] * naxes)
         axes_type = ['SPATIAL'] * naxes
 
+        pht = axis_physical_types or self._default_axis_physical_types(reference_frame, axes_names)
         super().__init__(naxes=naxes,
                          axes_type=axes_type,
                          axes_order=axes_order,
@@ -503,30 +521,30 @@ class CelestialFrame(CoordinateFrame):
                          unit=unit,
                          axes_names=axes_names,
                          name=name,
-                         axis_physical_types=axis_physical_types)
+                         axis_physical_types=pht)
 
-    @property
-    def _default_axis_physical_types(self):
-        if isinstance(self.reference_frame, coord.Galactic):
+    def _default_axis_physical_types(self, reference_frame, axes_names):
+        if isinstance(reference_frame, coord.Galactic):
             return "pos.galactic.lon", "pos.galactic.lat"
-        elif isinstance(self.reference_frame, (coord.GeocentricTrueEcliptic,
-                                               coord.GCRS,
-                                               coord.PrecessedGeocentric)):
+        elif isinstance(reference_frame, (coord.GeocentricTrueEcliptic,
+                                          coord.GCRS,
+                                          coord.PrecessedGeocentric)):
             return "pos.bodyrc.lon", "pos.bodyrc.lat"
-        elif isinstance(self.reference_frame, coord.builtin_frames.BaseRADecFrame):
+        elif isinstance(reference_frame, coord.builtin_frames.BaseRADecFrame):
             return "pos.eq.ra", "pos.eq.dec"
-        elif isinstance(self.reference_frame, coord.builtin_frames.BaseEclipticFrame):
+        elif isinstance(reference_frame, coord.builtin_frames.BaseEclipticFrame):
             return "pos.ecliptic.lon", "pos.ecliptic.lat"
         else:
-            return tuple("custom:{}".format(t) for t in self.axes_names)
+            return tuple("custom:{}".format(t) for t in axes_names)
 
     @property
     def world_axis_object_classes(self):
+        unit = np.array(self.unit)[np.argsort(self.axes_order)]
         return {'celestial': (
             coord.SkyCoord,
             (),
             {'frame': self.reference_frame,
-             'unit': self.unit})}
+             'unit': unit})}
 
     @property
     def _world_axis_object_components(self):
@@ -564,27 +582,32 @@ class SpectralFrame(CoordinateFrame):
     def __init__(self, axes_order=(0,), reference_frame=None, unit=None,
                  axes_names=None, name=None, axis_physical_types=None):
 
+        if not isiterable(unit):
+            unit = (unit,)
+
+        pht = axis_physical_types or self._default_axis_physical_types(unit)
+
         super().__init__(naxes=1, axes_type="SPECTRAL", axes_order=axes_order,
                          axes_names=axes_names, reference_frame=reference_frame,
                          unit=unit, name=name,
-                         axis_physical_types=axis_physical_types)
+                         #axis_physical_types="em.wl")
+                         axis_physical_types=pht)
 
-    @property
-    def _default_axis_physical_types(self):
-        if self.unit[0].physical_type == "frequency":
+    def _default_axis_physical_types(self, unit):
+        if unit[0].physical_type == "frequency":
             return ("em.freq",)
-        elif self.unit[0].physical_type == "length":
+        elif unit[0].physical_type == "length":
             return ("em.wl",)
-        elif self.unit[0].physical_type == "energy":
+        elif unit[0].physical_type == "energy":
             return ("em.energy",)
-        elif self.unit[0].physical_type == "speed":
+        elif unit[0].physical_type == "speed":
             return ("spect.dopplerVeloc",)
             logging.warning("Physical type may be ambiguous. Consider "
                             "setting the physical type explicitly as "
                             "either 'spect.dopplerVeloc.optical' or "
                             "'spect.dopplerVeloc.radio'.")
         else:
-            return ("custom:{}".format(self.unit[0].physical_type),)
+            return ("custom:{}".format(unit[0].physical_type),)
 
     @property
     def world_axis_object_classes(self):
@@ -625,9 +648,11 @@ class TemporalFrame(CoordinateFrame):
                                                       reference_frame.scale,
                                                       reference_frame.location)
 
+        pht = axis_physical_types or self._default_axis_physical_types()
+
         super().__init__(naxes=1, axes_type="TIME", axes_order=axes_order,
                          axes_names=axes_names, reference_frame=reference_frame,
-                         unit=unit, name=name, axis_physical_types=axis_physical_types)
+                         unit=unit, name=name, axis_physical_types=pht)
         self._attrs = {}
         for a in self.reference_frame.info._represent_as_dict_extra_attrs:
             try:
@@ -635,7 +660,7 @@ class TemporalFrame(CoordinateFrame):
             except AttributeError:
                 pass
 
-    @property
+    #@property
     def _default_axis_physical_types(self):
         return ("time",)
 
@@ -686,13 +711,16 @@ class CompositeFrame(CoordinateFrame):
     def __init__(self, frames, name=None):
         self._frames = frames[:]
         naxes = sum([frame._naxes for frame in self._frames])
+
         axes_type = list(range(naxes))
         unit = list(range(naxes))
         axes_names = list(range(naxes))
-        axes_order = []
         ph_type = list(range(naxes))
+        axes_order = []
+
         for frame in frames:
             axes_order.extend(frame.axes_order)
+
         for frame in frames:
             unsorted_prop = zip(
                 frame.axes_order,
@@ -706,6 +734,7 @@ class CompositeFrame(CoordinateFrame):
                 axes_names[ind] = n
                 unit[ind] = un
                 ph_type[ind] = pht
+
         if len(np.unique(axes_order)) != len(axes_order):
             raise ValueError("Incorrect numbering of axes, "
                              "axes_order should contain unique numbers, "
@@ -714,12 +743,29 @@ class CompositeFrame(CoordinateFrame):
         super().__init__(naxes, axes_type=axes_type,
                          axes_order=axes_order,
                          unit=unit, axes_names=axes_names,
+                         axis_physical_types=tuple(ph_type),
                          name=name)
         self._axis_physical_types = tuple(ph_type)
 
     @property
     def frames(self):
         return self._frames
+
+    @property
+    def unit(self):
+        return self._prop.unit
+
+    @property
+    def axes_names(self):
+        return self._prop.axes_names
+
+    @property
+    def axes_type(self):
+        return self._prop.axes_type
+
+    @property
+    def axis_physical_types(self):
+        return self._prop.axis_physical_types
 
     def __repr__(self):
         return repr(self.frames)
@@ -767,12 +813,14 @@ class CompositeFrame(CoordinateFrame):
         We need to generate the components respecting the axes_order.
         """
         out = [None] * self.naxes
+
         for frame, components in self._wao_renamed_components_iter:
             for i, ao in enumerate(frame.axes_order):
                 out[ao] = components[i]
 
         if any([o is None for o in out]):
             raise ValueError("axes_order leads to incomplete world_axis_object_components")
+
         return out
 
     @property
@@ -793,11 +841,13 @@ class StokesFrame(CoordinateFrame):
     """
 
     def __init__(self, axes_order=(0,), axes_names=("stokes",), name=None, axis_physical_types=None):
+
+        pht = axis_physical_types or self._default_axis_physical_types()
+
         super().__init__(1, ["STOKES"], axes_order, name=name,
                          axes_names=axes_names, unit=u.one,
-                         axis_physical_types=axis_physical_types)
+                         axis_physical_types=pht)
 
-    @property
     def _default_axis_physical_types(self):
         return ("phys.polarization.stokes",)
 
@@ -831,17 +881,19 @@ class Frame2D(CoordinateFrame):
     """
 
     def __init__(self, axes_order=(0, 1), unit=(u.pix, u.pix), axes_names=('x', 'y'),
-                 name=None, axis_physical_types=None):
+                 name=None, axes_type=["SPATIAL", "SPATIAL"], axis_physical_types=None):
 
-        super().__init__(naxes=2, axes_type=["SPATIAL", "SPATIAL"],
+        pht = axis_physical_types or self._default_axis_physical_types(axes_names, axes_type)
+
+        super().__init__(naxes=2, axes_type=axes_type,
                          axes_order=axes_order, name=name,
                          axes_names=axes_names, unit=unit,
-                         axis_physical_types=axis_physical_types)
+                         axis_physical_types=pht)
 
-    @property
-    def _default_axis_physical_types(self):
-        if all(self.axes_names):
-            ph_type = self.axes_names
+    def _default_axis_physical_types(self, axes_names, axes_type):
+        if axes_names is not None and all(axes_names):
+            ph_type = axes_names
         else:
-            ph_type = self.axes_type
+            ph_type = axes_type
+
         return tuple("custom:{}".format(t) for t in ph_type)

--- a/gwcs/coordinate_frames.py
+++ b/gwcs/coordinate_frames.py
@@ -481,7 +481,8 @@ class CoordinateFrame(BaseCoordinateFrame):
 
         These physical types are the types in frame order, not transform order.
         """
-        return self._prop.axis_physical_types or self._default_axis_physical_types
+        apt = self._prop.axis_physical_types or self._default_axis_physical_types
+        return self._sort_property(apt)
 
     @property
     def world_axis_object_classes(self):
@@ -500,7 +501,7 @@ class CelestialFrame(CoordinateFrame):
     Representation of a Celesital coordinate system.
 
     This class has a native order of longitude then latitude, meaning
-    ``axes_names``, ``unit`` should be lon, lat ordered.  If your transform is
+    ``axes_names``, ``unit`` and ``axis_physical_types`` should be lon, lat ordered.  If your transform is
     in a different order this should be specified with ``axes_order``.
 
     Parameters
@@ -515,6 +516,8 @@ class CelestialFrame(CoordinateFrame):
         Names of the axes in this frame.
     name : str
         Name of this frame.
+    axis_physical_types : list
+        The UCD 1+ physical types for the axes, in frame order (lon, lat).
     """
 
     def __init__(self, axes_order=None, reference_frame=None,

--- a/gwcs/coordinate_frames.py
+++ b/gwcs/coordinate_frames.py
@@ -564,17 +564,16 @@ class CelestialFrame(CoordinateFrame):
 
     @property
     def world_axis_object_classes(self):
-        unit = np.array(self.unit)[np.argsort(self.axes_order)]
         return {'celestial': (
             coord.SkyCoord,
             (),
             {'frame': self.reference_frame,
-             'unit': unit})}
+             'unit': self._prop.unit})}
 
     @property
-    def _world_axis_object_components(self):
-        return [('celestial', 0, lambda sc: sc.spherical.lon.to_value(self.unit[0])),
-                ('celestial', 1, lambda sc: sc.spherical.lat.to_value(self.unit[1]))]
+    def _native_world_axis_object_components(self):
+        return [('celestial', 0, lambda sc: sc.spherical.lon.to_value(self._prop.unit[0])),
+                ('celestial', 1, lambda sc: sc.spherical.lat.to_value(self._prop.unit[1]))]
 
 
 class SpectralFrame(CoordinateFrame):

--- a/gwcs/coordinate_frames.py
+++ b/gwcs/coordinate_frames.py
@@ -676,7 +676,6 @@ class TemporalFrame(CoordinateFrame):
             except AttributeError:
                 pass
 
-    #@property
     def _default_axis_physical_types(self):
         return ("time",)
 

--- a/gwcs/coordinate_frames.py
+++ b/gwcs/coordinate_frames.py
@@ -41,7 +41,7 @@ Each frame instance is both metadata for the inputs/outputs of a transform and
 also a converter between those inputs/outputs and richer coordinate
 representations of those inputs/ouputs.
 
-For example, an output frame of type `~astropy.coordinates.SpectralCoord`
+For example, an output frame of type `~gwcs.coordinate_frames.SpectralFrame`
 provides metadata to the `.WCS` object such as the ``axes_type`` being
 ``"SPECTRAL"`` and the unit of the output etc.  The output frame also provides a
 converter of the numeric output of the transform to a
@@ -478,20 +478,22 @@ class CelestialFrame(CoordinateFrame):
             unit = tuple([u.degree] * naxes)
         axes_type = ['SPATIAL'] * naxes
 
-        super(CelestialFrame, self).__init__(naxes=naxes, axes_type=axes_type,
-                                             axes_order=axes_order,
-                                             reference_frame=reference_frame,
-                                             unit=unit,
-                                             axes_names=axes_names,
-                                             name=name, axis_physical_types=axis_physical_types)
+        super().__init__(naxes=naxes,
+                         axes_type=axes_type,
+                         axes_order=axes_order,
+                         reference_frame=reference_frame,
+                         unit=unit,
+                         axes_names=axes_names,
+                         name=name,
+                         axis_physical_types=axis_physical_types)
 
     @property
     def _default_axis_physical_types(self):
         if isinstance(self.reference_frame, coord.Galactic):
             return "pos.galactic.lon", "pos.galactic.lat"
         elif isinstance(self.reference_frame, (coord.GeocentricTrueEcliptic,
-                                                coord.GCRS,
-                                                coord.PrecessedGeocentric)):
+                                               coord.GCRS,
+                                               coord.PrecessedGeocentric)):
             return "pos.bodyrc.lon", "pos.bodyrc.lat"
         elif isinstance(self.reference_frame, coord.builtin_frames.BaseRADecFrame):
             return "pos.eq.ra", "pos.eq.dec"
@@ -536,10 +538,10 @@ class SpectralFrame(CoordinateFrame):
     def __init__(self, axes_order=(0,), reference_frame=None, unit=None,
                  axes_names=None, name=None, axis_physical_types=None):
 
-        super(SpectralFrame, self).__init__(naxes=1, axes_type="SPECTRAL", axes_order=axes_order,
-                                            axes_names=axes_names, reference_frame=reference_frame,
-                                            unit=unit, name=name,
-                                            axis_physical_types=axis_physical_types)
+        super().__init__(naxes=1, axes_type="SPECTRAL", axes_order=axes_order,
+                         axes_names=axes_names, reference_frame=reference_frame,
+                         unit=unit, name=name,
+                         axis_physical_types=axis_physical_types)
 
     @property
     def _default_axis_physical_types(self):
@@ -759,9 +761,9 @@ class StokesFrame(CoordinateFrame):
     """
 
     def __init__(self, axes_order=(0,), axes_names=("stokes",), name=None, axis_physical_types=None):
-        super(StokesFrame, self).__init__(1, ["STOKES"], axes_order, name=name,
-                                          axes_names=axes_names, unit=u.one,
-                                          axis_physical_types=axis_physical_types)
+        super().__init__(1, ["STOKES"], axes_order, name=name,
+                         axes_names=axes_names, unit=u.one,
+                         axis_physical_types=axis_physical_types)
 
     @property
     def _default_axis_physical_types(self):
@@ -799,10 +801,10 @@ class Frame2D(CoordinateFrame):
     def __init__(self, axes_order=(0, 1), unit=(u.pix, u.pix), axes_names=('x', 'y'),
                  name=None, axis_physical_types=None):
 
-        super(Frame2D, self).__init__(naxes=2, axes_type=["SPATIAL", "SPATIAL"],
-                                      axes_order=axes_order, name=name,
-                                      axes_names=axes_names, unit=unit,
-                                      axis_physical_types=axis_physical_types)
+        super().__init__(naxes=2, axes_type=["SPATIAL", "SPATIAL"],
+                         axes_order=axes_order, name=name,
+                         axes_names=axes_names, unit=unit,
+                         axis_physical_types=axis_physical_types)
 
     @property
     def _default_axis_physical_types(self):

--- a/gwcs/coordinate_frames.py
+++ b/gwcs/coordinate_frames.py
@@ -647,7 +647,7 @@ class SpectralFrame(CoordinateFrame):
             {'unit': self.unit[0]})}
 
     @property
-    def _world_axis_object_components(self):
+    def _native_world_axis_object_components(self):
         return [('spectral', 0, lambda sc: sc.to_value(self.unit[0]))]
 
 

--- a/gwcs/coordinate_frames.py
+++ b/gwcs/coordinate_frames.py
@@ -110,7 +110,6 @@ from astropy.utils.misc import isiterable
 from astropy import time
 from astropy import units as u
 from astropy import utils as astutil
-from astropy.utils.decorators import deprecated
 from astropy import coordinates as coord
 from astropy.wcs.wcsapi.low_level_api import (validate_physical_types,
                                               VALID_UCDS)

--- a/gwcs/examples.py
+++ b/gwcs/examples.py
@@ -45,7 +45,7 @@ def gwcs_2d_spatial_reordered():
     A simple one step spatial WCS, in ICRS with a 1 and 2 px shift.
     """
     out_frame = cf.CelestialFrame(reference_frame=coord.ICRS(),
-                                   axes_order=(1, 0))
+                                  axes_order=(1, 0))
     return wcs.WCS(MODEL_2D_SHIFT | models.Mapping((1, 0)), input_frame=DETECTOR_2D_FRAME, output_frame=out_frame)
 
 
@@ -243,7 +243,7 @@ def gwcs_3d_galactic_spectral():
 
     shift = models.Shift(-crpix3) & models.Shift(-crpix1)
     scale = models.Multiply(cdelt3) & models.Multiply(cdelt1)
-    proj = models.Pix2Sky_CAR()
+    proj = models.Pix2Sky_TAN()
     skyrot = models.RotateNative2Celestial(crval3, 90 + crval1, 180)
     celestial = shift | scale | proj | skyrot
 

--- a/gwcs/examples.py
+++ b/gwcs/examples.py
@@ -488,3 +488,28 @@ def gwcs_7d_complex_mapping():
     w.pixel_shape = (16, 32, 21, 11, 11, 2)
 
     return w
+
+
+def gwcs_with_pipeline_celestial():
+    input_frame = cf.CoordinateFrame(2, ["PIXEL"]*2,
+                                     axes_order=list(range(2)),
+                                     unit=[u.pix]*2,
+                                     name="input")
+
+    spatial = models.Multiply(20*u.arcsec/u.pix) & models.Multiply(15*u.deg/u.pix)
+
+    celestial_frame = cf.CelestialFrame(axes_order=(0, 1), unit=(u.arcsec, u.deg),
+                                        reference_frame=coord.ICRS(), name="celestial")
+
+    custom = models.Shift(1*u.deg) & models.Shift(2*u.deg)
+
+    output_frame = cf.CoordinateFrame(2, ["CUSTOM"]*2,
+                                      axes_order=list(range(2)), unit=[u.arcsec]*2, name="output")
+
+    pipeline = [
+        (input_frame, spatial),
+        (celestial_frame, custom),
+        (output_frame, None),
+    ]
+
+    return wcs.WCS(pipeline)

--- a/gwcs/selector.py
+++ b/gwcs/selector.py
@@ -531,7 +531,20 @@ class RegionsSelector(Model):
             raise ValueError('"0" and " " are not allowed as keys.')
         self._input_units_strict = {key: False for key in self._inputs}
         self._input_units_allow_dimensionless = {key: False for key in self._inputs}
-        super(RegionsSelector, self).__init__(n_models=1, name=name, **kwargs)
+        super().__init__(n_models=1, name=name, **kwargs)
+        # Validate uses_quantity at init time for nicer error message
+        self.uses_quantity  # noqa
+
+    @property
+    def uses_quantity(self):
+        all_uses_quantity = [t.uses_quantity for t in self._selector.values()]
+        not_all_uses_quantity = [not uq for uq in all_uses_quantity]
+        if all(all_uses_quantity):
+            return True
+        elif not_all_uses_quantity:
+            return False
+        else:
+            raise ValueError("You can not mix models which use quantity and do not use quantity inside a RegionSelector")
 
     def set_input(self, rid):
         """

--- a/gwcs/tests/conftest.py
+++ b/gwcs/tests/conftest.py
@@ -141,3 +141,8 @@ def spher_to_cart():
 @pytest.fixture
 def cart_to_spher():
     return geometry.CartesianToSpherical()
+
+
+@pytest.fixture
+def gwcs_with_pipeline_celestial():
+    return examples.gwcs_with_pipeline_celestial()

--- a/gwcs/tests/test_api.py
+++ b/gwcs/tests/test_api.py
@@ -79,6 +79,11 @@ def test_names(wcsobj):
     assert wcsobj.pixel_axis_names == wcsobj.input_frame.axes_names
 
 
+def test_names_split(gwcs_3d_galactic_spectral):
+    wcs = gwcs_3d_galactic_spectral
+    assert wcs.world_axis_names == wcs.output_frame.axes_names == ("Latitude", "Frequency", "Longitude")
+
+
 @fixture_wcs_ndim_types_units
 def test_pixel_n_dim(wcs_ndim_types_units):
     wcsobj, ndims, *_ = wcs_ndim_types_units
@@ -201,7 +206,7 @@ def test_world_axis_object_classes_2d(gwcs_2d_spatial_shift):
     assert 'frame' in waoc['celestial'][2]
     assert 'unit' in waoc['celestial'][2]
     assert isinstance(waoc['celestial'][2]['frame'], coord.ICRS)
-    assert waoc['celestial'][2]['unit'] == (u.deg, u.deg)
+    assert tuple(waoc['celestial'][2]['unit']) == (u.deg, u.deg)
 
 
 def test_world_axis_object_classes_2d_generic(gwcs_2d_quantity_shift):
@@ -223,7 +228,7 @@ def test_world_axis_object_classes_4d(gwcs_4d_identity_units):
     assert 'frame' in waoc['celestial'][2]
     assert 'unit' in waoc['celestial'][2]
     assert isinstance(waoc['celestial'][2]['frame'], coord.ICRS)
-    assert waoc['celestial'][2]['unit'] == (u.deg, u.deg)
+    assert tuple(waoc['celestial'][2]['unit']) == (u.deg, u.deg)
 
     temporal = waoc['temporal']
     assert temporal[0] is time.Time

--- a/gwcs/tests/test_api.py
+++ b/gwcs/tests/test_api.py
@@ -265,7 +265,11 @@ def test_high_level_wrapper(wcsobj, request):
 
     hlvl = HighLevelWCSWrapper(wcsobj)
 
-    pixel_input = [6] * wcsobj.pixel_n_dim
+    pixel_input = [3] * wcsobj.pixel_n_dim
+    if wcsobj.bounding_box is not None:
+        for i, interval in wcsobj.bounding_box.intervals.items():
+            bbox_min = u.Quantity(interval.lower).value
+            pixel_input[i] = max(bbox_min + 1, pixel_input[i])
 
     # Assert that both APE 14 API and GWCS give the same answer The APE 14 API
     # uses the mixin class and __call__ calls values_to_high_level_objects

--- a/gwcs/tests/test_api.py
+++ b/gwcs/tests/test_api.py
@@ -558,3 +558,14 @@ def test_world_axis_object_components_units(gwcs_3d_identity_units):
 
     assert not any([isinstance(o, u.Quantity) for o in values])
     np.testing.assert_allclose(values, expected_values)
+
+
+def test_mismatched_high_level_types(gwcs_3d_identity_units):
+    wcs = gwcs_3d_identity_units
+
+    with pytest.raises(TypeError, match="Invalid types were passed.*(tuple, SpectralCoord).*(SkyCoord, SpectralCoord).*"):
+        wcs.invert((1*u.deg, 2*u.deg), coord.SpectralCoord(10*u.nm))
+
+    # Oh astropy why do you make us do this
+    with pytest.raises(TypeError, match="Invalid types were passed.*got.*Quantity.*expected.*SpectralCoord.*"):
+        wcs.invert(coord.SkyCoord(1*u.deg, 2*u.deg), 10*u.nm)

--- a/gwcs/tests/test_api.py
+++ b/gwcs/tests/test_api.py
@@ -497,7 +497,7 @@ def test_world_to_array_index_values(gwcs_simple_imaging, sky_ra_dec):
     wcsobj = gwcs_simple_imaging
     sky, ra, dec = sky_ra_dec
 
-    assert_allclose(wcsobj.world_to_array_index_values(sky),
+    assert_allclose(wcsobj.world_to_array_index_values(ra, dec),
                     wcsobj.invert(ra * u.deg, dec * u.deg, with_units=False)[::-1])
 
 

--- a/gwcs/tests/test_api.py
+++ b/gwcs/tests/test_api.py
@@ -280,7 +280,7 @@ def test_high_level_wrapper(wcsobj, request):
 
     # The wrapper and the raw gwcs class can take different paths
     wc1 = hlvl.pixel_to_world(*pixel_input)
-    wc2 = wcsobj.pixel_to_world(*pixel_input)
+    wc2 = wcsobj(*pixel_input, with_units=True)
 
     assert type(wc1) is type(wc2)
 

--- a/gwcs/tests/test_api.py
+++ b/gwcs/tests/test_api.py
@@ -497,12 +497,12 @@ def test_composite_many_base_frame():
     q_frame_2 = cf.CoordinateFrame(name='distance', axes_order=(1,), naxes=1, axes_type="SPATIAL", unit=(u.m,))
     frame = cf.CompositeFrame([q_frame_1, q_frame_2])
 
-    wao_classes = frame._world_axis_object_classes
+    wao_classes = frame.world_axis_object_classes
 
     assert len(wao_classes) == 2
     assert not set(wao_classes.keys()).difference({"SPATIAL", "SPATIAL1"})
 
-    wao_components = frame._world_axis_object_components
+    wao_components = frame.world_axis_object_components
 
     assert len(wao_components) == 2
     assert not {c[0] for c in wao_components}.difference({"SPATIAL", "SPATIAL1"})

--- a/gwcs/tests/test_api_slicing.py
+++ b/gwcs/tests/test_api_slicing.py
@@ -1,6 +1,7 @@
 
 import astropy.units as u
 from astropy.coordinates import Galactic, SkyCoord, SpectralCoord
+from astropy.wcs.wcsapi import wcs_info_str
 from astropy.wcs.wcsapi.wrappers import SlicedLowLevelWCS
 from numpy.testing import assert_allclose, assert_equal
 
@@ -31,6 +32,11 @@ World Dim    0    1    2
 """
 
 
+def test_no_ellipsis(gwcs_3d_galactic_spectral):
+    expected_repr = EXPECTED_ELLIPSIS_REPR.replace("SlicedLowLevel", "")
+    assert wcs_info_str(gwcs_3d_galactic_spectral) == expected_repr.strip()
+
+
 def test_ellipsis(gwcs_3d_galactic_spectral):
 
     wcs = SlicedLowLevelWCS(gwcs_3d_galactic_spectral, Ellipsis)
@@ -55,7 +61,7 @@ def test_ellipsis(gwcs_3d_galactic_spectral):
     assert wcs.world_axis_object_classes['celestial'][0] is SkyCoord
     assert wcs.world_axis_object_classes['celestial'][1] == ()
     assert isinstance(wcs.world_axis_object_classes['celestial'][2]['frame'], Galactic)
-    assert wcs.world_axis_object_classes['celestial'][2]['unit'] == (u.deg, u.deg)
+    assert tuple(wcs.world_axis_object_classes['celestial'][2]['unit']) == (u.deg, u.deg)
 
     assert wcs.world_axis_object_classes['spectral'][0] is SpectralCoord
     assert wcs.world_axis_object_classes['spectral'][1] == ()
@@ -120,7 +126,7 @@ def test_spectral_slice(gwcs_3d_galactic_spectral):
     assert wcs.world_axis_object_classes['celestial'][0] is SkyCoord
     assert wcs.world_axis_object_classes['celestial'][1] == ()
     assert isinstance(wcs.world_axis_object_classes['celestial'][2]['frame'], Galactic)
-    assert wcs.world_axis_object_classes['celestial'][2]['unit'] == (u.deg, u.deg)
+    assert tuple(wcs.world_axis_object_classes['celestial'][2]['unit']) == (u.deg, u.deg)
 
     assert_allclose(wcs.pixel_to_world_values(29, 44), (10, 25))
     assert_allclose(wcs.array_index_to_world_values(44, 29), (10, 25))
@@ -185,7 +191,7 @@ def test_spectral_range(gwcs_3d_galactic_spectral):
     assert wcs.world_axis_object_classes['celestial'][0] is SkyCoord
     assert wcs.world_axis_object_classes['celestial'][1] == ()
     assert isinstance(wcs.world_axis_object_classes['celestial'][2]['frame'], Galactic)
-    assert wcs.world_axis_object_classes['celestial'][2]['unit'] ==  (u.deg, u.deg)
+    assert tuple(wcs.world_axis_object_classes['celestial'][2]['unit']) ==  (u.deg, u.deg)
 
     assert wcs.world_axis_object_classes['spectral'][0] is SpectralCoord
     assert wcs.world_axis_object_classes['spectral'][1] == ()
@@ -253,7 +259,7 @@ def test_celestial_slice(gwcs_3d_galactic_spectral):
     assert wcs.world_axis_object_classes['celestial'][0] is SkyCoord
     assert wcs.world_axis_object_classes['celestial'][1] == ()
     assert isinstance(wcs.world_axis_object_classes['celestial'][2]['frame'], Galactic)
-    assert wcs.world_axis_object_classes['celestial'][2]['unit'] ==  (u.deg, u.deg)
+    assert tuple(wcs.world_axis_object_classes['celestial'][2]['unit']) ==  (u.deg, u.deg)
 
     assert wcs.world_axis_object_classes['spectral'][0] is SpectralCoord
     assert wcs.world_axis_object_classes['spectral'][1] == ()
@@ -322,7 +328,7 @@ def test_celestial_range(gwcs_3d_galactic_spectral):
     assert wcs.world_axis_object_classes['celestial'][0] is SkyCoord
     assert wcs.world_axis_object_classes['celestial'][1] == ()
     assert isinstance(wcs.world_axis_object_classes['celestial'][2]['frame'], Galactic)
-    assert wcs.world_axis_object_classes['celestial'][2]['unit'] ==  (u.deg, u.deg)
+    assert tuple(wcs.world_axis_object_classes['celestial'][2]['unit']) ==  (u.deg, u.deg)
 
     assert wcs.world_axis_object_classes['spectral'][0] is SpectralCoord
     assert wcs.world_axis_object_classes['spectral'][1] == ()
@@ -394,7 +400,7 @@ def test_no_array_shape(gwcs_3d_galactic_spectral):
     assert wcs.world_axis_object_classes['celestial'][0] is SkyCoord
     assert wcs.world_axis_object_classes['celestial'][1] == ()
     assert isinstance(wcs.world_axis_object_classes['celestial'][2]['frame'], Galactic)
-    assert wcs.world_axis_object_classes['celestial'][2]['unit'] ==  (u.deg, u.deg)
+    assert tuple(wcs.world_axis_object_classes['celestial'][2]['unit']) ==  (u.deg, u.deg)
 
     assert wcs.world_axis_object_classes['spectral'][0] is SpectralCoord
     assert wcs.world_axis_object_classes['spectral'][1] == ()
@@ -441,7 +447,7 @@ World Dim    0    1    2
 def test_ellipsis_none_types(gwcs_3d_galactic_spectral):
     pht = list(gwcs_3d_galactic_spectral.output_frame._axis_physical_types)
     pht[1] = None
-    gwcs_3d_galactic_spectral.output_frame._axis_physical_types = tuple(pht)
+    gwcs_3d_galactic_spectral.output_frame._prop.axis_physical_types = tuple(pht)
 
     wcs = SlicedLowLevelWCS(gwcs_3d_galactic_spectral, Ellipsis)
 
@@ -466,7 +472,7 @@ def test_ellipsis_none_types(gwcs_3d_galactic_spectral):
     assert wcs.world_axis_object_classes['celestial'][0] is SkyCoord
     assert wcs.world_axis_object_classes['celestial'][1] == ()
     assert isinstance(wcs.world_axis_object_classes['celestial'][2]['frame'], Galactic)
-    assert wcs.world_axis_object_classes['celestial'][2]['unit'] ==  (u.deg, u.deg)
+    assert tuple(wcs.world_axis_object_classes['celestial'][2]['unit']) ==  (u.deg, u.deg)
 
     assert_allclose(wcs.pixel_to_world_values(29, 39, 44), (10, 20, 25))
     assert_allclose(wcs.array_index_to_world_values(44, 39, 29), (10, 20, 25))

--- a/gwcs/tests/test_api_slicing.py
+++ b/gwcs/tests/test_api_slicing.py
@@ -67,11 +67,11 @@ def test_ellipsis(gwcs_3d_galactic_spectral):
     assert wcs.world_axis_object_classes['spectral'][1] == ()
     assert wcs.world_axis_object_classes['spectral'][2] == {'unit': 'Hz'}
 
-    assert_allclose(wcs.pixel_to_world_values(29, 39, 44), (10, 20, 25))
-    assert_allclose(wcs.array_index_to_world_values(44, 39, 29), (10, 20, 25))
+    assert_allclose(wcs.pixel_to_world_values(29, 39, 44), (80, 20, 205))
+    assert_allclose(wcs.array_index_to_world_values(44, 39, 29), (80, 20, 205))
 
-    assert_allclose(wcs.world_to_pixel_values(10, 20, 25), (29., 39., 44.))
-    assert_equal(wcs.world_to_array_index_values(10, 20, 25), (44, 39, 29))
+    assert_allclose(wcs.world_to_pixel_values(80, 20, 205), (29., 39., 44.))
+    assert_equal(wcs.world_to_array_index_values(80, 20, 205), (44, 39, 29))
 
     assert str(wcs) == EXPECTED_ELLIPSIS_REPR.strip()
     assert EXPECTED_ELLIPSIS_REPR.strip() in repr(wcs)
@@ -128,11 +128,11 @@ def test_spectral_slice(gwcs_3d_galactic_spectral):
     assert isinstance(wcs.world_axis_object_classes['celestial'][2]['frame'], Galactic)
     assert tuple(wcs.world_axis_object_classes['celestial'][2]['unit']) == (u.deg, u.deg)
 
-    assert_allclose(wcs.pixel_to_world_values(29, 44), (10, 25))
-    assert_allclose(wcs.array_index_to_world_values(44, 29), (10, 25))
+    assert_allclose(wcs.pixel_to_world_values(29, 44), (80, 205))
+    assert_allclose(wcs.array_index_to_world_values(44, 29), (80, 205))
 
-    assert_allclose(wcs.world_to_pixel_values(10, 25), (29., 44.))
-    assert_equal(wcs.world_to_array_index_values(10, 25), (44, 29))
+    assert_allclose(wcs.world_to_pixel_values(80, 205), (29., 44.))
+    assert_equal(wcs.world_to_array_index_values(80, 205), (44, 29))
 
     assert_equal(wcs.pixel_bounds, [(-1, 35), (5, 50)])
 
@@ -197,11 +197,11 @@ def test_spectral_range(gwcs_3d_galactic_spectral):
     assert wcs.world_axis_object_classes['spectral'][1] == ()
     assert wcs.world_axis_object_classes['spectral'][2] == {'unit': 'Hz'}
 
-    assert_allclose(wcs.pixel_to_world_values(29, 35, 44), (10, 20, 25))
-    assert_allclose(wcs.array_index_to_world_values(44, 35, 29), (10, 20, 25))
+    assert_allclose(wcs.pixel_to_world_values(29, 35, 44), (80, 20, 205))
+    assert_allclose(wcs.array_index_to_world_values(44, 35, 29), (80, 20, 205))
 
-    assert_allclose(wcs.world_to_pixel_values(10, 20, 25), (29., 35., 44.))
-    assert_equal(wcs.world_to_array_index_values(10, 20, 25), (44, 35, 29))
+    assert_allclose(wcs.world_to_pixel_values(80, 20, 205), (29., 35., 44.))
+    assert_equal(wcs.world_to_array_index_values(80, 20, 205), (44, 35, 29))
 
     assert_equal(wcs.pixel_bounds, [(-1, 35), (-6, 41), (5, 50)])
 
@@ -265,11 +265,11 @@ def test_celestial_slice(gwcs_3d_galactic_spectral):
     assert wcs.world_axis_object_classes['spectral'][1] == ()
     assert wcs.world_axis_object_classes['spectral'][2] == {'unit': 'Hz'}
 
-    assert_allclose(wcs.pixel_to_world_values(39, 44), (10.24, 20, 25))
-    assert_allclose(wcs.array_index_to_world_values(44, 39), (10.24, 20, 25))
+    assert_allclose(wcs.pixel_to_world_values(39, 44), (79.76, 20, 205))
+    assert_allclose(wcs.array_index_to_world_values(44, 39), (79.76, 20, 205))
 
-    assert_allclose(wcs.world_to_pixel_values(12.4, 20, 25), (39., 44.))
-    assert_equal(wcs.world_to_array_index_values(12.4, 20, 25), (44, 39))
+    assert_allclose(wcs.world_to_pixel_values(79.76, 20, 205), (39., 44.))
+    assert_equal(wcs.world_to_array_index_values(79.76, 20, 205), (44, 39))
 
     assert_equal(wcs.pixel_bounds, [(-2, 45), (5, 50)])
 
@@ -334,11 +334,11 @@ def test_celestial_range(gwcs_3d_galactic_spectral):
     assert wcs.world_axis_object_classes['spectral'][1] == ()
     assert wcs.world_axis_object_classes['spectral'][2] == {'unit': 'Hz'}
 
-    assert_allclose(wcs.pixel_to_world_values(24, 39, 44), (10, 20, 25))
-    assert_allclose(wcs.array_index_to_world_values(44, 39, 24), (10, 20, 25))
+    assert_allclose(wcs.pixel_to_world_values(24, 39, 44), (80, 20, 205))
+    assert_allclose(wcs.array_index_to_world_values(44, 39, 24), (80, 20, 205))
 
-    assert_allclose(wcs.world_to_pixel_values(10, 20, 25), (24., 39., 44.))
-    assert_equal(wcs.world_to_array_index_values(10, 20, 25), (44, 39, 24))
+    assert_allclose(wcs.world_to_pixel_values(80, 20, 205), (24., 39., 44.))
+    assert_equal(wcs.world_to_array_index_values(80, 20, 205), (44, 39, 24))
 
     assert_equal(wcs.pixel_bounds, [(-6, 30), (-2, 45), (5, 50)])
 
@@ -406,11 +406,11 @@ def test_no_array_shape(gwcs_3d_galactic_spectral):
     assert wcs.world_axis_object_classes['spectral'][1] == ()
     assert wcs.world_axis_object_classes['spectral'][2] == {'unit': 'Hz'}
 
-    assert_allclose(wcs.pixel_to_world_values(29, 39, 44), (10, 20, 25))
-    assert_allclose(wcs.array_index_to_world_values(44, 39, 29), (10, 20, 25))
+    assert_allclose(wcs.pixel_to_world_values(29, 39, 44), (80, 20, 205))
+    assert_allclose(wcs.array_index_to_world_values(44, 39, 29), (80, 20, 205))
 
-    assert_allclose(wcs.world_to_pixel_values(10, 20, 25), (29., 39., 44.))
-    assert_equal(wcs.world_to_array_index_values(10, 20, 25), (44, 39, 29))
+    assert_allclose(wcs.world_to_pixel_values(80, 20, 205), (29., 39., 44.))
+    assert_equal(wcs.world_to_array_index_values(80, 20, 205), (44, 39, 29))
 
     assert str(wcs) == EXPECTED_NO_SHAPE_REPR.strip()
     assert EXPECTED_NO_SHAPE_REPR.strip() in repr(wcs)
@@ -474,11 +474,11 @@ def test_ellipsis_none_types(gwcs_3d_galactic_spectral):
     assert isinstance(wcs.world_axis_object_classes['celestial'][2]['frame'], Galactic)
     assert tuple(wcs.world_axis_object_classes['celestial'][2]['unit']) ==  (u.deg, u.deg)
 
-    assert_allclose(wcs.pixel_to_world_values(29, 39, 44), (10, 20, 25))
-    assert_allclose(wcs.array_index_to_world_values(44, 39, 29), (10, 20, 25))
+    assert_allclose(wcs.pixel_to_world_values(29, 39, 44), (80, 20, 205))
+    assert_allclose(wcs.array_index_to_world_values(44, 39, 29), (80, 20, 205))
 
-    assert_allclose(wcs.world_to_pixel_values(10, 20, 25), (29., 39., 44.))
-    assert_equal(wcs.world_to_array_index_values(10, 20, 25), (44, 39, 29))
+    assert_allclose(wcs.world_to_pixel_values(80, 20, 205), (29., 39., 44.))
+    assert_equal(wcs.world_to_array_index_values(80, 20, 205), (44, 39, 29))
 
     assert_equal(wcs.pixel_bounds, [(-1, 35), (-2, 45), (5, 50)])
 

--- a/gwcs/tests/test_api_slicing.py
+++ b/gwcs/tests/test_api_slicing.py
@@ -446,7 +446,8 @@ World Dim    0    1    2
 
 def test_ellipsis_none_types(gwcs_3d_galactic_spectral):
     pht = list(gwcs_3d_galactic_spectral.output_frame._axis_physical_types)
-    pht[1] = None
+    # This index is in "axes_order" ordering
+    pht[2] = None
     gwcs_3d_galactic_spectral.output_frame._prop.axis_physical_types = tuple(pht)
 
     wcs = SlicedLowLevelWCS(gwcs_3d_galactic_spectral, Ellipsis)
@@ -467,7 +468,7 @@ def test_ellipsis_none_types(gwcs_3d_galactic_spectral):
                          ('spectral', 0),
                          ('celestial', 0)]
 
-    assert all([callable(l) for l in last_one])
+    assert all([callable(last) for last in last_one])
 
     assert wcs.world_axis_object_classes['celestial'][0] is SkyCoord
     assert wcs.world_axis_object_classes['celestial'][1] == ()

--- a/gwcs/tests/test_coordinate_systems.py
+++ b/gwcs/tests/test_coordinate_systems.py
@@ -347,7 +347,7 @@ def test_coordinate_to_quantity_error():
         coordinate_to_quantity(1, frame=frame)
 
 
-def test_axis_physical_type():
+def test_axis_physical_types():
     assert icrs.axis_physical_types == ("pos.eq.ra", "pos.eq.dec")
     assert spec1.axis_physical_types == ("em.freq",)
     assert spec2.axis_physical_types == ("em.wl",)

--- a/gwcs/tests/test_coordinate_systems.py
+++ b/gwcs/tests/test_coordinate_systems.py
@@ -475,3 +475,29 @@ def test_ucd1_to_ctype(caplog):
         assert ctype_to_ucd[v] == k
 
     assert inv_map['new.repeated.type'] in new_ctype_to_ucd
+
+
+def test_celestial_ordering():
+   c1 = cf.CelestialFrame(
+       reference_frame=coord.ICRS(),
+       axes_order=(0, 1),
+       axes_names=("lon", "lat"),
+       unit=(u.deg, u.arcsec),
+       axis_physical_types=("custom:lon", "custom:lat"),
+   )
+   c2 = cf.CelestialFrame(
+       reference_frame=coord.ICRS(),
+       axes_order=(1, 0),
+       axes_names=("lon", "lat"),
+       unit=(u.deg, u.arcsec),
+       axis_physical_types=("custom:lon", "custom:lat"),
+   )
+
+   assert c1.axes_names == ("lon", "lat")
+   assert c2.axes_names == ("lat", "lon")
+
+   assert c1.unit == (u.deg, u.arcsec)
+   assert c2.unit == (u.arcsec, u.deg)
+
+   assert c1.axis_physical_types == ("custom:lon", "custom:lat")
+   assert c2.axis_physical_types == ("custom:lat", "custom:lon")

--- a/gwcs/tests/test_coordinate_systems.py
+++ b/gwcs/tests/test_coordinate_systems.py
@@ -193,7 +193,7 @@ def test_temporal_relative():
     assert coordinates(10, frame=t) == Time("2018-01-01T00:00:00") + 10 * u.s
     assert coordinates(10 * u.s, frame=t) == Time("2018-01-01T00:00:00") + 10 * u.s
 
-    a = coordinates((10, 20), frame=t)
+    a = coordinates(np.array((10, 20)), frame=t)
     assert a[0] == Time("2018-01-01T00:00:00") + 10 * u.s
     assert a[1] == Time("2018-01-01T00:00:00") + 20 * u.s
 
@@ -201,21 +201,9 @@ def test_temporal_relative():
     assert coordinates(10 * u.s, frame=t) == Time("2018-01-01T00:00:00") + 10 * u.s
     assert coordinates(TimeDelta(10, format='sec'), frame=t) == Time("2018-01-01T00:00:00") + 10 * u.s
 
-    a = coordinates((10, 20) * u.s, frame=t)
+    a = coordinates(np.array((10, 20)) * u.s, frame=t)
     assert a[0] == Time("2018-01-01T00:00:00") + 10 * u.s
     assert a[1] == Time("2018-01-01T00:00:00") + 20 * u.s
-
-
-def test_temporal_absolute():
-    t = cf.TemporalFrame(reference_frame=Time([], format='isot'))
-    assert coordinates("2018-01-01T00:00:00", frame=t) == Time("2018-01-01T00:00:00")
-
-    a = coordinates(("2018-01-01T00:00:00", "2018-01-01T00:10:00"), frame=t)
-    assert a[0] == Time("2018-01-01T00:00:00")
-    assert a[1] == Time("2018-01-01T00:10:00")
-
-    t = cf.TemporalFrame(reference_frame=Time([], scale='tai', format='isot'))
-    assert coordinates("2018-01-01T00:00:00", frame=t) == Time("2018-01-01T00:00:00", scale='tai')
 
 
 @pytest.mark.parametrize('inp', [

--- a/gwcs/tests/test_coordinate_systems.py
+++ b/gwcs/tests/test_coordinate_systems.py
@@ -89,7 +89,7 @@ def coordinates(*inputs, frame):
 
 def coordinate_to_quantity(*inputs, frame):
     results = high_level_objects_to_values(*inputs, low_level_wcs=frame)
-    results = [r<<unit for r, unit in zip(results, frame.unit)]
+    results = [r << unit for r, unit in zip(results, frame.unit)]
     return results
 
 

--- a/gwcs/tests/test_coordinate_systems.py
+++ b/gwcs/tests/test_coordinate_systems.py
@@ -10,11 +10,12 @@ from astropy import coordinates as coord
 from astropy.tests.helper import assert_quantity_allclose
 from astropy.modeling import models as m
 from astropy.wcs.wcsapi.fitswcs import CTYPE_TO_UCD1
-from astropy.coordinates import StokesCoord
+from astropy.coordinates import StokesCoord, SpectralCoord
 
 from .. import WCS
 from .. import coordinate_frames as cf
 
+from astropy.wcs.wcsapi.high_level_api import values_to_high_level_objects, high_level_objects_to_values
 import astropy
 astropy_version = astropy.__version__
 
@@ -33,7 +34,7 @@ detector = cf.Frame2D(name='detector', axes_order=(0, 1))
 focal = cf.Frame2D(name='focal', axes_order=(0, 1), unit=(u.m, u.m))
 
 spec1 = cf.SpectralFrame(name='freq', unit=[u.Hz, ], axes_order=(2, ))
-spec2 = cf.SpectralFrame(name='wave', unit=[u.m, ], axes_order=(2, ), axes_names=('lambda', ))
+spec2 = cf.SpectralFrame(name='wave', unit=[u.m, ], axes_order=(2, ), axes_names=('lambda',))
 spec3 = cf.SpectralFrame(name='energy', unit=[u.J, ], axes_order=(2, ))
 spec4 = cf.SpectralFrame(name='pixel', unit=[u.pix, ], axes_order=(2, ))
 spec5 = cf.SpectralFrame(name='speed', unit=[u.m/u.s, ], axes_order=(2, ))
@@ -55,6 +56,19 @@ inputs1 = [xscalar, xarr]
 inputs3 = [(xscalar, yscalar, xscalar), (xarr, yarr, xarr)]
 
 
+@pytest.fixture(autouse=True, scope="module")
+def serialized_classes():
+    """
+    In the rest of this test file we are passing the CoordinateFrame object to
+    astropy helper functions as if they were a low level WCS object.
+
+    This little patch means that this works.
+    """
+    cf.CoordinateFrame.serialized_classes = False
+    yield
+    del cf.CoordinateFrame.serialized_classes
+
+
 def test_units():
     assert(comp1.unit == (u.deg, u.deg, u.Hz))
     assert(comp2.unit == (u.m, u.m, u.m))
@@ -64,19 +78,34 @@ def test_units():
     assert(comp.unit == (u.deg, u.deg, u.Hz, u.m))
 
 
+# These two functions fake the old methods on CoordinateFrame to reduce the
+# amount of refactoring that needed doing in these tests.
+def coordinates(*inputs, frame):
+    results = values_to_high_level_objects(*inputs, low_level_wcs=frame)
+    if isinstance(results, list) and len(results) == 1:
+        return results[0]
+    return results
+
+
+def coordinate_to_quantity(*inputs, frame):
+    results = high_level_objects_to_values(*inputs, low_level_wcs=frame)
+    results = [r<<unit for r, unit in zip(results, frame.unit)]
+    return results
+
+
 @pytest.mark.parametrize('inputs', inputs2)
 def test_coordinates_spatial(inputs):
-    sky_coo = icrs.coordinates(*inputs)
+    sky_coo = coordinates(*inputs, frame=icrs)
     assert isinstance(sky_coo, coord.SkyCoord)
     assert_allclose((sky_coo.ra.value, sky_coo.dec.value), inputs)
-    focal_coo = focal.coordinates(*inputs)
+    focal_coo = coordinates(*inputs, frame=focal)
     assert_allclose([coo.value for coo in focal_coo], inputs)
     assert [coo.unit for coo in focal_coo] == [u.m, u.m]
 
 
 @pytest.mark.parametrize('inputs', inputs1)
 def test_coordinates_spectral(inputs):
-    wave = spec2.coordinates(inputs)
+    wave = coordinates(inputs, frame=spec2)
     assert_allclose(wave.value, inputs)
     assert wave.unit == 'meter'
     assert isinstance(wave, u.Quantity)
@@ -85,7 +114,7 @@ def test_coordinates_spectral(inputs):
 @pytest.mark.parametrize('inputs', inputs3)
 def test_coordinates_composite(inputs):
     frame = cf.CompositeFrame([icrs, spec2])
-    result = frame.coordinates(*inputs)
+    result = coordinates(*inputs, frame=frame)
     assert isinstance(result[0], coord.SkyCoord)
     assert_allclose((result[0].ra.value, result[0].dec.value), inputs[:2])
     assert_allclose(result[1].value, inputs[2])
@@ -96,7 +125,7 @@ def test_coordinates_composite_order():
     dist = cf.CoordinateFrame(name='distance', naxes=1,
                               axes_type=["SPATIAL"], unit=[u.m, ], axes_order=(1, ))
     frame = cf.CompositeFrame([time, dist])
-    result = frame.coordinates(0, 0)
+    result = coordinates(0, 0, frame=frame)
     assert result[0] == Time("2011-01-01T00:00:00")
     assert u.allclose(result[1], 0*u.m)
 
@@ -104,7 +133,8 @@ def test_coordinates_composite_order():
 def test_bare_baseframe():
     # This is a regression test for the following call:
     frame = cf.CoordinateFrame(1, "SPATIAL", (0,), unit=(u.km,))
-    assert u.allclose(frame.coordinate_to_quantity((1*u.m,)), 1*u.m)
+    quantity = coordinate_to_quantity(1*u.m, frame=frame)
+    assert u.allclose(quantity, 1*u.m)
 
     # Now also setup the same situation through the whole call stack to be safe.
     w = WCS(forward_transform=m.Tabular1D(points=np.arange(10)*u.pix,
@@ -158,55 +188,52 @@ def test_base_coordinate():
     assert frame.name == 'CoordinateFrame'
     frame = cf.CoordinateFrame(name="CustomFrame", naxes=2,
                                axes_type=("SPATIAL", "SPATIAL"),
-                               axes_order=(0, 1))
+                               axes_order=(0, 1),
+                               unit=(u.deg, u.arcsec))
     assert frame.name == 'CustomFrame'
     frame.name = "DeLorean"
     assert frame.name == 'DeLorean'
 
-    q1, q2 = frame.coordinate_to_quantity(12 * u.deg, 3 * u.arcsec)
+    q1, q2 = coordinate_to_quantity(12 * u.deg, 3 * u.arcsec, frame=frame)
     assert_quantity_allclose(q1, 12 * u.deg)
     assert_quantity_allclose(q2, 3 * u.arcsec)
 
-    q1, q2 = frame.coordinate_to_quantity((12 * u.deg, 3 * u.arcsec))
+    q1, q2 = coordinate_to_quantity(*(12 * u.deg, 3 * u.arcsec), frame=frame)
     assert_quantity_allclose(q1, 12 * u.deg)
     assert_quantity_allclose(q2, 3 * u.arcsec)
 
 
 def test_temporal_relative():
     t = cf.TemporalFrame(reference_frame=Time("2018-01-01T00:00:00"), unit=u.s)
-    assert t.coordinates(10) == Time("2018-01-01T00:00:00") + 10 * u.s
-    assert t.coordinates(10 * u.s) == Time("2018-01-01T00:00:00") + 10 * u.s
+    assert coordinates(10, frame=t) == Time("2018-01-01T00:00:00") + 10 * u.s
+    assert coordinates(10 * u.s, frame=t) == Time("2018-01-01T00:00:00") + 10 * u.s
 
-    a = t.coordinates((10, 20))
+    a = coordinates((10, 20), frame=t)
     assert a[0] == Time("2018-01-01T00:00:00") + 10 * u.s
     assert a[1] == Time("2018-01-01T00:00:00") + 20 * u.s
 
     t = cf.TemporalFrame(reference_frame=Time("2018-01-01T00:00:00"))
-    assert t.coordinates(10 * u.s) == Time("2018-01-01T00:00:00") + 10 * u.s
-    assert t.coordinates(TimeDelta(10, format='sec')) == Time("2018-01-01T00:00:00") + 10 * u.s
+    assert coordinates(10 * u.s, frame=t) == Time("2018-01-01T00:00:00") + 10 * u.s
+    assert coordinates(TimeDelta(10, format='sec'), frame=t) == Time("2018-01-01T00:00:00") + 10 * u.s
 
-    a = t.coordinates((10, 20) * u.s)
+    a = coordinates((10, 20) * u.s, frame=t)
     assert a[0] == Time("2018-01-01T00:00:00") + 10 * u.s
     assert a[1] == Time("2018-01-01T00:00:00") + 20 * u.s
 
 
-@pytest.mark.skipif(astropy_version<"4", reason="Requires astropy 4.0 or higher")
 def test_temporal_absolute():
     t = cf.TemporalFrame(reference_frame=Time([], format='isot'))
-    assert t.coordinates("2018-01-01T00:00:00") == Time("2018-01-01T00:00:00")
+    assert coordinates("2018-01-01T00:00:00", frame=t) == Time("2018-01-01T00:00:00")
 
-    a = t.coordinates(("2018-01-01T00:00:00", "2018-01-01T00:10:00"))
+    a = coordinates(("2018-01-01T00:00:00", "2018-01-01T00:10:00"), frame=t)
     assert a[0] == Time("2018-01-01T00:00:00")
     assert a[1] == Time("2018-01-01T00:10:00")
 
     t = cf.TemporalFrame(reference_frame=Time([], scale='tai', format='isot'))
-    assert t.coordinates("2018-01-01T00:00:00") == Time("2018-01-01T00:00:00", scale='tai')
+    assert coordinates("2018-01-01T00:00:00", frame=t) == Time("2018-01-01T00:00:00", scale='tai')
 
 
 @pytest.mark.parametrize('inp', [
-    (10 * u.deg, 20 * u.deg),
-    ((10 * u.deg, 20 * u.deg),),
-    (u.Quantity([10, 20], u.deg),),
     (coord.SkyCoord(10 * u.deg, 20 * u.deg, frame=coord.ICRS),),
     # This is the same as 10,20 in ICRS
     (coord.SkyCoord(119.26936774, -42.79039286, unit=u.deg, frame='galactic'),)
@@ -214,54 +241,40 @@ def test_temporal_absolute():
 def test_coordinate_to_quantity_celestial(inp):
     cel = cf.CelestialFrame(reference_frame=coord.ICRS(), axes_order=(0, 1))
 
-    lon, lat = cel.coordinate_to_quantity(*inp)
+    lon, lat = coordinate_to_quantity(*inp, frame=cel)
     assert_quantity_allclose(lon, 10 * u.deg)
     assert_quantity_allclose(lat, 20 * u.deg)
 
     with pytest.raises(ValueError):
-        cel.coordinate_to_quantity(10 * u.deg, 2 * u.deg, 3 * u.deg)
+        coordinate_to_quantity(10 * u.deg, 2 * u.deg, 3 * u.deg, frame=cel)
 
     with pytest.raises(ValueError):
-        cel.coordinate_to_quantity((1, 2))
+        coordinate_to_quantity((1, 2), frame=cel)
 
 
 @pytest.mark.parametrize('inp', [
-    (100,),
-    (100 * u.nm,),
-    (0.1 * u.um,),
+    (SpectralCoord(100 * u.nm),),
+    (SpectralCoord(0.1 * u.um),),
 ])
 def test_coordinate_to_quantity_spectral(inp):
     spec = cf.SpectralFrame(unit=u.nm, axes_order=(1, ))
-    wav = spec.coordinate_to_quantity(*inp)
+    wav = coordinate_to_quantity(*inp, frame=spec)
     assert_quantity_allclose(wav, 100 * u.nm)
 
 
 @pytest.mark.parametrize('inp', [
     (Time("2011-01-01T00:00:10"),),
-    (10 * u.s,)
 ])
-@pytest.mark.skipif(astropy_version<"4", reason="Requires astropy 4.0 or higher.")
 def test_coordinate_to_quantity_temporal(inp):
     temp = cf.TemporalFrame(reference_frame=Time("2011-01-01T00:00:00"), unit=u.s)
 
-    t = temp.coordinate_to_quantity(*inp)
+    t = coordinate_to_quantity(*inp, frame=temp)
 
     assert_quantity_allclose(t, 10 * u.s)
 
-    temp2 = cf.TemporalFrame(reference_frame=Time([], format='isot'), unit=u.s)
-
-    tt = Time("2011-01-01T00:00:00")
-    t = temp2.coordinate_to_quantity(tt)
-
-    assert t is tt
-
 
 @pytest.mark.parametrize('inp', [
-    (211 * u.AA, 0 * u.s, 0 * u.arcsec, 0 * u.arcsec),
-    (211 * u.AA, 0 * u.s, (0 * u.arcsec, 0 * u.arcsec)),
-    (211 * u.AA, 0 * u.s, (0, 0) * u.arcsec),
-    (211 * u.AA, Time("2011-01-01T00:00:00"), (0, 0) * u.arcsec),
-    (211 * u.AA, Time("2011-01-01T00:00:00"), coord.SkyCoord(0, 0, unit=u.arcsec)),
+    (SpectralCoord(211 * u.AA), Time("2011-01-01T00:00:00"), coord.SkyCoord(0, 0, unit=u.arcsec)),
 ])
 def test_coordinate_to_quantity_composite(inp):
     # Composite
@@ -272,9 +285,31 @@ def test_coordinate_to_quantity_composite(inp):
 
     comp = cf.CompositeFrame([wave_frame, time_frame, sky_frame])
 
-    coords = comp.coordinate_to_quantity(*inp)
+    coords = coordinate_to_quantity(*inp, frame=comp)
 
     expected = (211 * u.AA, 0 * u.s, 0 * u.arcsec, 0 * u.arcsec)
+    for output, exp in zip(coords, expected):
+        assert_quantity_allclose(output, exp)
+
+
+def test_coordinate_to_quantity_composite_split():
+    inp = (
+        SpectralCoord(211 * u.AA),
+        coord.SkyCoord(0, 0, unit=u.arcsec),
+        Time("2011-01-01T00:00:00"),
+    )
+
+    # Composite
+    wave_frame = cf.SpectralFrame(axes_order=(1, ), unit=u.AA)
+    sky_frame = cf.CelestialFrame(axes_order=(2, 0), reference_frame=coord.ICRS())
+    time_frame = cf.TemporalFrame(
+        axes_order=(3,), unit=u.s, reference_frame=Time("2011-01-01T00:00:00"))
+
+    comp = cf.CompositeFrame([wave_frame, sky_frame, time_frame])
+
+    coords = coordinate_to_quantity(*inp, frame=comp)
+
+    expected = (0 * u.arcsec, 211 * u.AA, 0 * u.arcsec, 0 * u.s)
     for output, exp in zip(coords, expected):
         assert_quantity_allclose(output, exp)
 
@@ -282,19 +317,14 @@ def test_coordinate_to_quantity_composite(inp):
 def test_stokes_frame():
     sf = cf.StokesFrame()
 
-    assert sf.coordinates(1) == 'I'
-    assert sf.coordinates(1 * u.pix) == 'I'
-    assert sf.coordinate_to_quantity(StokesCoord('I')) == 1 * u.one
-    assert sf.coordinate_to_quantity(1) == 1
+    assert coordinates(1, frame=sf) == 'I'
+    assert coordinates(1 * u.one, frame=sf) == 'I'
+    assert coordinate_to_quantity(StokesCoord('I'), frame=sf) == 1 * u.one
+    assert coordinate_to_quantity(StokesCoord(1), frame=sf) == 1 * u.one
 
 
-@pytest.mark.parametrize('inp', [
-    (211 * u.AA, 0 * u.s, 0 * u.one, 0 * u.one),
-    (211 * u.AA, 0 * u.s, (0 * u.one, 0 * u.one)),
-    (211 * u.AA, 0 * u.s, (0, 0) * u.one),
-    (211 * u.AA, Time("2011-01-01T00:00:00"), (0, 0) * u.one)
-])
-def test_coordinate_to_quantity_frame2d_composite(inp):
+def test_coordinate_to_quantity_frame2d_composite():
+    inp = (SpectralCoord(211 * u.AA), Time("2011-01-01T00:00:00"), 0 * u.one, 0 * u.one)
     wave_frame = cf.SpectralFrame(axes_order=(0, ), unit=u.AA)
     time_frame = cf.TemporalFrame(
         axes_order=(1, ), unit=u.s, reference_frame=Time("2011-01-01T00:00:00"))
@@ -303,7 +333,7 @@ def test_coordinate_to_quantity_frame2d_composite(inp):
 
     comp = cf.CompositeFrame([wave_frame, time_frame, frame2d])
 
-    coords = comp.coordinate_to_quantity(*inp)
+    coords = coordinate_to_quantity(*inp, frame=comp)
 
     expected = (211 * u.AA, 0 * u.s, 0 * u.one, 0 * u.one)
     for output, exp in zip(coords, expected):
@@ -312,31 +342,24 @@ def test_coordinate_to_quantity_frame2d_composite(inp):
 
 def test_coordinate_to_quantity_frame_2d():
     frame = cf.Frame2D(unit=(u.one, u.arcsec))
-    inp = (1, 2)
+    inp = (1 * u.one, 2 * u.arcsec)
     expected = (1 * u.one, 2 * u.arcsec)
-    result = frame.coordinate_to_quantity(*inp)
-    for output, exp in zip(result, expected):
-        assert_quantity_allclose(output, exp)
-
-    inp = (1 * u.one, 2)
-    expected = (1 * u.one, 2 * u.arcsec)
-    result = frame.coordinate_to_quantity(*inp)
+    result = coordinate_to_quantity(*inp, frame=frame)
     for output, exp in zip(result, expected):
         assert_quantity_allclose(output, exp)
 
 
-@pytest.mark.skipif(astropy_version<"4", reason="Requires astropy 4.0 or higher.")
 def test_coordinate_to_quantity_error():
     frame = cf.Frame2D(unit=(u.one, u.arcsec))
     with pytest.raises(ValueError):
-        frame.coordinate_to_quantity(1)
+        coordinate_to_quantity(1, frame=frame)
 
     with pytest.raises(ValueError):
-        comp1.coordinate_to_quantity((1, 1), 2)
+        coordinate_to_quantity((1, 1), 2, frame=frame)
 
     frame = cf.TemporalFrame(reference_frame=Time([], format='isot'), unit=u.s)
     with pytest.raises(ValueError):
-        frame.coordinate_to_quantity(1)
+        coordinate_to_quantity(1, frame=frame)
 
 
 def test_axis_physical_type():
@@ -406,7 +429,7 @@ def test_base_frame():
     assert frame.naxes == 1
     assert frame.axes_names == ("x",)
 
-    frame.coordinate_to_quantity(1, 2)
+    coordinate_to_quantity(1*u.one, frame=frame)
 
 
 def test_ucd1_to_ctype_not_out_of_sync(caplog):

--- a/gwcs/tests/test_coordinate_systems.py
+++ b/gwcs/tests/test_coordinate_systems.py
@@ -375,7 +375,7 @@ def test_axis_physical_type():
     assert comp.axis_physical_types == ('pos.eq.ra', 'pos.eq.dec', 'em.freq', 'em.wl')
 
     spec6 = cf.SpectralFrame(name='waven', axes_order=(1,),
-                             axis_physical_types='em.wavenumber')
+                             axis_physical_types='em.wavenumber', unit=u.Unit(1))
     assert spec6.axis_physical_types == ('em.wavenumber',)
 
     t = cf.TemporalFrame(reference_frame=Time("2018-01-01T00:00:00"), unit=u.s)

--- a/gwcs/tests/test_coordinate_systems.py
+++ b/gwcs/tests/test_coordinate_systems.py
@@ -478,26 +478,47 @@ def test_ucd1_to_ctype(caplog):
 
 
 def test_celestial_ordering():
-   c1 = cf.CelestialFrame(
-       reference_frame=coord.ICRS(),
-       axes_order=(0, 1),
-       axes_names=("lon", "lat"),
-       unit=(u.deg, u.arcsec),
-       axis_physical_types=("custom:lon", "custom:lat"),
-   )
-   c2 = cf.CelestialFrame(
-       reference_frame=coord.ICRS(),
-       axes_order=(1, 0),
-       axes_names=("lon", "lat"),
-       unit=(u.deg, u.arcsec),
-       axis_physical_types=("custom:lon", "custom:lat"),
-   )
+    c1 = cf.CelestialFrame(
+        reference_frame=coord.ICRS(),
+        axes_order=(0, 1),
+        axes_names=("lon", "lat"),
+        unit=(u.deg, u.arcsec),
+        axis_physical_types=("custom:lon", "custom:lat"),
+    )
+    c2 = cf.CelestialFrame(
+        reference_frame=coord.ICRS(),
+        axes_order=(1, 0),
+        axes_names=("lon", "lat"),
+        unit=(u.deg, u.arcsec),
+        axis_physical_types=("custom:lon", "custom:lat"),
+    )
 
-   assert c1.axes_names == ("lon", "lat")
-   assert c2.axes_names == ("lat", "lon")
+    assert c1.axes_names == ("lon", "lat")
+    assert c2.axes_names == ("lat", "lon")
 
-   assert c1.unit == (u.deg, u.arcsec)
-   assert c2.unit == (u.arcsec, u.deg)
+    assert c1.unit == (u.deg, u.arcsec)
+    assert c2.unit == (u.arcsec, u.deg)
 
-   assert c1.axis_physical_types == ("custom:lon", "custom:lat")
-   assert c2.axis_physical_types == ("custom:lat", "custom:lon")
+    assert c1.axis_physical_types == ("custom:lon", "custom:lat")
+    assert c2.axis_physical_types == ("custom:lat", "custom:lon")
+
+
+def test_composite_ordering():
+    print("boo")
+    c1 = cf.CelestialFrame(
+        reference_frame=coord.ICRS(),
+        axes_order=(1, 0),
+        axes_names=("lon", "lat"),
+        unit=(u.deg, u.arcsec),
+        axis_physical_types=("custom:lon", "custom:lat"),
+    )
+    spec = cf.SpectralFrame(
+        axes_order=(2,),
+        axes_names=("spectral",),
+        unit=u.AA,
+    )
+    comp = cf.CompositeFrame([c1, spec])
+    assert comp.axes_names == ("lat", "lon", "spectral")
+    assert comp.axis_physical_types == ("custom:lat", "custom:lon", "em.wl")
+    assert comp.unit == (u.arcsec, u.deg, u.AA)
+    assert comp.axes_order == (1, 0, 2)

--- a/gwcs/tests/test_region.py
+++ b/gwcs/tests/test_region.py
@@ -8,8 +8,9 @@ import numpy as np
 from numpy.testing import assert_equal, assert_allclose
 from astropy.modeling import models
 import pytest
-from .. import region, selector
-from .. import utils as gwutils
+from gwcs import region, selector, WCS
+from gwcs import utils as gwutils
+from gwcs import coordinate_frames as cf
 
 
 def test_LabelMapperArray_from_vertices_int():
@@ -236,6 +237,10 @@ def test_RegionsSelector():
     # Test setting ``undefined_transform_value`` to a non-default value.
     reg_selector.undefined_transform_value = -100
     assert_equal(reg_selector(0, 0), [-100, -100])
+
+    wcs = WCS(forward_transform=reg_selector, output_frame=cf.Frame2D())
+    out = wcs(1, 1)
+    assert out == (-100, -100)
 
 
 def test_overalpping_ranges():

--- a/gwcs/tests/test_utils.py
+++ b/gwcs/tests/test_utils.py
@@ -6,7 +6,6 @@ from astropy import wcs as fitswcs
 from astropy import units as u
 from astropy import coordinates as coord
 from astropy.modeling import models
-from astropy import table
 
 from astropy.tests.helper import assert_quantity_allclose
 import pytest

--- a/gwcs/tests/test_utils.py
+++ b/gwcs/tests/test_utils.py
@@ -90,21 +90,6 @@ def test_get_axes():
     assert not other
 
 
-def test_isnumerical():
-    sky = coord.SkyCoord(1 * u.deg, 2 * u.deg)
-    assert not gwutils.isnumerical(sky)
-
-    assert not gwutils.isnumerical(2 * u.m)
-
-    assert gwutils.isnumerical(float(0))
-    assert gwutils.isnumerical(np.array(0))
-
-    assert not gwutils.isnumerical(np.array(['s200', '234']))
-
-    assert gwutils.isnumerical(np.array(0, dtype='>f8'))
-    assert gwutils.isnumerical(np.array(0, dtype='>i4'))
-
-
 def test_get_values():
     args = 2 * u.cm
     units=(u.m, )

--- a/gwcs/tests/test_wcs.py
+++ b/gwcs/tests/test_wcs.py
@@ -21,7 +21,6 @@ import asdf
 from .. import wcs
 from ..wcstools import (wcs_from_fiducial, grid_from_bounding_box, wcs_from_points)
 from .. import coordinate_frames as cf
-from .. import utils
 from ..utils import CoordinateFrameError
 from .utils import _gwcs_from_hst_fits_wcs
 from . import data

--- a/gwcs/tests/test_wcs.py
+++ b/gwcs/tests/test_wcs.py
@@ -1582,3 +1582,44 @@ def test_high_level_objects_in_pipeline_forward(gwcs_with_pipeline_celestial):
     sc = intermediate_world_with_units[0]
     assert u.allclose(sc.ra, 20*u.arcsec)
     assert u.allclose(sc.dec, 15*u.deg)
+
+
+def test_high_level_objects_in_pipeline_backward(gwcs_with_pipeline_celestial):
+    """
+    This test checks that high level objects still work with a multi-stage
+    pipeline when doing backward transforms.
+    """
+    iwcs = gwcs_with_pipeline_celestial
+
+    input_world = [
+        20*u.arcsec + 1*u.deg,
+        15*u.deg + 2*u.deg,
+    ]
+    pixel = iwcs.invert(*input_world)
+
+    assert all(isinstance(p, u.Quantity) for p in pixel)
+    assert u.allclose(pixel, [1, 1]*u.pix)
+
+    pixel = iwcs.invert(
+        *input_world,
+        with_units=True,
+    )
+
+    assert all(isinstance(p, u.Quantity) for p in pixel)
+    assert u.allclose(pixel, [1, 1]*u.pix)
+
+    intermediate_world = iwcs.transform(
+        "output",
+        "celestial",
+        *input_world,
+    )
+    assert all(isinstance(p, u.Quantity) for p in intermediate_world)
+    assert u.allclose(intermediate_world, [20*u.arcsec, 15*u.deg])
+
+    intermediate_world = iwcs.transform(
+        "output",
+        "celestial",
+        *input_world,
+        with_units=True,
+    )
+    assert isinstance(intermediate_world, coord.SkyCoord)

--- a/gwcs/tests/test_wcs.py
+++ b/gwcs/tests/test_wcs.py
@@ -220,7 +220,7 @@ def test_return_coordinates():
     output_quant = w.output_frame.coordinate_to_quantity(num_plus_output)
     assert_allclose(w(x, y), numerical_result)
     assert_allclose(utils.get_values(w.unit, *output_quant), numerical_result)
-    assert_allclose(w.invert(num_plus_output, with_units=True), (x, y))
+    assert_allclose(w.invert(num_plus_output), (x, y))
     assert isinstance(num_plus_output, coord.SkyCoord)
 
     # Spectral frame
@@ -698,7 +698,7 @@ class TestImaging(object):
 
     def test_inverse(self):
         sky_coord = self.wcs(10, 20, with_units=True)
-        assert np.allclose(self.wcs.invert(sky_coord, with_units=True), (10, 20))
+        assert np.allclose(self.wcs.invert(sky_coord), (10, 20))
 
     def test_back_coordinates(self):
         sky_coord = self.wcs(1, 2, with_units=True)

--- a/gwcs/tests/test_wcs.py
+++ b/gwcs/tests/test_wcs.py
@@ -1433,9 +1433,14 @@ def test_no_bounding_box_if_read_from_file(tmp_path):
 
 
 def test_split_frame_wcs():
-    # Setup a model where the pixel & world axes are (lat, wave, lon)
-    spatial = models.Multiply(10*u.arcsec/u.pix) & models.Multiply(15*u.arcsec/u.pix)  # pretend this is a spatial model
+    # Setup a WCS where the pixel & world axes are (lat, wave, lon)
+
+    # We setup a model which is pretending to be a celestial transform. Note
+    # that we are pretending that this model is ordered lon, lat because that's
+    # what the projections require in astropy.
+    spatial = models.Multiply(20*u.arcsec/u.pix) & models.Multiply(15*u.arcsec/u.pix)
     compound = models.Linear1D(intercept=0*u.nm, slope=10*u.nm/u.pix) & spatial
+    # This forward transforms uses mappings to be (lat, wave, lon)
     forward = models.Mapping((1, 2, 0)) | compound | models.Mapping((2, 0, 1))
 
     # Setup the output frame
@@ -1448,14 +1453,52 @@ def test_split_frame_wcs():
                                      axes_order=list(range(3)), unit=[u.pix]*3)
 
     iwcs = wcs.WCS(forward, input_frame, output_frame)
-    input_pixel = [0*u.pix, 1*u.pix, 2*u.pix]
+    input_pixel = [1*u.pix, 2*u.pix, 3*u.pix]
     output_world = iwcs.pixel_to_world_values(*input_pixel)
     output_pixel = iwcs.world_to_pixel_values(*output_world)
     assert_allclose(output_pixel, u.Quantity(input_pixel).to_value(u.pix))
+
+    expected_world = [15*u.arcsec, 20*u.nm, 60*u.arcsec]
+    for expected, output in zip(expected_world, output_world):
+        assert_allclose(output, expected.value)
 
     world_obj = iwcs.pixel_to_world(*input_pixel)
     assert isinstance(world_obj[0], coord.SkyCoord)
     assert isinstance(world_obj[1], coord.SpectralCoord)
 
+    assert u.allclose(world_obj[0].spherical.lat, expected_world[0])
+    assert u.allclose(world_obj[0].spherical.lon, expected_world[2])
+    assert u.allclose(world_obj[1], expected_world[1])
+
     obj_pixel = iwcs.world_to_pixel(*world_obj)
+    assert_allclose(obj_pixel, u.Quantity(input_pixel).to_value(u.pix))
+
+
+def test_reordered_celestial():
+    # This is a spatial model which is ordered lat, lon for the purposes of this test.
+    spatial = models.Multiply(20*u.deg/u.pix) & models.Multiply(15*u.deg/u.pix)
+
+    celestial_frame = cf.CelestialFrame(axes_order=(1, 0), unit=(u.deg, u.deg),
+                                        reference_frame=coord.ICRS())
+
+    input_frame = cf.CoordinateFrame(2, ["PIXEL"]*2,
+                                     axes_order=list(range(2)), unit=[u.pix]*2)
+
+    iwcs = wcs.WCS(spatial, input_frame, celestial_frame)
+
+    input_pixel = [1*u.pix, 3*u.pix]
+    output_world = iwcs.pixel_to_world_values(*input_pixel)
+    output_pixel = iwcs.world_to_pixel_values(*output_world)
+    assert_allclose(output_pixel, u.Quantity(input_pixel).to_value(u.pix))
+
+    expected_world = [20*u.deg, 45*u.deg]
+    assert_allclose(output_world, [e.value for e in expected_world])
+
+    world_obj = iwcs.pixel_to_world(*input_pixel)
+    assert isinstance(world_obj, coord.SkyCoord)
+
+    assert u.allclose(world_obj.spherical.lat, expected_world[0])
+    assert u.allclose(world_obj.spherical.lon, expected_world[1])
+
+    obj_pixel = iwcs.world_to_pixel(world_obj)
     assert_allclose(obj_pixel, u.Quantity(input_pixel).to_value(u.pix))

--- a/gwcs/tests/test_wcs.py
+++ b/gwcs/tests/test_wcs.py
@@ -1438,13 +1438,13 @@ def test_split_frame_wcs():
     # We setup a model which is pretending to be a celestial transform. Note
     # that we are pretending that this model is ordered lon, lat because that's
     # what the projections require in astropy.
-    spatial = models.Multiply(20*u.arcsec/u.pix) & models.Multiply(15*u.arcsec/u.pix)
+    spatial = models.Multiply(20*u.arcsec/u.pix) & models.Multiply(15*u.deg/u.pix)
     compound = models.Linear1D(intercept=0*u.nm, slope=10*u.nm/u.pix) & spatial
     # This forward transforms uses mappings to be (lat, wave, lon)
     forward = models.Mapping((1, 2, 0)) | compound | models.Mapping((2, 0, 1))
 
     # Setup the output frame
-    celestial_frame = cf.CelestialFrame(axes_order=(2, 0), unit=(u.arcsec, u.arcsec),
+    celestial_frame = cf.CelestialFrame(axes_order=(2, 0), unit=(u.arcsec, u.deg),
                                         reference_frame=coord.ICRS())
     spectral_frame = cf.SpectralFrame(axes_order=(1,), unit=u.nm)
     output_frame = cf.CompositeFrame([spectral_frame, celestial_frame])
@@ -1458,7 +1458,7 @@ def test_split_frame_wcs():
     output_pixel = iwcs.world_to_pixel_values(*output_world)
     assert_allclose(output_pixel, u.Quantity(input_pixel).to_value(u.pix))
 
-    expected_world = [15*u.arcsec, 20*u.nm, 60*u.arcsec]
+    expected_world = [15*u.deg, 20*u.nm, 60*u.arcsec]
     for expected, output in zip(expected_world, output_world):
         assert_allclose(output, expected.value)
 
@@ -1476,9 +1476,9 @@ def test_split_frame_wcs():
 
 def test_reordered_celestial():
     # This is a spatial model which is ordered lat, lon for the purposes of this test.
-    spatial = models.Multiply(20*u.deg/u.pix) & models.Multiply(15*u.deg/u.pix)
+    spatial = models.Multiply(20*u.arcsec/u.pix) & models.Multiply(15*u.deg/u.pix)
 
-    celestial_frame = cf.CelestialFrame(axes_order=(1, 0), unit=(u.deg, u.deg),
+    celestial_frame = cf.CelestialFrame(axes_order=(1, 0), unit=(u.arcsec, u.deg),
                                         reference_frame=coord.ICRS())
 
     input_frame = cf.CoordinateFrame(2, ["PIXEL"]*2,
@@ -1491,7 +1491,7 @@ def test_reordered_celestial():
     output_pixel = iwcs.world_to_pixel_values(*output_world)
     assert_allclose(output_pixel, u.Quantity(input_pixel).to_value(u.pix))
 
-    expected_world = [20*u.deg, 45*u.deg]
+    expected_world = [20*u.arcsec, 45*u.deg]
     assert_allclose(output_world, [e.value for e in expected_world])
 
     world_obj = iwcs.pixel_to_world(*input_pixel)

--- a/gwcs/tests/test_wcs.py
+++ b/gwcs/tests/test_wcs.py
@@ -1516,32 +1516,6 @@ def test_reordered_celestial():
     assert_allclose(obj_pixel, u.Quantity(input_pixel).to_value(u.pix))
 
 
-@pytest.fixture
-def gwcs_with_pipeline_celestial():
-    input_frame = cf.CoordinateFrame(2, ["PIXEL"]*2,
-                                     axes_order=list(range(2)),
-                                     unit=[u.pix]*2,
-                                     name="input")
-
-    spatial = models.Multiply(20*u.arcsec/u.pix) & models.Multiply(15*u.deg/u.pix)
-
-    celestial_frame = cf.CelestialFrame(axes_order=(0, 1), unit=(u.arcsec, u.deg),
-                                        reference_frame=coord.ICRS(), name="celestial")
-
-    custom = models.Shift(1*u.deg) & models.Shift(2*u.deg)
-
-    output_frame = cf.CoordinateFrame(2, ["CUSTOM"]*2,
-                                      axes_order=list(range(2)), unit=[u.arcsec]*2, name="output")
-
-    pipeline = [
-        (input_frame, spatial),
-        (celestial_frame, custom),
-        (output_frame, None),
-    ]
-
-    return wcs.WCS(pipeline)
-
-
 def test_high_level_objects_in_pipeline_forward(gwcs_with_pipeline_celestial):
     """
     This test checks that high level objects still work with a multi-stage

--- a/gwcs/tests/test_wcs.py
+++ b/gwcs/tests/test_wcs.py
@@ -208,49 +208,6 @@ def test_backward_transform_has_inverse():
     assert_allclose(w.backward_transform.inverse(1, 2), w(1, 2))
 
 
-@pytest.mark.skip
-def test_return_coordinates():
-    """Test converting to coordinate objects or quantities."""
-    w = wcs.WCS(pipe[:])
-    x = 1
-    y = 2.3
-    numerical_result = (26.8, -0.6)
-    # Celestial frame
-    num_plus_output = w(x, y, with_units=True)
-    output_quant = w.output_frame.coordinate_to_quantity(num_plus_output)
-    assert_allclose(w(x, y), numerical_result)
-    assert_allclose(utils.get_values(w.unit, *output_quant), numerical_result)
-    assert_allclose(w.invert(num_plus_output), (x, y))
-    assert isinstance(num_plus_output, coord.SkyCoord)
-
-    # Spectral frame
-    poly = models.Polynomial1D(1, c0=1, c1=2)
-    w = wcs.WCS(forward_transform=poly, output_frame=spec)
-    numerical_result = poly(y)
-    num_plus_output = w(y, with_units=True)
-    output_quant = w.output_frame.coordinate_to_quantity(num_plus_output)
-    assert_allclose(utils.get_values(w.unit, output_quant), numerical_result)
-    assert isinstance(num_plus_output, u.Quantity)
-
-    # CompositeFrame - [celestial, spectral]
-    output_frame = cf.CompositeFrame(frames=[icrs, spec])
-    transform = m1 & poly
-    w = wcs.WCS(forward_transform=transform, output_frame=output_frame)
-    numerical_result = transform(x, y, y)
-    num_plus_output = w(x, y, y, with_units=True)
-    output_quant = w.output_frame.coordinate_to_quantity(*num_plus_output)
-    assert_allclose(utils.get_values(w.unit, *output_quant), numerical_result)
-
-    # CompositeFrame - [celestial, Stokes]
-    output_frame = cf.CompositeFrame(frames=[icrs, stokes])
-    transform = m1 & models.Identity(1)
-    w = wcs.WCS(forward_transform=transform, output_frame=output_frame)
-    numerical_result = transform(x, y, y)
-    num_plus_output = w(x, y, y, with_units=True)
-    output_quant = w.output_frame.coordinate_to_quantity(*num_plus_output)
-    assert_allclose(utils.get_values(w.unit, *output_quant), numerical_result)
-
-
 def test_from_fiducial_sky():
     sky = coord.SkyCoord(1.63 * u.radian, -72.4 * u.deg, frame='fk5')
     tan = models.Pix2Sky_TAN()

--- a/gwcs/tests/test_wcs.py
+++ b/gwcs/tests/test_wcs.py
@@ -208,6 +208,7 @@ def test_backward_transform_has_inverse():
     assert_allclose(w.backward_transform.inverse(1, 2), w(1, 2))
 
 
+@pytest.mark.skip
 def test_return_coordinates():
     """Test converting to coordinate objects or quantities."""
     w = wcs.WCS(pipe[:])
@@ -219,7 +220,7 @@ def test_return_coordinates():
     output_quant = w.output_frame.coordinate_to_quantity(num_plus_output)
     assert_allclose(w(x, y), numerical_result)
     assert_allclose(utils.get_values(w.unit, *output_quant), numerical_result)
-    assert_allclose(w.invert(num_plus_output), (x, y))
+    assert_allclose(w.invert(num_plus_output, with_units=True), (x, y))
     assert isinstance(num_plus_output, coord.SkyCoord)
 
     # Spectral frame
@@ -269,7 +270,7 @@ def test_from_fiducial_composite():
     assert isinstance(w.cube_frame.frames[1].reference_frame, coord.FK5)
     assert_allclose(w(1, 1, 1), (1.5, 96.52373368309931, -71.37420187296995))
     # test returning coordinate objects with composite output_frame
-    res = w(1, 2, 2, with_units=True)
+    res = w.pixel_to_world(1, 2, 2)
     assert_allclose(res[0], u.Quantity(1.5 * u.micron))
     assert isinstance(res[1], coord.SkyCoord)
     assert_allclose(res[1].ra.value, 99.329496642319)
@@ -281,7 +282,7 @@ def test_from_fiducial_composite():
     assert_allclose(w(1, 1, 1), (11.5, 99.97738475762152, -72.29039139739766))
     # test coordinate object output
 
-    coord_result = w(1, 1, 1, with_units=True)
+    coord_result = w.pixel_to_world(1, 1, 1)
     assert_allclose(coord_result[0], u.Quantity(11.5 * u.micron))
 
 
@@ -312,13 +313,16 @@ def test_bounding_box():
     with pytest.raises(ValueError):
         w.bounding_box = ((1, 5), (2, 6))
 
+
+def test_bounding_box_units():
     # Test that bounding_box with quantities can be assigned and evaluates
     bb = ((1 * u.pix, 5 * u.pix), (2 * u.pix, 6 * u.pix))
     trans = models.Shift(10 * u .pix) & models.Shift(2 * u.pix)
     pipeline = [('detector', trans), ('sky', None)]
     w = wcs.WCS(pipeline)
     w.bounding_box = bb
-    assert_allclose(w(-1*u.pix, -1*u.pix), (np.nan, np.nan))
+    world = w(-1*u.pix, -1*u.pix)
+    assert_allclose(world, (np.nan, np.nan))
 
 
 def test_compound_bounding_box():
@@ -694,11 +698,11 @@ class TestImaging(object):
 
     def test_inverse(self):
         sky_coord = self.wcs(10, 20, with_units=True)
-        assert np.allclose(self.wcs.invert(sky_coord), (10, 20))
+        assert np.allclose(self.wcs.invert(sky_coord, with_units=True), (10, 20))
 
     def test_back_coordinates(self):
         sky_coord = self.wcs(1, 2, with_units=True)
-        res = self.wcs.transform('sky', 'focal', sky_coord)
+        res = self.wcs.transform('sky', 'focal', sky_coord, with_units=True)
         assert_allclose(res, self.wcs.get_transform('detector', 'focal')(1, 2))
 
     def test_units(self):
@@ -818,7 +822,7 @@ def test_to_fits_sip_composite_frame(gwcs_cube_with_separable_spectral):
     assert fw_hdr['NAXIS2'] == 64
 
     fw = astwcs.WCS(fw_hdr)
-    gskyval = w(1, 60, 55, with_units=True)[0]
+    gskyval = w.pixel_to_world(1, 60, 55)[1]
     fskyval = fw.all_pix2world(1, 60, 0)
     fskyval = [float(fskyval[ra_axis - 1]), float(fskyval[dec_axis - 1])]
     assert np.allclose([gskyval.ra.value, gskyval.dec.value], fskyval)
@@ -831,7 +835,7 @@ def test_to_fits_sip_composite_frame_galactic(gwcs_3d_galactic_spectral):
     assert fw_hdr['CTYPE1'] == 'GLAT-TAN'
 
     fw = astwcs.WCS(fw_hdr)
-    gskyval = w(7, 8, 9, with_units=True)[0]
+    gskyval = w.pixel_to_world(7, 8, 9)[0]
     assert np.allclose([gskyval.b.value, gskyval.l.value],
                        fw.all_pix2world(7, 9, 0), atol=1e-3)
 

--- a/gwcs/tests/test_wcs.py
+++ b/gwcs/tests/test_wcs.py
@@ -1474,3 +1474,32 @@ def test_no_bounding_box_if_read_from_file(tmp_path):
     with warnings.catch_warnings():
         warnings.simplefilter("error")
         wcs_from_file.bounding_box
+
+
+def test_split_frame_wcs():
+    # Setup a model where the pixel & world axes are (lat, wave, lon)
+    spatial = models.Multiply(10*u.arcsec/u.pix) & models.Multiply(15*u.arcsec/u.pix)  # pretend this is a spatial model
+    compound = models.Linear1D(intercept=0*u.nm, slope=10*u.nm/u.pix) & spatial
+    forward = models.Mapping((1, 2, 0)) | compound | models.Mapping((2, 0, 1))
+
+    # Setup the output frame
+    celestial_frame = cf.CelestialFrame(axes_order=(2, 0), unit=(u.arcsec, u.arcsec),
+                                        reference_frame=coord.ICRS())
+    spectral_frame = cf.SpectralFrame(axes_order=(1,), unit=u.nm)
+    output_frame = cf.CompositeFrame([spectral_frame, celestial_frame])
+
+    input_frame = cf.CoordinateFrame(3, ["PIXEL"]*3,
+                                     axes_order=list(range(3)), unit=[u.pix]*3)
+
+    iwcs = wcs.WCS(forward, input_frame, output_frame)
+    input_pixel = [0*u.pix, 1*u.pix, 2*u.pix]
+    output_world = iwcs.pixel_to_world_values(*input_pixel)
+    output_pixel = iwcs.world_to_pixel_values(*output_world)
+    assert_allclose(output_pixel, u.Quantity(input_pixel).to_value(u.pix))
+
+    world_obj = iwcs.pixel_to_world(*input_pixel)
+    assert isinstance(world_obj[0], coord.SkyCoord)
+    assert isinstance(world_obj[1], coord.SpectralCoord)
+
+    obj_pixel = iwcs.world_to_pixel(*world_obj)
+    assert_allclose(obj_pixel, u.Quantity(input_pixel).to_value(u.pix))

--- a/gwcs/utils.py
+++ b/gwcs/utils.py
@@ -465,24 +465,6 @@ def create_projection_transform(projcode):
     return projklass(**projparams)
 
 
-def isnumerical(val):
-    """
-    Determine if a value is numerical (number or np.array of numbers).
-    """
-    isnum = True
-    if isinstance(val, coords.SkyCoord):
-        isnum = False
-    elif isinstance(val, u.Quantity):
-        isnum = False
-    elif isinstance(val, (Time, TimeDelta)):
-        isnum = False
-    elif (isinstance(val, np.ndarray)
-          and not np.issubdtype(val.dtype, np.floating)
-          and not np.issubdtype(val.dtype, np.integer)):
-        isnum = False
-    return isnum
-
-
 def is_high_level(*args, low_level_wcs):
     """
     Determine if args matches the high level classes as defined by

--- a/gwcs/utils.py
+++ b/gwcs/utils.py
@@ -11,8 +11,6 @@ from astropy.modeling import core, projections
 from astropy.io import fits
 from astropy import coordinates as coords
 import astropy.units as u
-from astropy.time import Time, TimeDelta
-from astropy import table
 from astropy.wcs import Celprm
 
 

--- a/gwcs/utils.py
+++ b/gwcs/utils.py
@@ -11,7 +11,6 @@ from astropy.modeling import core, projections
 from astropy.io import fits
 from astropy import coordinates as coords
 from astropy import units as u
-from astropy.time import Time, TimeDelta
 from astropy.wcs import Celprm
 
 

--- a/gwcs/utils.py
+++ b/gwcs/utils.py
@@ -481,3 +481,15 @@ def isnumerical(val):
           and not np.issubdtype(val.dtype, np.integer)):
         isnum = False
     return isnum
+
+
+def is_high_level(*args, low_level_wcs):
+    """
+    Determine if args matches the high level classes as defined by
+    ``low_level_wcs``.
+    """
+    if len(args) != len(low_level_wcs.world_axis_object_classes):
+        return False
+
+    return all([type(arg) is waoc[0]
+                for arg, waoc in zip(args, low_level_wcs.world_axis_object_classes.values())])

--- a/gwcs/utils.py
+++ b/gwcs/utils.py
@@ -472,5 +472,18 @@ def is_high_level(*args, low_level_wcs):
     if len(args) != len(low_level_wcs.world_axis_object_classes):
         return False
 
-    return all([type(arg) is waoc[0]
-                for arg, waoc in zip(args, low_level_wcs.world_axis_object_classes.values())])
+    type_match = [(type(arg), waoc[0])
+                  for arg, waoc in zip(args, low_level_wcs.world_axis_object_classes.values())]
+
+    types_are_high_level = [argt is t for argt, t in type_match]
+
+    if all(types_are_high_level):
+        return True
+
+    if any(types_are_high_level):
+        raise TypeError(
+            "Invalid types were passed, got "
+            f"({', '.join(tm[0].__name__ for tm in type_match)}) expected "
+            f"({', '.join(tm[1].__name__ for tm in type_match)}).")
+
+    return False

--- a/gwcs/wcs.py
+++ b/gwcs/wcs.py
@@ -496,7 +496,7 @@ class WCS(GWCSAPIMixin):
             transform returns ``Quantity`` objects, else values.
 
         """
-        if not utils.isnumerical(args[0]):
+        if utils.is_high_level(*args, low_level_wcs=self):
             args = high_level_objects_to_values(*args, low_level_wcs=self)
 
         results = self._call_backward(*args, **kwargs)

--- a/gwcs/wcs.py
+++ b/gwcs/wcs.py
@@ -404,7 +404,6 @@ class WCS(GWCSAPIMixin):
         if transform is None:
             raise NotImplementedError("WCS.forward_transform is not implemented.")
 
-        breakpoint()
         # Validate that the input type matches what the transform expects
         input_is_quantity = any((isinstance(a, u.Quantity) for a in args))
         if not input_is_quantity and transform.uses_quantity:

--- a/gwcs/wcs.py
+++ b/gwcs/wcs.py
@@ -3,6 +3,7 @@ import functools
 import itertools
 import warnings
 
+import astropy.units as u
 import astropy.io.fits as fits
 import numpy as np
 import numpy.linalg as npla

--- a/gwcs/wcs.py
+++ b/gwcs/wcs.py
@@ -1154,8 +1154,8 @@ class WCS(GWCSAPIMixin):
         to_frame = self._get_frame_by_name(to_frame)
 
         with_units = kwargs.pop("with_units", False)
-        if with_units and backward:
-            args = high_level_objects_to_values(*args, low_level_wcs=self)
+        if backward and utils.is_high_level(*args, low_level_wcs=from_frame):
+            args = high_level_objects_to_values(*args, low_level_wcs=from_frame)
 
         results = self._call_forward(*args, from_frame=from_frame, to_frame=to_frame, **kwargs)
 

--- a/gwcs/wcs.py
+++ b/gwcs/wcs.py
@@ -369,6 +369,8 @@ class WCS(GWCSAPIMixin):
         if with_units:
             if not astutil.isiterable(results):
                 results = (results,)
+            # values are always expected to be arrays or scalars not quantities
+            results = self._remove_units_input(results, self.output_frame)
             high_level = values_to_high_level_objects(*results, low_level_wcs=self)
             if len(high_level) == 1:
                 high_level = high_level[0]

--- a/gwcs/wcs.py
+++ b/gwcs/wcs.py
@@ -15,6 +15,7 @@ from astropy.modeling.models import (Const1D, Identity, Mapping, Polynomial2D,
                                      Sky2Pix_TAN)
 from astropy.wcs.utils import celestial_frame_to_wcs, proj_plane_pixel_scales
 from scipy import linalg, optimize
+from astropy.wcs.wcsapi.high_level_api import high_level_objects_to_values, values_to_high_level_objects
 
 from . import coordinate_frames as cf
 from . import utils
@@ -134,7 +135,6 @@ class WCS(GWCSAPIMixin):
 
     def __init__(self, forward_transform=None, input_frame='detector', output_frame=None,
                  name=""):
-        #self.low_level_wcs = self
         self._approx_inverse = None
         self._available_frames = []
         self._pipeline = []
@@ -329,6 +329,19 @@ class WCS(GWCSAPIMixin):
             frame_obj = frame
         return name, frame_obj
 
+    def _add_units_input(self, arrays, frame):
+        if frame is not None:
+            return tuple(u.Quantity(array, unit) for array, unit in zip(arrays, frame.unit))
+
+        return arrays
+
+    def _remove_units_input(self, arrays, frame):
+        if frame is not None:
+            return tuple(array.to_value(unit) if isinstance(array, u.Quantity) else array
+                         for array, unit in zip(arrays, frame.unit))
+
+        return arrays
+
     def __call__(self, *args, **kwargs):
         """
         Executes the forward transform.
@@ -336,11 +349,6 @@ class WCS(GWCSAPIMixin):
         args : float or array-like
             Inputs in the input coordinate system, separate inputs
             for each dimension.
-        with_units : bool
-            If ``True`` returns a `~astropy.coordinates.SkyCoord` or
-            `~astropy.coordinates.SpectralCoord` object, by using the units of
-            the output cooridnate frame.
-            Optional, default=False.
         with_bounding_box : bool, optional
              If True(default) values in the result which correspond to
              any of the inputs being outside the bounding_box are set
@@ -348,26 +356,45 @@ class WCS(GWCSAPIMixin):
         fill_value : float, optional
             Output value for inputs outside the bounding_box
             (default is np.nan).
+        with_units : bool, optional
+            If ``True`` then high level Astropy objects will be returned.
+            Optional, default=False.
         """
-        transform = self.forward_transform
+        with_units = kwargs.pop("with_units", False)
+
+        results = self._call_forward(*args, **kwargs)
+
+        if with_units:
+            high_level = values_to_high_level_objects(*results, low_level_wcs=self)
+            if len(high_level) == 1:
+                high_level = high_level[0]
+            return high_level
+        return results
+
+    def _call_forward(self, *args, from_frame=None, to_frame=None,
+                      with_bounding_box=True, fill_value=np.nan, **kwargs):
+        """
+        Executes the forward transform, but values only.
+        """
+        if from_frame is None and to_frame is None:
+            transform = self.forward_transform
+        else:
+            transform = self.get_transform(from_frame, to_frame)
+
         if transform is None:
             raise NotImplementedError("WCS.forward_transform is not implemented.")
 
-        with_units = kwargs.pop("with_units", False)
-        if 'with_bounding_box' not in kwargs:
-            kwargs['with_bounding_box'] = True
-        if 'fill_value' not in kwargs:
-            kwargs['fill_value'] = np.nan
+        # Validate that the input type matches what the transform expects
+        input_is_quantity = any((isinstance(a, u.Quantity) for a in args))
+        if not input_is_quantity and transform.uses_quantity:
+            args = self._add_units_input(args, self.input_frame)
+        if not transform.uses_quantity and input_is_quantity:
+            args = self._remove_units_input(args, self.input_frame)
 
-        result = transform(*args, **kwargs)
-
-        if with_units:
-            if self.output_frame.naxes == 1:
-                result = self.output_frame.coordinates(result)
-            else:
-                result = self.output_frame.coordinates(*result)
-
-        return result
+        return transform(*args,
+                         with_bounding_box=with_bounding_box,
+                         fill_value=fill_value,
+                         **kwargs)
 
     def in_image(self, *args, **kwargs):
         """
@@ -451,9 +478,8 @@ class WCS(GWCSAPIMixin):
             Output value for inputs outside the bounding_box (default is ``np.nan``).
 
         with_units : bool, optional
-            If ``True`` returns a `~astropy.coordinates.SkyCoord` or
-            `~astropy.coordinates.SpectralCoord` object, by using the units of
-            the output cooridnate frame. Default is `False`.
+            If ``True`` then high level Astropy objects will be accepted.
+            Optional, default=False.
 
         Other Parameters
         ----------------
@@ -466,40 +492,35 @@ class WCS(GWCSAPIMixin):
         result : tuple or value
             Returns a tuple of scalar or array values for each axis. Unless
             ``input_frame.naxes == 1`` when it shall return the value.
+            The return type will be `~astropy.unit.Quantity` objects if the
+            transform returns ``Quantity`` objects, else values.
 
         """
         with_units = kwargs.pop('with_units', False)
+        if with_units:
+            args = high_level_objects_to_values(*args, low_level_wcs=self)
 
-        if not utils.isnumerical(args[0]):
-            args = self.output_frame.coordinate_to_quantity(*args)
-            if self.output_frame.naxes == 1:
-                args = [args]
-            try:
-                if not self.backward_transform.uses_quantity:
-                    args = utils.get_values(self.output_frame.unit, *args)
-            except (NotImplementedError, KeyError):
-                args = utils.get_values(self.output_frame.unit, *args)
+        return self._call_backward(*args, **kwargs)
 
-        if 'with_bounding_box' not in kwargs:
-            kwargs['with_bounding_box'] = True
-
-        if 'fill_value' not in kwargs:
-            kwargs['fill_value'] = np.nan
-
+    def _call_backward(self, *args, with_bounding_box=True, fill_value=np.nan, **kwargs):
         try:
+            transform = self.backward_transform
+            # Validate that the input type matches what the transform expects
+            input_is_quantity = any((isinstance(a, u.Quantity) for a in args))
+            if not input_is_quantity and transform.uses_quantity:
+                args = self._add_units_input(args, self.output_frame)
+            if not transform.uses_quantity and input_is_quantity:
+                args = self._remove_units_input(args, self.output_frame)
+
             # remove iterative inverse-specific keyword arguments:
             akwargs = {k: v for k, v in kwargs.items() if k not in _ITER_INV_KWARGS}
-            result = self.backward_transform(*args, **akwargs)
+            result = transform(*args, with_bounding_box=with_bounding_box, fill_value=fill_value, **akwargs)
         except (NotImplementedError, KeyError):
-            result = self.numerical_inverse(*args, **kwargs, with_units=with_units)
+            # Always strip units for numerical inverse
+            args = self._remove_units_input(args, self.output_frame)
+            result = self.numerical_inverse(*args, with_bounding_box=with_bounding_box, fill_value=fill_value, **kwargs)
 
-        if with_units and self.input_frame:
-            if self.input_frame.naxes == 1:
-                return self.input_frame.coordinates(result)
-            else:
-                return self.input_frame.coordinates(*result)
-        else:
-            return result
+        return result
 
     def numerical_inverse(self, *args, tolerance=1e-5, maxiter=50, adaptive=True,
                           detect_divergence=True, quiet=True, with_bounding_box=True,
@@ -739,12 +760,6 @@ class WCS(GWCSAPIMixin):
          [2.76552923e-05 1.14789013e-05]]
 
         """
-        if not utils.isnumerical(args[0]):
-            args = self.output_frame.coordinate_to_quantity(*args)
-            if self.output_frame.naxes == 1:
-                args = [args]
-            args = utils.get_values(self.output_frame.unit, *args)
-
         args_shape = np.shape(args)
         nargs = args_shape[0]
         arg_dim = len(args_shape) - 1
@@ -813,13 +828,7 @@ class WCS(GWCSAPIMixin):
 
             result = tuple(np.reshape(result, args_shape))
 
-        if with_units and self.input_frame:
-            if self.input_frame.naxes == 1:
-                return self.input_frame.coordinates(result)
-            else:
-                return self.input_frame.coordinates(*result)
-        else:
-            return result
+        return result
 
     def _vectorized_fixed_point(self, pix0, world, tolerance, maxiter,
                                 adaptive, detect_divergence, quiet,
@@ -1103,33 +1112,20 @@ class WCS(GWCSAPIMixin):
         fill_value : float, optional
             Output value for inputs outside the bounding_box (default is np.nan).
         """
-        transform = self.get_transform(from_frame, to_frame)
-        if not utils.isnumerical(args[0]):
-            inp_frame = getattr(self, from_frame)
-            args = inp_frame.coordinate_to_quantity(*args)
-            if not transform.uses_quantity:
-                args = utils.get_values(inp_frame.unit, *args)
+        # Determine if the transform is actually an inverse
+        from_ind = self._get_frame_index(from_frame)
+        to_ind = self._get_frame_index(to_frame)
+        backward = to_ind < from_ind
 
         with_units = kwargs.pop("with_units", False)
-        if 'with_bounding_box' not in kwargs:
-            kwargs['with_bounding_box'] = True
-        if 'fill_value' not in kwargs:
-            kwargs['fill_value'] = np.nan
+        if with_units and backward:
+            args = high_level_objects_to_values(*args, low_level_wcs=self)
 
-        result = transform(*args, **kwargs)
+        results = self._call_forward(*args, from_frame=from_frame, to_frame=to_frame, **kwargs)
 
-        if with_units:
-            to_frame_name, to_frame_obj = self._get_frame_name(to_frame)
-            if to_frame_obj is not None:
-                if to_frame_obj.naxes == 1:
-                    result = to_frame_obj.coordinates(result)
-                else:
-                    result = to_frame_obj.coordinates(*result)
-            else:
-                raise TypeError("Coordinate objects could not be created because"
-                                "frame {0} is not defined.".format(to_frame_name))
-
-        return result
+        if with_units and not backward:
+            return values_to_high_level_objects(*results, low_level_wcs=self)
+        return results
 
     @property
     def available_frames(self):

--- a/gwcs/wcs.py
+++ b/gwcs/wcs.py
@@ -492,7 +492,7 @@ class WCS(GWCSAPIMixin):
         result : tuple or value
             Returns a tuple of scalar or array values for each axis. Unless
             ``input_frame.naxes == 1`` when it shall return the value.
-            The return type will be `~astropy.unit.Quantity` objects if the
+            The return type will be `~astropy.units.Quantity` objects if the
             transform returns ``Quantity`` objects, else values.
 
         """

--- a/gwcs/wcs.py
+++ b/gwcs/wcs.py
@@ -478,7 +478,7 @@ class WCS(GWCSAPIMixin):
             Output value for inputs outside the bounding_box (default is ``np.nan``).
 
         with_units : bool, optional
-            If ``True`` then high level Astropy objects will be accepted.
+            If ``True`` then high level astropy object (i.e. ``Quantity``) will be returned.
             Optional, default=False.
 
         Other Parameters
@@ -496,11 +496,19 @@ class WCS(GWCSAPIMixin):
             transform returns ``Quantity`` objects, else values.
 
         """
-        with_units = kwargs.pop('with_units', False)
-        if with_units:
+        if not utils.isnumerical(args[0]):
             args = high_level_objects_to_values(*args, low_level_wcs=self)
 
-        return self._call_backward(*args, **kwargs)
+        results = self._call_backward(*args, **kwargs)
+
+        with_units = kwargs.pop('with_units', False)
+        if with_units:
+            high_level = values_to_high_level_objects(*results, low_level_wcs=self)
+            if len(high_level) == 1:
+                high_level = high_level[0]
+            return high_level
+
+        return results
 
     def _call_backward(self, *args, with_bounding_box=True, fill_value=np.nan, **kwargs):
         try:

--- a/gwcs/wcs.py
+++ b/gwcs/wcs.py
@@ -523,8 +523,6 @@ class WCS(GWCSAPIMixin):
         except NotImplementedError:
             transform = None
 
-        with_bounding_box = kwargs.pop('with_bounding_box', True)
-        fill_value = kwargs.pop('fill_value', np.nan)
         if with_bounding_box and self.bounding_box is not None:
             args = self.outside_footprint(args)
 

--- a/gwcs/wcs.py
+++ b/gwcs/wcs.py
@@ -533,7 +533,7 @@ class WCS(GWCSAPIMixin):
 
     def numerical_inverse(self, *args, tolerance=1e-5, maxiter=50, adaptive=True,
                           detect_divergence=True, quiet=True, with_bounding_box=True,
-                          fill_value=np.nan, with_units=False, **kwargs):
+                          fill_value=np.nan, **kwargs):
         """
         Invert coordinates from output frame to input frame using numerical
         inverse.
@@ -559,11 +559,6 @@ class WCS(GWCSAPIMixin):
 
         fill_value : float, optional
             Output value for inputs outside the bounding_box (default is ``np.nan``).
-
-        with_units : bool, optional
-            If ``True`` returns a `~astropy.coordinates.SkyCoord` or
-            `~astropy.coordinates.SpectralCoord` object, by using the units of
-            the output cooridnate frame. Default is `False`.
 
         tolerance : float, optional
             *Absolute tolerance* of solution. Iteration terminates when the
@@ -769,6 +764,9 @@ class WCS(GWCSAPIMixin):
          [2.76552923e-05 1.14789013e-05]]
 
         """
+        if kwargs.pop("with_units", False):
+            raise ValueError("Support for with_units in numerical_inverse has been removed, use inverse")
+
         args_shape = np.shape(args)
         nargs = args_shape[0]
         arg_dim = len(args_shape) - 1

--- a/gwcs/wcs.py
+++ b/gwcs/wcs.py
@@ -19,9 +19,7 @@ from astropy.modeling.parameters import _tofloat
 from astropy.wcs.utils import celestial_frame_to_wcs, proj_plane_pixel_scales
 from astropy.wcs.wcsapi.high_level_api import high_level_objects_to_values, values_to_high_level_objects
 
-from astropy import units as u
 from scipy import linalg, optimize
-from astropy.wcs.wcsapi.high_level_api import high_level_objects_to_values, values_to_high_level_objects
 
 from . import coordinate_frames as cf
 from . import utils

--- a/gwcs/wcs.py
+++ b/gwcs/wcs.py
@@ -7,6 +7,7 @@ import astropy.units as u
 import astropy.io.fits as fits
 import numpy as np
 import numpy.linalg as npla
+from astropy import utils as astutil
 from astropy.modeling import fix_inputs, projections
 from astropy.modeling.bounding_box import CompoundBoundingBox
 from astropy.modeling.bounding_box import ModelBoundingBox as Bbox
@@ -366,6 +367,8 @@ class WCS(GWCSAPIMixin):
         results = self._call_forward(*args, **kwargs)
 
         if with_units:
+            if not astutil.isiterable(results):
+                results = (results,)
             high_level = values_to_high_level_objects(*results, low_level_wcs=self)
             if len(high_level) == 1:
                 high_level = high_level[0]

--- a/gwcs/wcstools.py
+++ b/gwcs/wcstools.py
@@ -327,7 +327,7 @@ def wcs_from_points(xy, world_coords, proj_point='center',
                          "Only one of {} is supported.".format(polynomial_type,
                                                                supported_poly_types.keys()))
 
-    skyrot = models.RotateCelestial2Native(crval[0].deg, crval[1].deg, 180)
+    skyrot = models.RotateCelestial2Native(crval[0].to_value(u.deg), crval[1].to_value(u.deg), 180)
     trans = (skyrot | projection)
     projection_x, projection_y = trans(lon, lat)
     poly = supported_poly_types[polynomial_type](poly_degree)

--- a/tox.ini
+++ b/tox.ini
@@ -66,6 +66,9 @@ pass_env =
     CI
     CODECOV_*
     DISPLAY
+    CC
+    LOCALE_ARCHIVE
+    LC_ALL
     jwst,romancal: CRDS_*
     romanisim,romancal: WEBBPSF_PATH
     romanisim: GALSIM_CAT_PATH


### PR DESCRIPTION
This PR has been going on for a long time, but I think it's finally close. So here's a write up of what this PR does and why based on what I can remember and my own review of the code.


## Objective

Ultimately this whole thing span out of trying to fix #455, which boils down to `axes_order` and the way frames worked being inconsistent and weird. So the primary objective of this PR is to clarify, fix and document the purpose of the frames and how they interact with the WCS class and WCS API.

## Core changes

### Coordinate Frame Ordering

The coordinate frames now have a "native" order of axes, the main one where this is apparent is `CelestialFrame` where the native order is lon, lat. The `__init__` for frames is always in the native order, and a different effective order can be given using `axes_order`. The native ordering of a frame is then passed into a `FrameProperties` class, and properties on the frame itself return an ordered view into this class. This functionality is tested [here](https://github.com/spacetelescope/gwcs/pull/457/files#diff-be1517c28a0262a9530f646c03274fc7b8468591541ca3f6a063da50587d1b4cR1353)

This split between native and axes_order ordering is also used by `CompositeFrame` to allow it to combine split axes ordering into the expected order. This is tested [here](https://github.com/spacetelescope/gwcs/pull/457/files#diff-be1517c28a0262a9530f646c03274fc7b8468591541ca3f6a063da50587d1b4cR1303)


### High Level Objects and Units

The other main change is to the handling of units and high level objects. This has a few smaller prongs to it.

Firstly, this PR codifies that `with_units` controls the return type of `__call__` `inverse` and `transform`, if `with_units=True` then high level astropy objects (Quantity, SkyCoord, Time etc) will be returned. All high level object handling is now confined to these user facing methods, and numerical only (Quantity or non-Quantity) transforms are executed by the new [`_call_forward`](https://github.com/spacetelescope/gwcs/pull/457/files#diff-a87a0820dd9de1090bab781695dd821ec8385db4e0aa9f07c98b1f3d972c303dR362) and [`_call_backward`](https://github.com/spacetelescope/gwcs/pull/457/files#diff-a87a0820dd9de1090bab781695dd821ec8385db4e0aa9f07c98b1f3d972c303dR507) methods.

Secondly, this PR also codifies and refactors the input handling for all these methods. Quantity and non-Quantity inputs are always supported for forward transforms, and depending on the `transform.uses_quantity` property on the `Model` the units will be retained, added or stripped as needed. All this happens in the new `_call_forward` and `_call_backward` methods.

Finally, to align with the new `_call_backward` method `WCS.numerical_inverse` is now low-level only, it can no longer accept high-level objects to be type converted by the frames, and will not return them either. If you need this functionality it will be automatically handled by `inverse`. (`with_units=True` to `numerical_inverse` now raises an exception).


### Use more high level object handling from astropy core

The final major change in this PR is to remove as much high level WCS API code as possible and rely on astropy to do this for us. This consists of two main parts:

#### Using `HighLevelWCSMixin`

The `GWCSAPIMixin` now [inherits from the `HighLevelWCSMixin`](https://github.com/spacetelescope/gwcs/pull/457/files#diff-bea7bdec04abcc6fa0474b74c24f80ad35542711ccfaf04f0dbf260f6cae51ddR17) and [no longer implements the high level API](https://github.com/spacetelescope/gwcs/pull/457/files#diff-bea7bdec04abcc6fa0474b74c24f80ad35542711ccfaf04f0dbf260f6cae51ddL268-L333) as this is provided by the mixin. 

#### Removing custom high <> low level object conversion

We now use `high_level_objects_to_values` and `values_to_high_level_objects` from `astropy.wcs.wcsapi.high_level_api` to convert to/from high level objects when they are passed to the user facing methods or to return them from these methods when `with_units=True`.

The combination of these two changes means that we no longer need to implement low-level <> high-level conversions on the coordinate frame classes, so the `coordinates` and `coordinate_to_quantity` methods have been removed.

---

# Breaking changes:

* `WCS.numerical_inverse` no longer handles high level inputs or outputs, `with_units=True` errors.
* `CoordinateFrame.coordinates` and `.coordinate_to_quantity` have been removed, these should never really have been used by users.
* Inputs to `CelestialFrame` should always be in lon,lat order and will be re-ordered by axes_order. This behaviour before was poorly specified and inconsistent.
* Specifying strings inplace of frame classes is now not really supported.

# Open Questions

1. High Level Object Input: https://github.com/spacetelescope/gwcs/pull/457#discussion_r1776889797
2. ~RegionSelector seems to not propagate `uses_quantity` correctly: https://github.com/spacetelescope/gwcs/pull/457#issuecomment-2374354308~
---

fixes #224
hopefully fixes #269
