### PR TITLE
Testing Fix for JWST downstream

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -68,7 +68,7 @@ extras =
 deps =
     xdist: pytest-xdist
     cov: pytest-cov
-    jwst: jwst[test] @ git+https://github.com/spacetelescope/jwst.git
+    jwst: jwst[test] @ git+https://github.com/spacetelescope/jwst.git@657c132f2036a5fe07f5f4832a9ab0dd7bc87c50
     romancal: romancal[test] @ git+https://github.com/spacetelescope/romancal.git
     numpy123: numpy==1.23.*
     numpy125: numpy==1.25.*

--- a/tox.ini
+++ b/tox.ini
@@ -68,7 +68,7 @@ extras =
 deps =
     xdist: pytest-xdist
     cov: pytest-cov
-    jwst: jwst[test] @ git+https://github.com/spacetelescope/jwst.git@657c132f2036a5fe07f5f4832a9ab0dd7bc87c50
+    jwst: jwst[test] @ git+https://github.com/WilliamJamieson/jwst.git@testing_gwcs_downstream
     romancal: romancal[test] @ git+https://github.com/spacetelescope/romancal.git
     numpy123: numpy==1.23.*
     numpy125: numpy==1.25.*

--- a/tox.ini
+++ b/tox.ini
@@ -68,7 +68,7 @@ extras =
 deps =
     xdist: pytest-xdist
     cov: pytest-cov
-    jwst: jwst[test] @ git+https://github.com/WilliamJamieson/jwst.git@testing_gwcs_downstream
+    jwst: jwst[test] @ git+https://github.com/spacetelescope/jwst.git
     romancal: romancal[test] @ git+https://github.com/spacetelescope/romancal.git
     numpy123: numpy==1.23.*
     numpy125: numpy==1.25.*
@@ -82,7 +82,7 @@ commands =
     warnings: -W error \
     xdist: -n auto \
     pyargs: {toxinidir}/docs --pyargs gwcs \
-    jwst: --pyargs jwst --ignore-glob=timeconversion --ignore-glob=associations --ignore-glob=scripts\
+    jwst: --pyargs jwst --ignore-glob=timeconversion --ignore-glob=associations --ignore-glob=scripts --show-capture=no \
     romancal: --pyargs romancal \
     cov: --cov=. --cov-config=pyproject.toml --cov-report=term-missing --cov-report=xml \
     {posargs}


### PR DESCRIPTION
spacetelescope/jwst#8887 altered some tests in JWST in such a way that JWST's test suite now requires the `--show-capture=no` setting so that the logs produced can be properly captured by the tests. Since GWCS purposely does not set this option by default for its own tests, this caused the test failures we have been seeing in the JWST downstream tests. Note that I can only reproduce this issue in the CI and I was unable to reproduce this issue locally.

This PR fixes this issue by adding this option when the JWST downstream tests are run by the CI.