### PR TITLE
Register empty 1.0.0 extension to avoid warning when opening old files

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,6 +28,9 @@ other
 - Register all available asdf extension manifests from ``asdf-wcs-schemas``
   except 1.0.0 (which contains duplicate tag versions). [#469]
 
+- Register empty extension for 1.0.0 to avoid warning about a missing
+  extension when opening old files. [#475]
+
 
 0.18.3 (2022-12-23)
 -------------------

--- a/gwcs/extension.py
+++ b/gwcs/extension.py
@@ -1,7 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import importlib.resources
 
-from asdf.extension import ManifestExtension
+from asdf.extension import Extension, ManifestExtension
 from .converters.wcs import (
     CelestialFrameConverter, CompositeFrameConverter, FrameConverter,
     Frame2DConverter, SpectralFrameConverter, StepConverter,
@@ -57,6 +57,20 @@ TRANSFORM_EXTENSIONS = [
     for uri in WCS_MANIFEST_URIS
     if len(WCS_MANIFEST_URIS) == 1 or '1.0.0' not in uri
 ]
+
+# if we don't register something for the 1.0.0 extension/manifest
+# opening old files will issue AsdfWarning messages stating that
+# the file was produced with an extension that is not installed
+# As the 1.0.1 and 1.1.0 extensions support all the required tags
+# it's not a helpful warning so here we register an 'empty'
+# extension for 1.0.0 which doesn't support any tags or types
+# but will be installed into asdf preventing the warning
+if len(TRANSFORM_EXTENSIONS) > 1:
+    class _EmptyExtension(Extension):
+        extension_uri = 'asdf://asdf-format.org/astronomy/gwcs/extensions/gwcs-1.0.0'
+        legacy_class_names=["gwcs.extension.GWCSExtension"]
+
+    TRANSFORM_EXTENSIONS.append(_EmptyExtension())
 
 
 def get_extensions():

--- a/gwcs/tests/test_extension.py
+++ b/gwcs/tests/test_extension.py
@@ -1,0 +1,58 @@
+import io
+import warnings
+
+import asdf
+import asdf_wcs_schemas
+import gwcs.extension
+
+import pytest
+
+
+@pytest.mark.skipif(asdf_wcs_schemas.__version__ < "0.2.0", reason="version 0.2 provides the new manifests")
+def test_empty_extension():
+    """
+    Test that an empty extension was installed for gwcs 1.0.0
+    and that extensions are installed for gwcs 1.0.1 and 1.1.0
+    """
+    extensions = gwcs.extension.get_extensions()
+    assert len(extensions) > 1
+
+    extensions_by_uri = {ext.extension_uri: ext for ext in extensions}
+
+    # check for duplicate uris
+    assert len(extensions_by_uri) == len(extensions)
+
+    # check that all 3 versions are installed
+    for version in ('1.0.0', '1.0.1', '1.1.0'):
+        assert f"asdf://asdf-format.org/astronomy/gwcs/extensions/gwcs-{version}" in extensions_by_uri
+
+    # the 1.0.0 extension should support no tags or types
+    legacy = extensions_by_uri["asdf://asdf-format.org/astronomy/gwcs/extensions/gwcs-1.0.0"]
+    assert len(legacy.tags) == 0
+    assert len(legacy.converters) == 0
+
+
+def test_open_legacy_without_warning():
+    """
+    Opening a file produced with extension 1.0.0 should not produce any
+    warnings because of the empty extension registered for 1.0.0
+    """
+    asdf_bytes = b"""#ASDF 1.0.0
+#ASDF_STANDARD 1.5.0
+%YAML 1.1
+%TAG ! tag:stsci.edu:asdf/
+--- !core/asdf-1.1.0
+asdf_library: !core/software-1.0.0 {author: The ASDF Developers, homepage: 'http://github.com/asdf-format/asdf',
+  name: asdf, version: 2.9.2}
+history:
+  extensions:
+  - !core/extension_metadata-1.0.0
+    extension_class: asdf.extension._manifest.ManifestExtension
+    extension_uri: asdf://asdf-format.org/astronomy/gwcs/extensions/gwcs-1.0.0
+    software: !core/software-1.0.0 {name: gwcs, version: 0.18.0}
+foo: 1
+..."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        with asdf.open(io.BytesIO(asdf_bytes)) as af:
+            assert af['foo'] == 1


### PR DESCRIPTION
See #473 for more details.

Changes in #469 removed the `1.0.0` extension (which contains erroneous duplicate tags). A consequence of this removal is that opening old files produced with this extension results in the following warning:
```
asdf.exceptions.AsdfWarning: File was created with extension URI 'asdf://asdf-format.org/astronomy/gwcs/extensions/gwcs-1.0.0' (from package gwcs==0.18.2), which is not currently installed 
```
Based on discussions linked in #473 these warnings should be ignored (as the `1.0.1` and `1.1.0` extensions support all the `1.0.0` tags). Rather than describe this nuance in the documentation and request that users update files this PR takes the alternative approach proposed in #473 to register an empty extension for the `1.0.0` uri (which does not use the `1.0.0` manifest). This prevents the above warning without requiring the user to update their files (this does mean that old files will continue to have the `1.0.0` extension listed in the asdf history, a test was added to verify that the changes in this PR are sufficient to allow opening of those files without a warning).

Fixes #473