### PR TITLE
Allow splitting Celestial axes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,9 @@ Bug Fixes
 - Synchronize ``array_shape`` and ``pixel_shape`` attributes of WCS
   objects. [#439]
 
+- Fix an issue with ``CompositeFrame``, containing a ``CelestialFrame``
+  with non-consecutive axes. [#467]
+
 other
 ^^^^^
 

--- a/gwcs/coordinate_frames.py
+++ b/gwcs/coordinate_frames.py
@@ -635,13 +635,17 @@ class CompositeFrame(CoordinateFrame):
         if len(coords) == len(self.frames):
             args = coords
         elif len(coords) == self.naxes:
-            args = []
-            for _frame in self.frames:
-                if _frame.naxes > 1:
-                    # Collect the arguments for this frame based on axes_order
-                    args.append([coords[i] for i in _frame.axes_order])
-                else:
-                    args.append(coords[_frame.axes_order[0]])
+            if all([isinstance(a, u.Quantity) for a in coords]):
+                args = coords
+                return args
+            else:
+                args = []
+                for _frame in self.frames:
+                    if _frame.naxes > 1:
+                        # Collect the arguments for this frame based on axes_order
+                        args.append([coords[i] for i in _frame.axes_order])
+                    else:
+                        args.append(coords[_frame.axes_order[0]])
         else:
             raise ValueError("Incorrect number of arguments")
 

--- a/gwcs/tests/test_api.py
+++ b/gwcs/tests/test_api.py
@@ -521,3 +521,22 @@ def test_coordinate_frame_api():
 
     pixel2 = wcs.invert(world)
     assert u.allclose(pixel2, 0*u.pix)
+
+
+def test_split_celestial_axes():
+    forward = (m.Multiply(10*u.arcsec/u.pix) &
+               m.Linear1D(intercept=0*u.nm, slope=10*u.nm/u.pix) &
+               m.Multiply(15*u.arcsec/u.pix))
+
+    celestial_frame = cf.CelestialFrame(axes_order=(0, 2), unit=(u.arcsec, u.arcsec))
+    spectral_frame = cf.SpectralFrame(axes_order=(1,), unit=u.nm)
+    output_frame = cf.CompositeFrame([spectral_frame, celestial_frame])
+
+    input_frame = cf.CoordinateFrame(3, ["PIXEL"]*3, axes_order=list(range(3)), unit=[u.pix]*3)
+
+    wcs = gwcs.WCS(forward, input_frame, output_frame)
+
+    input_pixel = [1, 2, 3] * u.pix
+    output_world = wcs.pixel_to_world_values(*input_pixel)
+    output_pixel = wcs.world_to_pixel_values(*output_world)
+    assert_allclose(input_pixel.value, output_pixel)

--- a/gwcs/tests/test_api.py
+++ b/gwcs/tests/test_api.py
@@ -540,3 +540,8 @@ def test_split_celestial_axes():
     output_world = wcs.pixel_to_world_values(*input_pixel)
     output_pixel = wcs.world_to_pixel_values(*output_world)
     assert_allclose(input_pixel.value, output_pixel)
+
+    input_pixel = [1, 2, 3]
+    output_world = wcs.pixel_to_world_values(*input_pixel)
+    output_pixel = wcs.world_to_pixel_values(*output_world)
+    assert_allclose(input_pixel, output_pixel)


### PR DESCRIPTION
Closes #455 

This fixes a problem with evaluating the backwards transform when a `CompositeFrame` contains a `CelestialFrame` with non-consecutive axes.