### PR TITLE
remove unsupported `system_packages` RTD config setting

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -17,7 +17,6 @@ conda:
 
 # Set the version of Python and requirements required to build your docs
 python:
-  system_packages: false
   install:
     - method: pip
       path: .


### PR DESCRIPTION
RTD no longer supports any `system_packages` setting: https://blog.readthedocs.com/drop-support-system-packages/

This PR removes the unused `system_packages` setting