### PR TITLE
vendorize and fix contexts workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
     outputs:
       data_path: ${{ steps.data_path.outputs.path }}
   crds_contexts:
-    uses: spacetelescope/crds/.github/workflows/contexts.yml@7a0fe0b50d5f426cdf1ba8d3ac5c406705773f2a  # 12.0.3
+    uses: ./.github/workflows/contexts.yml
   test_downstream:
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@924441154cf3053034c6513d5e06c69d262fb9a6  # v1.13.0
     needs: [ environment, crds_contexts ]

--- a/.github/workflows/contexts.yml
+++ b/.github/workflows/contexts.yml
@@ -1,0 +1,39 @@
+name: contexts
+
+on:
+  workflow_call:
+    outputs:
+      jwst:
+        value: ${{ jobs.contexts.outputs.jwst }}
+      roman:
+        value: ${{ jobs.contexts.outputs.roman }}
+  workflow_dispatch:
+
+jobs:
+  contexts:
+    name: retrieve latest CRDS contexts
+    runs-on: ubuntu-latest
+    outputs:
+      jwst: ${{ steps.jwst_crds_context.outputs.pmap }}
+      roman: ${{ steps.roman_crds_context.outputs.pmap }}
+    steps:
+      - id: jwst_crds_context
+        env:
+          OBSERVATORY: jwst
+          CRDS_SERVER_URL: https://jwst-crds.stsci.edu
+        run: >
+          echo "pmap=$(
+          curl -s -X POST -d '{"jsonrpc": "1.0", "method": "get_default_context", "params": ["${{ env.OBSERVATORY }}", null], "id": 1}' ${{ env.CRDS_SERVER_URL }}/json/ --retry 8 --connect-timeout 10 |
+          python -c "import sys, json; print(json.load(sys.stdin)['result'])"
+          )" >> $GITHUB_OUTPUT
+      - run: if [[ ! -z "${{ steps.jwst_crds_context.outputs.pmap }}" ]]; then echo ${{ steps.jwst_crds_context.outputs.pmap }}; else exit 1; fi
+      - id: roman_crds_context
+        env:
+          OBSERVATORY: roman
+          CRDS_SERVER_URL: https://roman-crds.stsci.edu
+        run: >
+          echo "pmap=$(
+          curl -s -X POST -d '{"jsonrpc": "1.0", "method": "get_default_context", "params": ["${{ env.OBSERVATORY }}", null], "id": 1}' ${{ env.CRDS_SERVER_URL }}/json/ --retry 8 |
+          python -c "import sys, json; print(json.load(sys.stdin)['result'])"
+          )" >> $GITHUB_OUTPUT
+      - run: if [[ ! -z "${{ steps.roman_crds_context.outputs.pmap }}" ]]; then echo ${{ steps.roman_crds_context.outputs.pmap }}; else exit 1; fi


### PR DESCRIPTION
Similar to https://github.com/spacetelescope/romancal/pull/1467 and https://github.com/spacetelescope/jwst/pull/8869

Although it looks like only `jwst` is required there is some CI infrastructure in place for `romancal` so keeping that context as well. The second argument for the `jwst` curl command is `null` which matches what is currently on `jwst`. It has since diverged from what's on crds (which uses `latest`) but I don't think that's an issue.