### PR TITLE
Update Fits object to non-deprecated version (FITS)

### DIFF
--- a/gwcs/wcs.py
+++ b/gwcs/wcs.py
@@ -2032,7 +2032,7 @@ class WCS(GWCSAPIMixin):
                 # index of the axis in this frame's
                 fidx = frame.axes_order.index(axno)
                 if hasattr(frame.unit[fidx], 'get_format_name'):
-                    cunit = frame.unit[fidx].get_format_name(u.format.Fits).upper()
+                    cunit = frame.unit[fidx].get_format_name(u.format.FITS).upper()
                 else:
                     cunit = ''
 


### PR DESCRIPTION
In one of our notebooks, we are getting this warning stemming from `gwcs`:

```
WARNING: AstropyDeprecationWarning: The class "Fits" has been renamed to "FITS" in version 7.0. 
The old name is deprecated and may be removed in a future version. Use FITS instead. [astropy.units.format]
```

This is a quick fix to update the usage on line 2035 of `wcs.py`.