### PR TITLE
Clean up some warnings in CI

### DIFF
--- a/gwcs/converters/tests/test_transforms.py
+++ b/gwcs/converters/tests/test_transforms.py
@@ -4,8 +4,11 @@ import pytest
 
 from astropy.modeling.models import Identity
 from astropy import units as u
-from asdf_astropy.converters.transform.tests.test_transform import (
-     assert_model_roundtrip)
+
+try:
+    from asdf_astropy.testing.helpers import assert_model_roundtrip
+except ImportError:
+    from asdf_astropy.converters.transform.tests.test_transform import assert_model_roundtrip
 
 from ... import spectroscopy as sp
 from ... import geometry

--- a/gwcs/tests/test_geometry.py
+++ b/gwcs/tests/test_geometry.py
@@ -7,8 +7,11 @@ import pytest
 import asdf
 import numpy as np
 from astropy import units as u
-from asdf_astropy.converters.transform.tests.test_transform import (
-     assert_model_roundtrip)
+
+try:
+    from asdf_astropy.testing.helpers import assert_model_roundtrip
+except ImportError:
+    from asdf_astropy.converters.transform.tests.test_transform import assert_model_roundtrip
 
 from .. import geometry
 

--- a/gwcs/tests/test_geometry.py
+++ b/gwcs/tests/test_geometry.py
@@ -153,9 +153,9 @@ def test_spherical_to_cartesian_mixed_Q(spher_to_cart, unit1, unit2):
 
 @pytest.mark.parametrize(
     'x, y, z',
-    list(set(
+    sorted(list(set(
         tuple(permutations([1 * u.m, 1, 1])) + tuple(permutations([1 * u.m, 1 * u.m, 1]))
-    ))
+    )), key=str)
 )
 def test_cartesian_to_spherical_mixed_Q(cart_to_spher, x, y, z):
     with pytest.raises(TypeError) as arg_err:

--- a/gwcs/tests/test_wcs.py
+++ b/gwcs/tests/test_wcs.py
@@ -1091,7 +1091,9 @@ def test_in_image():
 
 
 def test_iter_inv():
-    w = asdf.open(get_pkg_data_filename('data/nircamwcs.asdf')).tree['wcs']
+    fn = get_pkg_data_filename('data/nircamwcs.asdf')
+    with asdf.open(fn, lazy_load=False, copy_arrays=False, ignore_missing_extensions=True) as af:
+        w = af.tree['wcs']
     # remove analytic/user-supplied inverse:
     w.pipeline[0].transform.inverse = None
     w.bounding_box = None
@@ -1117,7 +1119,8 @@ def test_iter_inv():
     )
     assert np.allclose((x, y), (xp, yp))
 
-    w = asdf.open(get_pkg_data_filename('data/nircamwcs.asdf')).tree['wcs']
+    with asdf.open(fn, lazy_load=False, copy_arrays=False, ignore_missing_extensions=True) as af:
+        w = af.tree['wcs']
 
     # test single point
     assert np.allclose((1, 2), w.numerical_inverse(*w(1, 2)))

--- a/gwcs/tests/test_wcs.py
+++ b/gwcs/tests/test_wcs.py
@@ -1194,7 +1194,7 @@ def test_iter_inv():
 
 def test_tabular_2d_quantity():
     shape = (3, 3)
-    data = np.arange(np.product(shape)).reshape(shape) * u.m / u.s
+    data = np.arange(np.prod(shape)).reshape(shape) * u.m / u.s
 
     # The integer location is at the centre of the pixel.
     points_unit = u.pix

--- a/gwcs/tests/test_wcs.py
+++ b/gwcs/tests/test_wcs.py
@@ -640,8 +640,9 @@ def test_to_fits_sip():
     y, x = np.mgrid[:1024:10, :1024:10]
     xflat = np.ravel(x[1:-1, 1:-1])
     yflat = np.ravel(y[1:-1, 1:-1])
-    af = asdf.open(get_pkg_data_filename('data/miriwcs.asdf'))
-    miriwcs = af.tree['wcs']
+    fn = get_pkg_data_filename('data/miriwcs.asdf')
+    with asdf.open(fn, lazy_load=False, copy_arrays=True, ignore_missing_extensions=True) as af:
+        miriwcs = af.tree['wcs']
     bounding_box = ((0, 1024), (0, 1024))
     mirisip = miriwcs.to_fits_sip(bounding_box, max_inv_pix_error=0.1, verbose=True)
     fitssip = astwcs.WCS(mirisip)
@@ -1000,8 +1001,9 @@ def test_to_fits_tab_time_cube(gwcs_cube_with_separable_time):
 
 def test_to_fits_tab_miri_image():
     # gWCS:
-    af = asdf.open(get_pkg_data_filename('data/miriwcs.asdf'))
-    w = af.tree['wcs']
+    fn = get_pkg_data_filename('data/miriwcs.asdf')
+    with asdf.open(fn, copy_arrays=True, lazy_load=False, ignore_missing_extensions=True) as af:
+        w = af.tree['wcs']
 
     # FITS WCS -TAB:
     hdr, bt = w.to_fits_tab(sampling=0.5)
@@ -1023,8 +1025,9 @@ def test_to_fits_tab_miri_image():
 
 
 def test_to_fits_tab_miri_lrs():
-    af = asdf.open(get_pkg_data_filename('data/miri_lrs_wcs.asdf'))
-    w = af.tree['wcs']
+    fn = get_pkg_data_filename('data/miri_lrs_wcs.asdf')
+    with asdf.open(fn, copy_arrays=True, lazy_load=False, ignore_missing_extensions=True) as af:
+        w = af.tree['wcs']
 
     # FITS WCS -TAB:
     hdr, bt = w.to_fits(sampling=0.25)
@@ -1240,7 +1243,9 @@ def test_sip_roundtrip():
     hdr['naxis'] = 2
     hdr['naxis1'] = nx
     hdr['naxis2'] = ny
-    gw = _gwcs_from_hst_fits_wcs(hdr)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", category=astwcs.FITSFixedWarning)
+        gw = _gwcs_from_hst_fits_wcs(hdr)
     hdr_back = gw.to_fits_sip(
         max_pix_error=1e-6,
         max_inv_pix_error=None,
@@ -1271,7 +1276,9 @@ def test_sip_roundtrip():
 def test_spatial_spectral_stokes():
     """ Converts a FITS WCS to GWCS and compares results."""
     hdr = fits.Header.fromfile(get_pkg_data_filename("data/stokes.txt"))
-    aw = astwcs.WCS(hdr)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", category=astwcs.FITSFixedWarning)
+        aw = astwcs.WCS(hdr)
     crpix = aw.wcs.crpix
     crval = aw.wcs.crval
     cdelt = aw.wcs.cdelt

--- a/gwcs/wcs.py
+++ b/gwcs/wcs.py
@@ -679,7 +679,8 @@ class WCS(GWCSAPIMixin):
         >>> import numpy as np
 
         >>> filename = get_pkg_data_filename('data/nircamwcs.asdf', package='gwcs.tests')
-        >>> w = asdf.open(filename).tree['wcs']
+        >>> with asdf.open(filename, copy_arrays=True, lazy_load=False, ignore_missing_extensions=True) as af:
+        ...    w = af.tree['wcs']
 
         >>> ra, dec = w([1,2,3], [1,1,1])
         >>> assert np.allclose(ra, [5.927628, 5.92757069, 5.92751337]);

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,6 +85,8 @@ doctest_plus = "enabled"
 addopts = "--doctest-rst"
 filterwarnings = [
     "ignore:Models in math_functions:astropy.utils.exceptions.AstropyUserWarning",
+    # importing astropy code causes this warning to be issued, so ignore it
+    "ignore:numpy.ndarray size changed:RuntimeWarning",
 ]
 
 [tool.coverage.run]


### PR DESCRIPTION
This PR cleans up several warnings in the tests.

- switch `asdf_astropy.converters.transform.tests.test_transform.assert_roundtrip_model` to the non-deprecated `asdf_astropy.testing.helpers.assert_roundtrip_model` (this was done with a try-except which falls back for asdf-astropy versions <0.4.0).
- use `asdf.open` in a `with` statement (to assure the file is closed) and changing some of the arguments to `asdf.open` to `ignore_missing_extensions` so warnings are not issued for a missing 'JWSTExtension' (if jwst is not installed).
- switch`np.prod` to `np.product`.
- a test suite wide `ignore` was added for the `RuntimeWarning` "numpy.ndarray size changed" which occurs when some astopy code is imported
- `FITSFiixedWarning` warnings were ignored in 2 tests (see: https://github.com/spacetelescope/gwcs/commit/8613aa0bf2a91ca2e77df7ba8ea0a19d4fbe50d4). I'm not quite sure what these are or if they should just be ignored or fixed in some other way. @nden do you have any advice for these? The warnings seen in the most recent run on the main branch are as follows:
```
gwcs/tests/test_wcs.py::test_sip_roundtrip
  /home/runner/work/gwcs/gwcs/.tox/test/lib/python3.9/site-packages/astropy/wcs/wcs.py:819: FITSFixedWarning: 'datfix' made the change 'Set MJD-OBS to 53436.000000 from DATE-OBS'.
    warnings.warn(

gwcs/tests/test_wcs.py::test_spatial_spectral_stokes
  /home/runner/work/gwcs/gwcs/.tox/test/lib/python3.9/site-packages/astropy/wcs/wcs.py:819: FITSFixedWarning: 'obsfix' made the change 'Set OBSGEO-L to   -67.754929 from OBSGEO-[XYZ].
  Set OBSGEO-B to   -23.022886 from OBSGEO-[XYZ].
  Set OBSGEO-H to     5053.796 from OBSGEO-[XYZ]'.
    warnings.warn(
```

One other mostly unrelated change was added. fdfc99805f0bad00ca99adf3c83839e02e8eb472 sorts the `test_cartesian_to_spherical_mixed_Q` tests so that the test order is deterministic (which allows for the use of pytest-xdist to run the tests in parallel). However, given the speed of the test suite there doesn't appear to be a gain in running the tests in parallel.

This PR does not turn warnings into errors but it might provide a good opportunity to do so (if it succeeds in cleaning up all the warnings).