### PR TITLE
add pixel_shape to WCS converter

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,8 @@ other
 
 - Replace ``pkg_resources`` with ``importlib.metadata``. [#478]
 
+- Serialize and deserialize ``pixel_shape`` with asdf. [#480]
+
 0.19.0 (2023-09-15)
 -------------------
 

--- a/gwcs/converters/tests/test_wcs.py
+++ b/gwcs/converters/tests/test_wcs.py
@@ -52,6 +52,7 @@ def assert_frame_roundtrip(frame, tmpdir, version=None):
 
 def _assert_wcs_equal(a, b):
     assert a.name == b.name # nosec
+    assert a.pixel_shape == b.pixel_shape
     assert len(a.available_frames) == len(b.available_frames) # nosec
     for a_step, b_step in zip(a.pipeline, b.pipeline):
         _assert_frame_equal(a_step.frame, b_step.frame)
@@ -75,10 +76,13 @@ def test_create_wcs(tmpdir):
     gw1 = wcs.WCS(output_frame='icrs', input_frame='detector', forward_transform=m1)
     gw2 = wcs.WCS(output_frame='icrs', forward_transform=m1)
     gw3 = wcs.WCS(output_frame=icrs, input_frame=det, forward_transform=m1)
+    gw4 = wcs.WCS(output_frame=icrs, input_frame=det, forward_transform=m1)
+    gw4.pixel_shape = (100, 200)
 
     assert_wcs_roundtrip(gw1, tmpdir)
     assert_wcs_roundtrip(gw2, tmpdir)
     assert_wcs_roundtrip(gw3, tmpdir)
+    assert_wcs_roundtrip(gw4, tmpdir)
 
 
 def test_composite_frame(tmpdir):

--- a/gwcs/converters/wcs.py
+++ b/gwcs/converters/wcs.py
@@ -15,12 +15,16 @@ class WCSConverter(Converter):
 
     def from_yaml_tree(self, node, tag, ctx):
         from ..wcs import WCS
-        return WCS(node['steps'], name=node['name'])
+        gwcsobj = WCS(node['steps'], name=node['name'])
+        if 'pixel_shape' in node:
+            gwcsobj.pixel_shape = node['pixel_shape']
+        return gwcsobj
 
     def to_yaml_tree(self, gwcsobj, tag, ctx):
         return {
             'name': gwcsobj.name,
-            'steps': gwcsobj.pipeline
+            'steps': gwcsobj.pipeline,
+            'pixel_shape': gwcsobj.pixel_shape,
         }
 
 


### PR DESCRIPTION
Fixes: #474

Schema changes to add `pixel_shape` to the `wcs` schema are included in:
https://github.com/asdf-format/asdf-wcs-schemas/pull/56