### PR TITLE
Possible fix for world-to-pixel when out of bounding box

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,8 @@
 0.22.0 (unreleased)
 -------------------
 
+- Return nan for world to pixel transformations outside of the
+  bounding box. [#497]
 
 0.21.0 (2024-03-10)
 -------------------

--- a/gwcs/api.py
+++ b/gwcs/api.py
@@ -135,6 +135,7 @@ class GWCSAPIMixin(BaseHighLevelWCS, BaseLowLevelWCS):
         world_arrays = self._add_units_input(world_arrays, self.backward_transform, self.output_frame)
 
         result = self.invert(*world_arrays, with_units=False)
+        result = self._out_of_bounding_box_to_nan(result, world_arrays)
 
         return self._remove_quantity_output(result, self.input_frame)
 
@@ -321,6 +322,8 @@ class GWCSAPIMixin(BaseHighLevelWCS, BaseLowLevelWCS):
         else:
             if not utils.isnumerical(result):
                 result = result.value
+
+        result = self._out_of_bounding_box_to_nan(result, world_objects)
 
         return result
 

--- a/gwcs/api.py
+++ b/gwcs/api.py
@@ -135,9 +135,10 @@ class GWCSAPIMixin(BaseHighLevelWCS, BaseLowLevelWCS):
         world_arrays = self._add_units_input(world_arrays, self.backward_transform, self.output_frame)
 
         result = self.invert(*world_arrays, with_units=False)
-        result = self._out_of_bounding_box_to_nan(result, world_arrays)
+        result = self._remove_quantity_output(result, self.input_frame)
 
-        return self._remove_quantity_output(result, self.input_frame)
+        return self._out_of_bounding_box_to_nan(result, world_arrays)
+
 
     def world_to_array_index_values(self, *world_arrays):
         """

--- a/gwcs/wcs.py
+++ b/gwcs/wcs.py
@@ -433,6 +433,11 @@ class WCS(GWCSAPIMixin):
             coords,
             np.nan
         )
+
+        if isinstance(result, np.ndarray) and result.shape == ():
+            # scalar results should be floats:
+            result = float(result)
+
         return result
 
     def invert(self, *args, **kwargs):


### PR DESCRIPTION
This PR attempts to address #496. 

GWCS implements an `in_image` method that returns a False for out-of-bounds _world coordinates_ by converting to pixel coords with `invert` and then comparing to the bounding box. 

This PR simply adds a line to `world_to_pixel` and `world_to_pixel_values` which sets pixel results outside of the bounding box to nan. Rather than calling `in_image`, I moved the logic for pixel coordinate comparisons to the bounding box into a separate function, and call that function in `world_to_pixel*` transformations, as well as within `in_image`. The pixel/bounding box comparison logic had to be moved to a separate method because `in_image` calls `invert` – so calling `in_image` to from within `invert` to mask the result would lead to recursion.

Right now there are two test failures where I would have to change the expected output in the test. I've left these two cases in so you can see what changes. Let me know if you agree that I can change those expected answers to nan.

cc @astrofrog @nden