### PR TITLE
Fix units issue with parameterless transform models

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,9 @@
 - Fix bug where "vector" (shape (n,) not shape (1, n)) arrays would loose all their entries except the
   first if ``with_units=True`` was used. [#563]
 
+- Bugfix for ``__call__`` and ``invert`` incorrectly handling units when involving
+  "parameterless" transforms. [#562]
+
 0.24.0 (2025-02-04)
 -------------------
 

--- a/gwcs/wcs/_wcs.py
+++ b/gwcs/wcs/_wcs.py
@@ -168,6 +168,85 @@ class WCS(GWCSAPIMixin, Pipeline):
             return high_level
         return results
 
+    def _evaluate_transform(
+        self,
+        transform,
+        from_frame,
+        to_frame,
+        *args,
+        with_bounding_box: bool = True,
+        fill_value: float | np.number = np.nan,
+        **kwargs,
+    ):
+        """
+        Introduces or removes units from the arguments as need so that the transform
+        can be successfully evaluated.
+
+        Notes
+        -----
+        Much of the logic in this method is due to the unfortunate fact that the
+        `uses_quantity` property for models is not reliable for determining if one
+        must pass quantities or not. It instead tells you:
+            1. If it has any parameter that is a quantity
+            2. It defaults to true for parameterless models.
+
+        This is problematic because its entirely possible to construct a model with
+        a parameter that is a quantity but the model itself either doesn't require
+        them or in fact cannot use them. This is a very rare case but it could happen.
+        Currently, this case is not handled, but it is worth noting in case it comes up
+
+        The more problematic case is for parameterless models. `uses_quantity` assumes
+        that if there are no parameters, then the model is agnostic to quantity inputs.
+        This is an incorrect assumption, even with in `astropy.modeling`'s built in
+        models.  The `Tabular1D` model for example has no "parameters" but it can
+        require quantities if its "points" construction input is a quantity. This
+        is the main case for the try/except block in this method.
+
+        Properly dealing with this will require upstream work in `astropy.modeling`
+        which is outside the scope of what GWCS can control.
+
+        to_frame is included as we really ought to be stripping the result of units
+        but we currently are not. API refactor should include addressing this.
+        """
+
+        # Validate that the input type matches what the transform expects
+        input_is_quantity = any(isinstance(a, u.Quantity) for a in args)
+
+        def _transform(*args):
+            """Wrap the transform evaluation"""
+
+            return transform(
+                *args,
+                with_bounding_box=with_bounding_box,
+                fill_value=fill_value,
+                **kwargs,
+            )
+
+        # Models with no parameters claim they use quantities but this may incorrectly
+        # introduce units so we don't at first
+        if (
+            not input_is_quantity
+            and transform.uses_quantity
+            and transform.parameters.size
+        ):
+            args = self._add_units_input(args, from_frame)
+        if not transform.uses_quantity and input_is_quantity:
+            args = self._remove_units_input(args, from_frame)
+
+        try:
+            return _transform(*args)
+        except u.UnitsError:
+            # In this case we are handling parameterless models that require units
+            # to function correctly.
+            if (
+                not input_is_quantity
+                and transform.uses_quantity
+                and not transform.parameters.size
+            ):
+                return _transform(*self._add_units_input(args, from_frame))
+
+            raise
+
     def _call_forward(
         self,
         *args,
@@ -193,15 +272,14 @@ class WCS(GWCSAPIMixin, Pipeline):
             msg = "WCS.forward_transform is not implemented."
             raise NotImplementedError(msg)
 
-        # Validate that the input type matches what the transform expects
-        input_is_quantity = any(isinstance(a, u.Quantity) for a in args)
-        if not input_is_quantity and transform.uses_quantity:
-            args = self._add_units_input(args, from_frame)
-        if not transform.uses_quantity and input_is_quantity:
-            args = self._remove_units_input(args, from_frame)
-
-        return transform(
-            *args, with_bounding_box=with_bounding_box, fill_value=fill_value, **kwargs
+        return self._evaluate_transform(
+            transform,
+            from_frame,
+            to_frame,
+            *args,
+            with_bounding_box=with_bounding_box,
+            fill_value=fill_value,
+            **kwargs,
         )
 
     def in_image(self, *args, **kwargs):
@@ -324,16 +402,12 @@ class WCS(GWCSAPIMixin, Pipeline):
             args = self.outside_footprint(args)
 
         if transform is not None:
-            # Validate that the input type matches what the transform expects
-            input_is_quantity = any(isinstance(a, u.Quantity) for a in args)
-            if not input_is_quantity and transform.uses_quantity:
-                args = self._add_units_input(args, self.output_frame)
-            if not transform.uses_quantity and input_is_quantity:
-                args = self._remove_units_input(args, self.output_frame)
-
             # remove iterative inverse-specific keyword arguments:
             akwargs = {k: v for k, v in kwargs.items() if k not in _ITER_INV_KWARGS}
-            result = transform(
+            result = self._evaluate_transform(
+                transform,
+                self.output_frame,
+                self.input_frame,
                 *args,
                 with_bounding_box=with_bounding_box,
                 fill_value=fill_value,


### PR DESCRIPTION
This fixes #558.

This fix is a bandaid fix until a fix upstream in `astropy.modeling` can be worked out. Note that this does not address the API issues expressed in #558, those are now being tracked by #561.