### PR TITLE
Remove old bbox support

### DIFF
--- a/gwcs/wcs.py
+++ b/gwcs/wcs.py
@@ -2,33 +2,26 @@
 import functools
 import itertools
 import warnings
+
+import astropy.io.fits as fits
 import numpy as np
 import numpy.linalg as npla
-from scipy import optimize, linalg
 from astropy import units as u
+from astropy.modeling import fix_inputs, projections
+from astropy.modeling.bounding_box import CompoundBoundingBox
+from astropy.modeling.bounding_box import ModelBoundingBox as Bbox
 from astropy.modeling.core import Model
-from astropy.modeling.models import (
-    Identity, Mapping, Const1D, Shift, Polynomial2D,
-    Sky2Pix_TAN, RotateCelestial2Native
-)
-from astropy.modeling import projections, fix_inputs
-import astropy.io.fits as fits
+from astropy.modeling.models import (Const1D, Identity, Mapping, Polynomial2D,
+                                     RotateCelestial2Native, Shift,
+                                     Sky2Pix_TAN)
 from astropy.wcs.utils import celestial_frame_to_wcs, proj_plane_pixel_scales
+from scipy import linalg, optimize
 
-from .api import GWCSAPIMixin
 from . import coordinate_frames as cf
-from .utils import CoordinateFrameError
 from . import utils
+from .api import GWCSAPIMixin
+from .utils import CoordinateFrameError
 from .wcstools import grid_from_bounding_box
-
-try:
-    from astropy.modeling.bounding_box import ModelBoundingBox as Bbox
-    from astropy.modeling.bounding_box import CompoundBoundingBox
-    new_bbox = True
-except ImportError:
-    from astropy.modeling.utils import _BoundingBox as Bbox
-    new_bbox = False
-
 
 __all__ = ['WCS', 'Step', 'NoConvergence']
 
@@ -366,14 +359,7 @@ class WCS(GWCSAPIMixin):
             # Currently compound models do not attempt to combine individual model
             # bounding boxes. Get the forward transform and assign the bounding_box to it
             # before evaluating it. The order Model.bounding_box is reversed.
-            if new_bbox:
-                transform.bounding_box = self.bounding_box
-            else:
-                axes_ind = self._get_axes_indices()
-                if transform.n_inputs > 1:
-                    transform.bounding_box = [self.bounding_box[ind] for ind in axes_ind][::-1]
-                else:
-                    transform.bounding_box = self.bounding_box
+            transform.bounding_box = self.bounding_box
 
         result = transform(*args, **kwargs)
 
@@ -425,10 +411,7 @@ class WCS(GWCSAPIMixin):
             return result
 
         if self.input_frame.naxes == 1:
-            if new_bbox:
-                x1, x2 = self.bounding_box.bounding_box()
-            else:
-                x1, x2 = self.bounding_box
+            x1, x2 = self.bounding_box.bounding_box()
 
             if len(np.shape(args[0])) > 0:
                 result[result] = (coords[result] >= x1) & (coords[result] <= x2)
@@ -1318,17 +1301,7 @@ class WCS(GWCSAPIMixin):
         except NotImplementedError:
             return None
 
-        if new_bbox:
-            return bb
-        else:
-            if transform_0.n_inputs == 1:
-                return bb
-            try:
-                axes_order = self.input_frame.axes_order
-            except AttributeError:
-                axes_order = np.arange(transform_0.n_inputs)
-            # Model.bounding_box is in python order, need to reverse it first.
-            return tuple(bb[::-1][i] for i in axes_order)
+        return bb
 
     @bounding_box.setter
     def bounding_box(self, value):
@@ -1350,39 +1323,23 @@ class WCS(GWCSAPIMixin):
         else:
             try:
                 # Make sure the dimensions of the new bbox are correct.
-                if new_bbox:
-                    if isinstance(value, CompoundBoundingBox):
-                        bbox = CompoundBoundingBox.validate(transform_0, value, order='F')
-                    else:
-                        bbox = Bbox.validate(transform_0, value, order='F')
+                if isinstance(value, CompoundBoundingBox):
+                    bbox = CompoundBoundingBox.validate(transform_0, value, order='F')
                 else:
-                    Bbox.validate(transform_0, value)
+                    bbox = Bbox.validate(transform_0, value, order='F')
             except Exception:
                 raise
 
-            if new_bbox:
-                transform_0.bounding_box = bbox
-            else:
-                # get the sorted order of axes' indices
-                axes_ind = self._get_axes_indices()
-                if transform_0.n_inputs == 1:
-                    transform_0.bounding_box = value
-                else:
-                    # The axes in bounding_box in modeling follow python order
-                    #transform_0.bounding_box = np.array(value)[axes_ind][::-1]
-                    transform_0.bounding_box = [value[ind] for ind in axes_ind][::-1]
+            transform_0.bounding_box = bbox
 
         self.set_transform(frames[0], frames[1], transform_0)
 
     def attach_compound_bounding_box(self, cbbox, selector_args):
-        if new_bbox:
-            frames = self.available_frames
-            transform_0 = self.get_transform(frames[0], frames[1])
+        frames = self.available_frames
+        transform_0 = self.get_transform(frames[0], frames[1])
 
-            self.bounding_box = CompoundBoundingBox.validate(transform_0, cbbox, selector_args=selector_args,
-                                                             order='F')
-        else:
-            raise NotImplementedError('Compound bounding box is not supported for your version of astropy')
+        self.bounding_box = CompoundBoundingBox.validate(transform_0, cbbox, selector_args=selector_args,
+                                                            order='F')
 
     def _get_axes_indices(self):
         try:
@@ -1394,6 +1351,7 @@ class WCS(GWCSAPIMixin):
 
     def __str__(self):
         from astropy.table import Table
+
         #col1 = [item[0] for item in self._pipeline]
         col1 = [step.frame for step in self._pipeline]
         col2 = []
@@ -2554,13 +2512,12 @@ class WCS(GWCSAPIMixin):
         if isinstance(bin_ext, str):
             bin_ext = (bin_ext, 1)
 
-        if new_bbox:
-            if isinstance(bounding_box, Bbox):
-                bounding_box = bounding_box.bounding_box(order='F')
-            if isinstance(bounding_box, list):
-                for index, bbox in enumerate(bounding_box):
-                    if isinstance(bbox, Bbox):
-                        bounding_box[index] = bbox.bounding_box(order='F')
+        if isinstance(bounding_box, Bbox):
+            bounding_box = bounding_box.bounding_box(order='F')
+        if isinstance(bounding_box, list):
+            for index, bbox in enumerate(bounding_box):
+                if isinstance(bbox, Bbox):
+                    bounding_box[index] = bbox.bounding_box(order='F')
 
         # identify input axes:
         input_axes = []


### PR DESCRIPTION
This is the first split out from #457 

Given we recently bumped the Astropy version to 5.3 we presumably don't need this any more.