### PR TITLE
fix __str__ for wcs with a None transform

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@
 
 - Add a minimum version requirement for ``asdf-wcs-schemas``. [#488]
 
+- Fix ``WCS.__str__`` for instances without transforms. [#489]
+
 0.20.0 (2023-11-29)
 -------------------
 

--- a/gwcs/tests/test_wcs.py
+++ b/gwcs/tests/test_wcs.py
@@ -1316,3 +1316,8 @@ def test_spatial_spectral_stokes():
     assert_allclose(gw_sky.data.lat, aw_sky.data.lat)
     assert_allclose(gw_spec.value, aw_spec.value)
     assert_allclose(gw_stokes.value, aw_stokes.value)
+
+
+def test_wcs_str():
+    w = wcs.WCS(output_frame="icrs")
+    assert 'icrs' in str(w)

--- a/gwcs/wcs.py
+++ b/gwcs/wcs.py
@@ -1338,13 +1338,13 @@ class WCS(GWCSAPIMixin):
     def __str__(self):
         from astropy.table import Table
 
-        #col1 = [item[0] for item in self._pipeline]
         col1 = [step.frame for step in self._pipeline]
         col2 = []
         for item in self._pipeline[: -1]:
-            #model = item[1]
             model = item.transform
-            if model.name is not None:
+            if model is None:
+                col2.append(None)
+            elif model.name is not None:
                 col2.append(model.name)
             else:
                 col2.append(model.__class__.__name__)


### PR DESCRIPTION
Constructing a WCS without a transform leads to an error for `str(wcs)`:
```
w = gwcs.WCS(output_frame="icrs")
print(w)
```
```
File ~/projects/src/gwcs/gwcs/wcs.py:1347, in WCS.__str__(self)
   1344 for item in self._pipeline[: -1]:
   1345     #model = item[1]
   1346     model = item.transform
-> 1347     if model.name is not None:
   1348         col2.append(model.name)
   1349     else:

AttributeError: 'NoneType' object has no attribute 'name'
```

This PR updates `WCS.__str__` to handle this case so the output is now:
```
  From   Transform
-------- ---------
detector      None
    icrs      None
```

The issue was found due to usage of a wcs without a transform in roman_datamodels [maker_utils](https://github.com/spacetelescope/roman_datamodels/blob/2af32d9c31742128483a3e2e85984e5c41f6d4b0/src/roman_datamodels/maker_utils/_datamodels.py#L140) combined with an update to `asdf.info` that uses the `str` representation of objects: https://github.com/asdf-format/asdf/pull/1687

This PR includes a test for a wcs without a transform. It appears that `WCS.__str__` is otherwise untested so it might be an improvement to add other wcs configurations to the new test.