### PR TITLE
Increase `asdf-wcs-schemas` version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,13 +32,13 @@ jobs:
           python-version: 3.9
         - linux: test-numpy125
           python-version: 3.9
-        - linux: test-numpy122
+        - linux: test-numpy123
           python-version: 3.9
         - linux: test
           python-version: 3.10
         - linux: test-numpy125
           python-version: 3.10
-        - linux: test-numpy122
+        - linux: test-numpy123
           python-version: 3.10
         - linux: test
           python-version: 3.11

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,7 +3,7 @@
 
 - Improve documentation (part 1) [#483]
 
-- Add a minimum version requirement for ``asdf-wcs-schemas``. [#488]
+- Add a minimum version requirement for ``asdf-wcs-schemas``. [#491]
 
 - Fix ``WCS.__str__`` for instances without transforms. [#489]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = [
     "astropy >= 5.3",
     "numpy",
     "scipy",
-    "asdf_wcs_schemas >= 0.3.0",
+    "asdf_wcs_schemas >= 0.4.0",
     "asdf-astropy >= 0.2.0",
 ]
 dynamic = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ docs = [
 ]
 test = [
     "ci-watson>=0.3.0",
-    "pytest>=4.6.0, <8.1",
+    "pytest>=4.6.0",
     "pytest-astropy",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ docs = [
 ]
 test = [
     "ci-watson>=0.3.0",
-    "pytest>=4.6.0",
+    "pytest>=4.6.0, <8.1",
     "pytest-astropy",
 ]
 

--- a/tox.ini
+++ b/tox.ini
@@ -70,7 +70,7 @@ deps =
     cov: pytest-cov
     jwst: jwst[test] @ git+https://github.com/spacetelescope/jwst.git
     romancal: romancal[test] @ git+https://github.com/spacetelescope/romancal.git
-    numpy122: numpy==1.22.*
+    numpy123: numpy==1.23.*
     numpy125: numpy==1.25.*
 pass_env =
     jwst,romancal: CRDS_*


### PR DESCRIPTION
`asdf-wcs-schemas` 0.4.0 was released.

This PR increases the minimum required version to 0.4.0.

As https://github.com/spacetelescope/gwcs/pull/488 is not yet released the changelog entry was updated to point to this PR.

~Additionally this PR adds an upper pin for pytest (as a test dependency) as the newest version 8.1.1 is incompatible with pytest-doctestplus (see https://github.com/scientific-python/pytest-doctestplus/issues/243).~ EDIT: a new version of pytest-doctestplus was released that fixed the issue

Finally, this PR also increases the minimum tested numpy to 1.23 (the oldest supported version at this time, see: https://numpy.org/neps/nep-0029-deprecation_policy.html#support-table).