### PR TITLE
prefix jwst downstream toxenv with py310

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,4 +90,4 @@ jobs:
       cache-path: ${{ needs.crds.outputs.path }}
       cache-key: crds-${{ needs.crds.outputs.context }}
       envs: |
-        - linux: test-jwst-cov-xdist
+        - linux: py310-test-jwst-cov-xdist


### PR DESCRIPTION
See: https://github.com/spacetelescope/roman_datamodels/pull/261 for more details

In brief, tox updated, because `test-jwst-cov-xdist` env is not listed in `tox.ini` and not prefixed with `pyxx` it no longer works. This PR prefixes it with `py310` to run with python 3.10.