### PR TITLE
Update development version installation instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -43,7 +43,7 @@ To clone from github and install the master branch::
 
     git clone https://github.com/spacetelescope/gwcs.git
     cd gwcs
-    python setup.py install
+    pip install --editable .
 
     
 Contributing Code, Documentation, or Feedback


### PR DESCRIPTION
The current instructions have been invalid since b32ec53261b9f39e773d2ee04582231802d75d1f deleted `setup.py`.