### PR TITLE
Fixes for bounding box units

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,9 @@
 - Refactor ``WCS`` to use a ``Pipeline`` base class which adds basic checks to ensure that the pipeline is valid. These
   include checking for duplicate frame names and that the last transform is ``None``. [#545]
 
+- Bugfix for ``WCS.invert`` and ``WCS.to_fits`` that prevented evaluation when the attached bounding box happened to have
+  units on its values. [#554]
+
 
 0.22.0 (2024-12-19)
 -------------------


### PR DESCRIPTION
This PR attempts to fix some issues related to having bounding boxes with units in GWCS. In particular it fixes the `WCS.invert` failing in this case and `WCS.to_fits`.

Resolves #408.

CC @pllim, @bmorris3 