### PR TITLE
register all gwcs manifests available from asdf-wcs-schemas

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,6 +23,10 @@ other
 
 - Code and docstrings clean up. [#460]
 
+- Register all available asdf extension manifests from ``asdf-wcs-schemas``
+  except 1.0.0 (which contains duplicate tag versions). [#469]
+
+
 0.18.3 (2022-12-23)
 -------------------
 Bug Fixes

--- a/gwcs/extension.py
+++ b/gwcs/extension.py
@@ -43,7 +43,7 @@ WCS_MODEL_CONVERTERS = [
 # that occur earlier in the list.
 WCS_MANIFEST_URIS = [
     f"asdf://asdf-format.org/astronomy/gwcs/manifests/{path.stem}"
-    for path in sorted((importlib.resources.files("asdf_wcs_schemas.resources") / "manifests" / "gwcs").iterdir(), reverse=True)
+    for path in sorted((importlib.resources.files("asdf_wcs_schemas.resources") / "manifests").iterdir(), reverse=True)
 ]
 
 TRANSFORM_EXTENSIONS = [

--- a/gwcs/extension.py
+++ b/gwcs/extension.py
@@ -46,6 +46,8 @@ WCS_MANIFEST_URIS = [
     for path in sorted((importlib.resources.files("asdf_wcs_schemas.resources") / "manifests").iterdir(), reverse=True)
 ]
 
+# 1.0.0 contains multiple versions of the same tag, a bug fixed in
+# 1.0.1 so only register 1.0.0 if it's the only available manifest
 TRANSFORM_EXTENSIONS = [
     ManifestExtension.from_uri(
         uri,
@@ -53,7 +55,9 @@ TRANSFORM_EXTENSIONS = [
         converters=WCS_MODEL_CONVERTERS,
     )
     for uri in WCS_MANIFEST_URIS
+    if len(WCS_MANIFEST_URIS) == 1 or '1.0.0' not in uri
 ]
+
 
 def get_extensions():
     """

--- a/gwcs/extension.py
+++ b/gwcs/extension.py
@@ -1,4 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+import importlib.resources
+
 from asdf.extension import ManifestExtension
 from .converters.wcs import (
     CelestialFrameConverter, CompositeFrameConverter, FrameConverter,
@@ -40,9 +42,9 @@ WCS_MODEL_CONVERTERS = [
 # The order here is important; asdf will prefer to use extensions
 # that occur earlier in the list.
 WCS_MANIFEST_URIS = [
-    "asdf://asdf-format.org/astronomy/gwcs/manifests/gwcs-1.0.0",
+    f"asdf://asdf-format.org/astronomy/gwcs/manifests/{path.stem}"
+    for path in sorted((importlib.resources.files("asdf_wcs_schemas.resources") / "manifests" / "gwcs").iterdir(), reverse=True)
 ]
-
 
 TRANSFORM_EXTENSIONS = [
     ManifestExtension.from_uri(


### PR DESCRIPTION
The current gwcs manifest contains duplicate tags. See https://github.com/asdf-format/asdf-wcs-schemas/pull/46 for changes to address that issue.

This PR adds support for new manifests available from `asdf-wcs-schemas` (like the ones added in https://github.com/asdf-format/asdf-wcs-schemas/pull/46). It should be 'forward-compatible' (as long as the location of the gwcs manifests in `asdf-wcs-schemas` does not change). This is achieved by inspecting the `asdf-wcs-schemas` package data and creating an extension for every manifest (with so far one exception).

As the `gwcs-1.0.0` manifest contains problematic duplicate tags (see https://github.com/asdf-format/asdf-wcs-schemas/pull/46 for details) this manifest is only included if it is the only one available (which will be the case for all currently released versions of asdf-wcs-schemas). Once a new version of asdf-wcs-schemas is released (which will contain multiple manifests), gwcs will no longer register an extension using the 1.0.0 manifest (and instead include the compatible but duplicate-free 1.0.1 in addition to 1.1.0 which contains the newest version of tags).

~Currently 2 CI jobs are failing (this will be updated as other PRs are merged to address the related and unrelated issues):
`test-jwst-cov-xdist` failing due to tox 4.9 issue fixed in: https://github.com/spacetelescope/gwcs/pull/470~
~`test-dev` failing because the gwcs manifest was moved in `asdf-wcs-schemas`, this change in location has not yet been released and is reverted in: https://github.com/asdf-format/asdf-wcs-schemas/pull/45~