### PR TITLE
Allow for small rounding errors in bbox for inverse

### DIFF
--- a/gwcs/wcs.py
+++ b/gwcs/wcs.py
@@ -490,11 +490,16 @@ class WCS(GWCSAPIMixin):
             return result
 
     def outside_footprint(self, world_arrays):
+        world_eps = 5.0 * np.finfo(np.float32).eps
+        eps_p = 1.0 + world_eps
+        eps_m = 1.0 - world_eps
+
         world_arrays = list(world_arrays)
 
         axes_types = set(self.output_frame.axes_type)
         axes_phys_types = self.world_axis_physical_types
         footprint = self.footprint()
+
         not_numerical = False
         if not utils.isnumerical(world_arrays[0]):
             not_numerical = True
@@ -518,9 +523,10 @@ class WCS(GWCSAPIMixin):
                             axis_range[axis_range < d].max(),
                             axis_range[axis_range > d].min()
                         ]
-                        outside = (coord >= range[0]) & (coord < range[1])
+                        outside = (coord > range[0] * eps_p) & (coord < range[1] * eps_m)
                 else:
-                    outside = (coord < range[0]) | (coord > range[1])
+                    outside = (coord < range[0] * eps_m) | (coord > range[1] * eps_p)
+
                 if np.any(outside):
                     if np.isscalar(coord):
                         coord = np.nan


### PR DESCRIPTION
This PR is a followup to #536 and adds some cushioning for inside/outside comparison for evaluating whether points in world CS are within the footprint. This is to allow for small rounding errors.

Second fix is a small inconsistency in the use of `>=` and strict comparisons in #536.