### PR TITLE
Fix units in WCS API world_axis_object_components

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@
 
 - Fix an issue with units in ``wcs_from_points``. [#507]
 
+- Fix incorrect units being returned in the low level WCS API. [#512]
+
 0.21.0 (2024-03-10)
 -------------------
 

--- a/gwcs/coordinate_frames.py
+++ b/gwcs/coordinate_frames.py
@@ -355,8 +355,8 @@ class CelestialFrame(CoordinateFrame):
 
     @property
     def _world_axis_object_components(self):
-        return [('celestial', 0, 'spherical.lon'),
-                ('celestial', 1, 'spherical.lat')]
+        return [('celestial', 0, lambda sc: sc.spherical.lon.to_value(self.unit[0])),
+                ('celestial', 1, lambda sc: sc.spherical.lat.to_value(self.unit[1]))]
 
     def coordinates(self, *args):
         """
@@ -457,7 +457,7 @@ class SpectralFrame(CoordinateFrame):
 
     @property
     def _world_axis_object_components(self):
-        return [('spectral', 0, 'value')]
+        return [('spectral', 0, lambda sc: sc.to_value(self.unit[0]))]
 
     def coordinates(self, *args):
         # using SpectralCoord

--- a/gwcs/tests/conftest.py
+++ b/gwcs/tests/conftest.py
@@ -125,7 +125,8 @@ def gwcs_3d_identity_units():
                 models.Multiply(1 * u.nm / u.pixel))
     sky_frame = cf.CelestialFrame(axes_order=(0, 1), name='icrs',
                                   reference_frame=coord.ICRS(),
-                                  axes_names=("longitude", "latitude"))
+                                  axes_names=("longitude", "latitude"),
+                                  unit=(u.arcsec, u.arcsec))
     wave_frame = cf.SpectralFrame(axes_order=(2, ), unit=u.nm, axes_names=("wavelength",))
 
     frame = cf.CompositeFrame([sky_frame, wave_frame])

--- a/gwcs/tests/test_api_slicing.py
+++ b/gwcs/tests/test_api_slicing.py
@@ -44,9 +44,13 @@ def test_ellipsis(gwcs_3d_galactic_spectral):
 
     assert_equal(wcs.axis_correlation_matrix, [[True, False, True], [False, True, False], [True, False, True]])
 
-    assert wcs.world_axis_object_components == [('celestial', 1, 'spherical.lat'),
-                                                ('spectral', 0, 'value'),
-                                                ('celestial', 0, 'spherical.lon')]
+    first_two = [c[:2] for c in wcs.world_axis_object_components]
+    last_one = [c[2] for c in wcs.world_axis_object_components]
+    assert first_two == [('celestial', 1),
+                         ('spectral', 0),
+                         ('celestial', 0)]
+
+    assert all([callable(l) for l in last_one])
 
     assert wcs.world_axis_object_classes['celestial'][0] is SkyCoord
     assert wcs.world_axis_object_classes['celestial'][1] == ()
@@ -106,8 +110,12 @@ def test_spectral_slice(gwcs_3d_galactic_spectral):
 
     assert_equal(wcs.axis_correlation_matrix, [[True, True], [True, True]])
 
-    assert wcs.world_axis_object_components == [('celestial', 1, 'spherical.lat'),
-                                                ('celestial', 0, 'spherical.lon')]
+    first_two = [c[:2] for c in wcs.world_axis_object_components]
+    last_one = [c[2] for c in wcs.world_axis_object_components]
+    assert first_two == [('celestial', 1),
+                         ('celestial', 0)]
+
+    assert all([callable(l) for l in last_one])
 
     assert wcs.world_axis_object_classes['celestial'][0] is SkyCoord
     assert wcs.world_axis_object_classes['celestial'][1] == ()
@@ -166,9 +174,13 @@ def test_spectral_range(gwcs_3d_galactic_spectral):
 
     assert_equal(wcs.axis_correlation_matrix, [[True, False, True], [False, True, False], [True, False, True]])
 
-    assert wcs.world_axis_object_components == [('celestial', 1, 'spherical.lat'),
-                                                  ('spectral', 0, 'value'),
-                                                  ('celestial', 0, 'spherical.lon')]
+    first_two = [c[:2] for c in wcs.world_axis_object_components]
+    last_one = [c[2] for c in wcs.world_axis_object_components]
+    assert first_two == [('celestial', 1),
+                         ('spectral', 0),
+                         ('celestial', 0)]
+
+    assert all([callable(l) for l in last_one])
 
     assert wcs.world_axis_object_classes['celestial'][0] is SkyCoord
     assert wcs.world_axis_object_classes['celestial'][1] == ()
@@ -230,9 +242,13 @@ def test_celestial_slice(gwcs_3d_galactic_spectral):
 
     assert_equal(wcs.axis_correlation_matrix, [[False, True], [True, False], [False, True]])
 
-    assert wcs.world_axis_object_components == [('celestial', 1, 'spherical.lat'),
-                                                ('spectral', 0, 'value'),
-                                                ('celestial', 0, 'spherical.lon')]
+    first_two = [c[:2] for c in wcs.world_axis_object_components]
+    last_one = [c[2] for c in wcs.world_axis_object_components]
+    assert first_two == [('celestial', 1),
+                         ('spectral', 0),
+                         ('celestial', 0)]
+
+    assert all([callable(l) for l in last_one])
 
     assert wcs.world_axis_object_classes['celestial'][0] is SkyCoord
     assert wcs.world_axis_object_classes['celestial'][1] == ()
@@ -295,9 +311,13 @@ def test_celestial_range(gwcs_3d_galactic_spectral):
 
     assert_equal(wcs.axis_correlation_matrix, [[True, False, True], [False, True, False], [True, False, True]])
 
-    assert wcs.world_axis_object_components == [('celestial', 1, 'spherical.lat'),
-                                                ('spectral', 0, 'value'),
-                                                ('celestial', 0, 'spherical.lon')]
+    first_two = [c[:2] for c in wcs.world_axis_object_components]
+    last_one = [c[2] for c in wcs.world_axis_object_components]
+    assert first_two == [('celestial', 1),
+                         ('spectral', 0),
+                         ('celestial', 0)]
+
+    assert all([callable(l) for l in last_one])
 
     assert wcs.world_axis_object_classes['celestial'][0] is SkyCoord
     assert wcs.world_axis_object_classes['celestial'][1] == ()
@@ -363,9 +383,13 @@ def test_no_array_shape(gwcs_3d_galactic_spectral):
 
     assert_equal(wcs.axis_correlation_matrix, [[True, False, True], [False, True, False], [True, False, True]])
 
-    assert wcs.world_axis_object_components == [('celestial', 1, 'spherical.lat'),
-                                                ('spectral', 0, 'value'),
-                                                ('celestial', 0, 'spherical.lon')]
+    first_two = [c[:2] for c in wcs.world_axis_object_components]
+    last_one = [c[2] for c in wcs.world_axis_object_components]
+    assert first_two == [('celestial', 1),
+                         ('spectral', 0),
+                         ('celestial', 0)]
+
+    assert all([callable(l) for l in last_one])
 
     assert wcs.world_axis_object_classes['celestial'][0] is SkyCoord
     assert wcs.world_axis_object_classes['celestial'][1] == ()
@@ -431,9 +455,13 @@ def test_ellipsis_none_types(gwcs_3d_galactic_spectral):
     assert_equal(wcs.axis_correlation_matrix, [[True, False, True],
                                                [False, True, False], [True, False, True]])
 
-    assert wcs.world_axis_object_components == [('celestial', 1, 'spherical.lat'),
-                                                  ('spectral', 0, 'value'),
-                                                  ('celestial', 0, 'spherical.lon')]
+    first_two = [c[:2] for c in wcs.world_axis_object_components]
+    last_one = [c[2] for c in wcs.world_axis_object_components]
+    assert first_two == [('celestial', 1),
+                         ('spectral', 0),
+                         ('celestial', 0)]
+
+    assert all([callable(l) for l in last_one])
 
     assert wcs.world_axis_object_classes['celestial'][0] is SkyCoord
     assert wcs.world_axis_object_classes['celestial'][1] == ()


### PR DESCRIPTION
fixes #495

We were returning Quantity objects for CelestialFrame when we shouldn't have been, but we also need to make sure we cast the values to the units of the frame.