### PR TITLE
Make imports lazy (to speed up asdf extension)

### DIFF
--- a/gwcs/__init__.py
+++ b/gwcs/__init__.py
@@ -65,8 +65,12 @@ except importlib.metadata.PackageNotFoundError:  # pragma: no cover
     # package is not installed
     pass  # pragma: no cover
 
+def __getattr__(name):
+    for sub_module in ("wcs", "wcstools", "coordinate_frames", "selector"):
+        module = __import__(f"gwcs.{sub_module}", fromlist=['*'])
+        globals().update({name: getattr(module, name) for name in module.__all__})
 
-from .wcs import *   # noqa
-from .wcstools import *   # noqa
-from .coordinate_frames import *  # noqa
-from .selector import *   # noqa
+    try:
+        return globals()[name]
+    except KeyError:
+        raise AttributeError(f"module 'gwcs' has no attribute '{name}'") from None

--- a/gwcs/converters/selector.py
+++ b/gwcs/converters/selector.py
@@ -2,12 +2,7 @@
 # -*- coding: utf-8 -*-
 
 from collections import OrderedDict
-import numpy as np
-from astropy.modeling import models
-from astropy.modeling.core import Model
-from astropy.utils.misc import isiterable
 
-from asdf.tags.core.ndarray import NDArrayType
 from asdf_astropy.converters.transform.core import TransformConverterBase
 
 
@@ -20,6 +15,12 @@ class LabelMapperConverter(TransformConverterBase):
              "gwcs.selector.LabelMapperRange", "gwcs.selector.LabelMapper"]
 
     def from_yaml_tree_transform(self, node, tag, ctx):
+        from asdf.tags.core.ndarray import NDArrayType
+        from astropy.modeling import models
+        from astropy.modeling.core import Model
+        from astropy.utils.misc import isiterable
+        import numpy as np
+
         from ..selector import (LabelMapperArray, LabelMapperDict,
                                 LabelMapperRange, LabelMapper)
         inputs_mapping = node.get('inputs_mapping', None)
@@ -52,6 +53,7 @@ class LabelMapperConverter(TransformConverterBase):
                 return LabelMapperDict(inputs, dict_mapper, inputs_mapping, atol=atol)
 
     def to_yaml_tree_transform(self, model, tag, ctx):
+        from astropy.utils.misc import isiterable
         from ..selector import (LabelMapperArray, LabelMapperDict,
                                 LabelMapperRange, LabelMapper)
         node = OrderedDict()
@@ -91,6 +93,7 @@ class RegionsSelectorConverter(TransformConverterBase):
 
     def from_yaml_tree_transform(self, node, tag, ctx):
         from ..selector import RegionsSelector
+
         inputs = node['inputs']
         outputs = node['outputs']
         label_mapper = node['label_mapper']

--- a/gwcs/converters/spectroscopy.py
+++ b/gwcs/converters/spectroscopy.py
@@ -2,7 +2,6 @@
 ASDF tags for spectroscopy related models.
 
 """
-from astropy import units as u
 from asdf_astropy.converters.transform.core import (
     TransformConverterBase, parameter_to_value
 )
@@ -84,6 +83,7 @@ class GratingEquationConverter(TransformConverterBase):
         return model
 
     def to_yaml_tree_transform(self, model, tag, ctx):
+        from astropy import units as u
         from ..spectroscopy import (AnglesFromGratingEquation3D,
                                     WavelengthFromGratingEquation)
         if model.groove_density.unit is not None:


### PR DESCRIPTION
The general idea is to speed up the asdf entry point (which is loaded when the asdf extension manager is created). The entrypoint lists `gwcs.extensions`:
https://github.com/spacetelescope/gwcs/blob/53025a9400c2bfb07a865d02ae7399228b0f392c/pyproject.toml#L35
This will trigger the `*` imports in `gwcs.__init__.py`:
https://github.com/spacetelescope/gwcs/blob/53025a9400c2bfb07a865d02ae7399228b0f392c/gwcs/__init__.py#L69-L72
which end up importing lots of "heavy hitters" (like scipy, big parts of astropy etc).

Minimal code for testing the entry point is:
```python
from importlib_metadata import entry_points
list(entry_points(group="asdf.extensions", name="gwcs"))[0].load()
```
To check which modules this import (and ignoring asdf as that's unavoidable):
```python
import asdf
import sys
from importlib_metadata import entry_points
pre_modules = set(sys.modules.keys())
list(entry_points(group="asdf.extensions", name="gwcs"))[0].load()
imported = pre_modules ^ set(sys.modules.keys())
```
With the current gwcs this imports 747 modules including many parts of scipy and astropy and on my system the entry point loading takes ~600ms.

With this PR the same code imports 90 modules with none from scipy and takes ~250ms. The remaining imports are as follows:
<details>
<summary>Click to expand</summary>

```python
{'asdf._core',
 'asdf._core._integration',
 'asdf_astropy',
 'asdf_astropy._astropy_init',
 'asdf_astropy._version',
 'asdf_astropy.converters',
 'asdf_astropy.converters.coordinates',
 'asdf_astropy.converters.coordinates.angle',
 'asdf_astropy.converters.coordinates.earth_location',
 'asdf_astropy.converters.coordinates.frame',
 'asdf_astropy.converters.coordinates.representation',
 'asdf_astropy.converters.coordinates.sky_coord',
 'asdf_astropy.converters.coordinates.spectral_coord',
 'asdf_astropy.converters.fits',
 'asdf_astropy.converters.fits.fits',
 'asdf_astropy.converters.helpers',
 'asdf_astropy.converters.table',
 'asdf_astropy.converters.table.table',
 'asdf_astropy.converters.time',
 'asdf_astropy.converters.time.time',
 'asdf_astropy.converters.time.time_delta',
 'asdf_astropy.converters.transform',
 'asdf_astropy.converters.transform.compound',
 'asdf_astropy.converters.transform.core',
 'asdf_astropy.converters.transform.functional_models',
 'asdf_astropy.converters.transform.mappings',
 'asdf_astropy.converters.transform.math_functions',
 'asdf_astropy.converters.transform.polynomial',
 'asdf_astropy.converters.transform.projections',
 'asdf_astropy.converters.transform.properties',
 'asdf_astropy.converters.transform.rotations',
 'asdf_astropy.converters.transform.spline',
 'asdf_astropy.converters.transform.tabular',
 'asdf_astropy.converters.unit',
 'asdf_astropy.converters.unit.equivalency',
 'asdf_astropy.converters.unit.magunit',
 'asdf_astropy.converters.unit.quantity',
 'asdf_astropy.converters.unit.unit',
 'asdf_astropy.converters.utils',
 'asdf_astropy.integration',
 'asdf_astropy.resources',
 'asdf_coordinates_schemas',
 'asdf_coordinates_schemas._version',
 'asdf_coordinates_schemas.integration',
 'asdf_standard.integration',
 'asdf_transform_schemas',
 'asdf_transform_schemas._version',
 'asdf_transform_schemas.integration',
 'asdf_unit_schemas',
 'asdf_unit_schemas._version',
 'asdf_unit_schemas.integration',
 'asdf_wcs_schemas',
 'asdf_wcs_schemas._version',
 'asdf_wcs_schemas.integration',
 'asdf_wcs_schemas.resources',
 'astropy',
 'astropy._version',
 'astropy.config',
 'astropy.config.configuration',
 'astropy.config.paths',
 'astropy.extern',
 'astropy.extern.configobj',
 'astropy.extern.configobj.configobj',
 'astropy.extern.configobj.validate',
 'astropy.logger',
 'astropy.tests',
 'astropy.tests.runner',
 'astropy.utils',
 'astropy.utils._compiler',
 'astropy.utils.codegen',
 'astropy.utils.compat',
 'astropy.utils.compat.misc',
 'astropy.utils.compat.numpycompat',
 'astropy.utils.decorators',
 'astropy.utils.exceptions',
 'astropy.utils.introspection',
 'astropy.utils.misc',
 'astropy.utils.shapes',
 'astropy.utils.state',
 'astropy.version',
 'difflib',
 'glob',
 'gwcs',
 'gwcs.converters',
 'gwcs.converters.geometry',
 'gwcs.converters.selector',
 'gwcs.converters.spectroscopy',
 'gwcs.converters.wcs',
 'gwcs.extension',
 'shlex'}
```
</details>