### PR TITLE
add lower pin to asdf-wcs-schemas

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,8 @@
 
 - Improve documentation (part 1) [#483]
 
+- Add a minimum version requirement for ``asdf-wcs-schemas``. [#488]
+
 0.20.0 (2023-11-29)
 -------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = [
     "astropy >= 5.3",
     "numpy",
     "scipy",
-    "asdf_wcs_schemas",
+    "asdf_wcs_schemas >= 0.3.0",
     "asdf-astropy >= 0.2.0",
 ]
 dynamic = [


### PR DESCRIPTION
`asdf-wcs-schemas` provides the schemas and manifests used by gwcs to provide asdf serialization and validation of WCS objects. gwcs does not currently list a minimum `asdf-wcs-schemas` version which can lead to issues with older versions opening new files (see: https://github.com/spacetelescope/roman_datamodels/issues/307 and an as-discussed dkist issue with @Cadair ).

This PR adds a minimum pin to `asdf-wcs-schemas`. The pin is set to the current `asdf-wcs-schemas` version and I propose that this pin be updated to match the latest `asdf-wcs-schemas` version at the time of `gwcs` release (as that is what is used in the CI).

I considered adding an upper pin as well (on the next minor version `<0.4.0`) to add some protection against a schema manifest update that for some reason is incompatible with gwcs. However I'm concerned that this might cause dependency resolution issues and if not maintained would lead to `asdf-wcs-schema` updates not being caught by gwcs. For now, the lower pin [captures the wcs manifest issue](https://github.com/asdf-format/asdf-wcs-schemas/pull/46) which lead to the above linked roman_datamodels issue.