### PR TITLE
Remove redundant astropy from source install

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,9 +4,6 @@ git+https://github.com/asdf-format/asdf-standard
 # Use weekly astropy dev build
 --extra-index-url https://pypi.anaconda.org/astropy/simple astropy --pre
 
-git+https://github.com/astropy/astropy
-
-
 git+https://github.com/astropy/asdf-astropy
 git+https://github.com/asdf-format/asdf-transform-schemas
 git+https://github.com/asdf-format/asdf-coordinates-schemas


### PR DESCRIPTION
I don't understand why you install the `astropy` nightly wheel, and then reinstall again from source.