### PR TITLE
BUGFIX fix issue with `with_units` causing a loss of array entries

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,9 @@
 
 - Switch to using a new sphinx theme and clean up the documentation. [#580]
 
+- Fix bug where "vector" (shape (n,) not shape (1, n)) arrays would loose all their entries except the
+  first if ``with_units=True`` was used. [#563]
+
 0.24.0 (2025-02-04)
 -------------------
 

--- a/gwcs/coordinate_frames.py
+++ b/gwcs/coordinate_frames.py
@@ -488,6 +488,29 @@ class BaseCoordinateFrame(abc.ABC):
         to be able to get the components in their native order.
         """
 
+    def add_units(self, arrays: u.Quantity | np.ndarray | float) -> tuple[u.Quantity]:
+        """
+        Add units to the arrays
+        """
+        return tuple(
+            u.Quantity(array, unit=unit)
+            for array, unit in zip(arrays, self.unit, strict=True)
+        )
+
+    def remove_units(
+        self, arrays: u.Quantity | np.ndarray | float
+    ) -> tuple[np.ndarray]:
+        """
+        Remove units from the input arrays
+        """
+        if self.naxes == 1:
+            arrays = (arrays,)
+
+        return tuple(
+            array.to_value(unit) if isinstance(array, u.Quantity) else array
+            for array, unit in zip(arrays, self.unit, strict=True)
+        )
+
 
 class CoordinateFrame(BaseCoordinateFrame):
     """

--- a/gwcs/tests/test_wcs.py
+++ b/gwcs/tests/test_wcs.py
@@ -1813,3 +1813,25 @@ def test_direct_numerical_inverse(gwcs_romanisim):
     out = gwcs_romanisim.numerical_inverse(*ra_dec)
 
     assert_allclose(xy, out)
+
+
+def test_array_high_level_output():
+    """
+    Test that we don't loose array values when requesting a high-level output
+    from a WCS object.
+    """
+    input_frame = cf.CoordinateFrame(
+        naxes=1,
+        axes_type=("SPATIAL",),
+        axes_order=(0,),
+        name="pixels",
+        unit=(u.pix,),
+        axes_names=("x",),
+    )
+    output_frame = cf.SpectralFrame(unit=(u.nm,), axes_names=("lambda",))
+    wave_model = models.Scale(0.1) | models.Shift(500)
+    gwcs = wcs.WCS([(input_frame, wave_model), (output_frame, None)])
+    assert (
+        gwcs(np.array([0, 1, 2]), with_units=True)
+        == coord.SpectralCoord([500, 500.1, 500.2] * u.nm)
+    ).all()

--- a/gwcs/wcs/_wcs.py
+++ b/gwcs/wcs/_wcs.py
@@ -1194,7 +1194,6 @@ class WCS(GWCSAPIMixin, Pipeline):
         """
 
         def _order_clockwise(v):
-            v = [self._remove_units_input(vv, self.input_frame) for vv in v]
             return np.asarray(
                 [
                     [v[0][0], v[1][0]],
@@ -1218,7 +1217,9 @@ class WCS(GWCSAPIMixin, Pipeline):
                 bb = np.asarray([b.value for b in bb]) * bb[0].unit
             vertices = (bb,)
         elif all_spatial:
-            vertices = _order_clockwise(bb)
+            vertices = _order_clockwise(
+                [self._remove_units_input(b, self.input_frame) for b in bb]
+            )
         else:
             vertices = np.array(list(itertools.product(*bb))).T
 


### PR DESCRIPTION
This fixes #559 

The issue is that `with_units` was accidentally loosing elements of an array for "vector" values. That is if your in the 1D case and your shape is `(n,)` instead of `(1, n)` the only the first entry of the vector was returned in the "high-level" object.

The issue was due to a `zip(arrays, units, strict=False)` loosing things because there were more `arrays` entries than `units` entries. The issue is that for the "vector" the zip will iterate over each of the entries in the vector, where as a 1D array would just iterate once yielding the entire "vector" entry.

The solution is twofold:

1. Force strictness so that we catch future bugs in `gwcs`.
2. Add check for `naxes==1` before the zip and wrapping the "vector" into a tuple.