### PR TITLE
Add a multi-dimensional `PixelFrame`

### DIFF
--- a/gwcs/coordinate_frames.py
+++ b/gwcs/coordinate_frames.py
@@ -312,6 +312,34 @@ class CoordinateFrame:
         return [(f"{at}{i}" if i != 0 else at, 0, 'value') for i, at in enumerate(self._axes_type)]
 
 
+class PixelFrame(CoordinateFrame):
+    """
+    A coordinate frame describing pixels.
+
+    Parameters
+    ----------
+    naxes : int
+        The number of pixel dimensions described by the frame.
+    axes_order : list of int, optional
+        The axes order, if not specified defaults to `range(naxes)` (i.e. all
+        axes are in this frame).
+    name : str, optional
+        The name of this frame.
+    axes_names : list of str, optional
+        The names of the pixel axes.
+    """
+    def __init__(self, naxes, axes_order=None, axes_names=None, name=None):
+        axes_order = axes_order if axes_order is not None else list(range(naxes))
+        super().__init__(
+            naxes,
+            ["PIXEL"]*naxes,
+            axes_order=axes_order,
+            unit=[u.pix]*naxes,
+            axes_names=axes_names,
+            name=name,
+        )
+
+
 class CelestialFrame(CoordinateFrame):
     """
     Celestial Frame Representation


### PR DESCRIPTION
I often find myself doing `cf.CoordinateFrame(3, ["PIXEL", "PIXEL", "PIXEL"], unit=[u.pix, u.pix, u.pix], ...)` to generate an input frame to a single stage "pixel to world" type WCS.

Having a shortcut, designed to be an input frame where you aren't going to have a compound frame or anything as input, like this `PixelFrame` would let you do `PixelFrame(3)` and get the same result.

I do think that `Frame2D` feels somewhat like a special case of this new `PixelFrame`, but not sure if it's worth deprecating `Frame2D` or not.