### PR TITLE
Set the bounding_box within the forward_transform property

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,8 @@
 
 - Force ``bounding_box`` to always be returned as a ``F`` ordered box. [#522] 
 
+- Move the bounding box attachment to the forward transform property. [#532]
+
 0.21.0 (2024-03-10)
 -------------------
 


### PR DESCRIPTION
Astropy modeling does not attempt to determine the bounding box for compound models. Thus when the `wcs.forward_transform` computes the transform model by chaining all the `wcs` transforms together the bounding box is lost. The bounding box for the `wcs.forward_transform` should always be the `bounding_box` for the `wcs`. Where ever the `forward_transform` is actually used the bounding box is manually attached.

This PR moves that attachment inside the `forward_transform` property itself.