### PR TITLE
Fix `numerical_inverse` API issue

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,8 @@
 0.25.0 (unreleased)
 -------------------
 
+- Fix API issue with ``wcs.numerical_inverse``. [#565]
+
 0.24.0 (2025-02-04)
 -------------------
 

--- a/gwcs/tests/conftest.py
+++ b/gwcs/tests/conftest.py
@@ -156,3 +156,8 @@ def cart_to_spher():
 @pytest.fixture
 def gwcs_with_pipeline_celestial():
     return examples.gwcs_with_pipeline_celestial()
+
+
+@pytest.fixture
+def gwcs_romanisim():
+    return examples.gwcs_romanisim()

--- a/gwcs/tests/test_wcs.py
+++ b/gwcs/tests/test_wcs.py
@@ -1804,3 +1804,12 @@ def test_bounding_box_with_units():
 
     w_gwcs.invert(4 * u.deg, 5 * u.deg)
     w_gwcs.to_fits(bounding_box=([0, 100] * u.pix, [0, 100] * u.pix))
+
+
+def test_direct_numerical_inverse(gwcs_romanisim):
+    xy = (128, 256)
+    coord = gwcs_romanisim(*xy)
+    ra_dec = (np.radians(c) * u.rad for c in coord)
+    out = gwcs_romanisim.numerical_inverse(*ra_dec)
+
+    assert_allclose(xy, out)

--- a/gwcs/wcs/_wcs.py
+++ b/gwcs/wcs/_wcs.py
@@ -352,7 +352,7 @@ class WCS(GWCSAPIMixin, Pipeline):
         else:
             # Always strip units for numerical inverse
             args = self._remove_units_input(args, self.output_frame)
-            result = self.numerical_inverse(
+            result = self._numerical_inverse(
                 *args,
                 with_bounding_box=with_bounding_box,
                 fill_value=fill_value,
@@ -678,6 +678,30 @@ class WCS(GWCSAPIMixin, Pipeline):
          [2.76552923e-05 1.14789013e-05]]
 
         """  # noqa: E501
+        return self._numerical_inverse(
+            *args,
+            tolerance=tolerance,
+            maxiter=maxiter,
+            adaptive=adaptive,
+            detect_divergence=detect_divergence,
+            quiet=quiet,
+            with_bounding_box=with_bounding_box,
+            fill_value=fill_value,
+            **kwargs,
+        )
+
+    def _numerical_inverse(
+        self,
+        *args,
+        tolerance=1e-5,
+        maxiter=30,
+        adaptive=True,
+        detect_divergence=True,
+        quiet=True,
+        with_bounding_box=True,
+        fill_value=np.nan,
+        **kwargs,
+    ):
         if kwargs.pop("with_units", False):
             msg = (
                 "Support for with_units in numerical_inverse has been removed, "

--- a/gwcs/wcs/_wcs.py
+++ b/gwcs/wcs/_wcs.py
@@ -679,7 +679,7 @@ class WCS(GWCSAPIMixin, Pipeline):
 
         """  # noqa: E501
         return self._numerical_inverse(
-            *args,
+            *self._remove_units_input(args, self.output_frame),
             tolerance=tolerance,
             maxiter=maxiter,
             adaptive=adaptive,


### PR DESCRIPTION
Fixes #564

The `WCS.numerical_inverse`'s actual implementation does not take kindly to `Quantity` values being passed in. Prior to #457 `WCS.numerical_inverse` had some pre-processing of the input arguments to strip this out. This removal was a minor mistake. This PR fixes that issue by restoring equivalent functionality to a public version of `WCS.numerical_inverse` while providing a hidden internal implementation that does not need this pre-processing.