### PR TITLE
Drop support for Python 3.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,11 +27,11 @@ jobs:
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@8c0fde6f7e926df6ed7057255d29afa9c1ad5320  # v1.16.0
     with:
       envs: |
-        - linux: py310-oldestdeps
-        - linux: py311-cov
+        - linux: py311-oldestdeps
+        - linux: py312-cov
           coverage: codecov
           pytest-results-summary: true
-        - macos: py311
+        - macos: py313
           pytest-results-summary: true
-        - linux: py312
+        - linux: py313
         - linux: py3-dev

--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -48,7 +48,7 @@ jobs:
       cache-path: ${{ needs.environment.outputs.data_path }}/crds
       cache-key: crds-${{ needs.crds_contexts.outputs.jwst }}
       envs: |
-        - linux: py311-test-jwst-cov-xdist
+        - linux: py312-test-jwst-cov-xdist
 
   romancal:
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@8c0fde6f7e926df6ed7057255d29afa9c1ad5320  # v1.16.0
@@ -62,7 +62,7 @@ jobs:
       cache-path: ${{ needs.environment.outputs.data_path }}/crds
       cache-key: crds-${{ needs.crds_contexts.outputs.jwst }}
       envs: |
-        - linux: py311-test-romancal-cov-xdist
+        - linux: py312-test-romancal-cov-xdist
 
   romanisim_data:
     needs: [ environment ]
@@ -85,7 +85,7 @@ jobs:
       cache-path: ${{ needs.romanisim_data.outputs.cache_path }}
       cache-key: ${{ needs.romanisim_data.outputs.cache_key }}
       envs: |
-        - linux: py311-test-romanisim-cov-xdist
+        - linux: py312-test-romanisim-cov-xdist
 
   astropy:
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@8c0fde6f7e926df6ed7057255d29afa9c1ad5320  # v1.16.0
@@ -93,7 +93,7 @@ jobs:
     with:
       submodules: false
       # Any env name which does not start with `pyXY` will use this Python version.
-      default_python: '3.11'
+      default_python: '3.12'
       envs: |
         - linux: specutils
 
@@ -103,7 +103,7 @@ jobs:
     with:
       submodules: false
       # Any env name which does not start with `pyXY` will use this Python version.
-      default_python: '3.11'
+      default_python: '3.12'
       envs: |
         - linux: ndcube
         - linux: dkist

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,8 @@
 
 - Fix API issue with ``wcs.numerical_inverse``. [#565]
 
+- Drop support for Python 3.10. [#570]
+
 0.24.0 (2025-02-04)
 -------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "gwcs"
 description = "Generalized World Coordinate System"
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 authors = [
     { name = "gwcs developers", email = "help@stsci.edu" },
 ]


### PR DESCRIPTION
Per [SPEC 0](https://scientific-python.org/specs/spec-0000/) this drops Python 3.10 support.