### PR TITLE
Standardize the version setting scheme and fix version displayed in the docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ __pycache__
 
 # Other generated files
 */version.py
+*/_version.py
 */cython_version.py
 htmlcov
 .coverage

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -16,6 +16,8 @@ build:
       - git fetch --unshallow || true
       - git config remote.origin.fetch '+refs/heads/*:refs/remotes/origin/*' || true
       - git fetch --all --tags || true
+    pre_install:
+      - git update-index --assume-unchanged docs/rtd_environment.yaml docs/conf.py
 
 conda:
   environment: docs/rtd_environment.yaml

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -25,15 +25,14 @@
 # be accessible, and the documentation will not build correctly.
 
 import sys
+import tomllib
 from datetime import datetime
 from pathlib import Path
 
-try:
-    import tomllib
-except ImportError:
-    import tomli as tomllib
-
-import importlib.metadata
+if sys.version_info >= (3, 12):
+    from importlib.metadata import distribution
+else:
+    from importlib_metadata import distribution
 
 try:
     from sphinx_astropy.conf.v2 import *  # noqa: F403
@@ -86,7 +85,7 @@ copyright = f"{datetime.now().year}, {author}"  # noqa: A001
 # |version| and |release|, also used in various other places throughout the
 # built documents.
 
-release = importlib.metadata.version(project)
+release = distribution(project).version
 # for example take major/minor
 version = ".".join(release.split(".")[:2])
 

--- a/gwcs/__init__.py
+++ b/gwcs/__init__.py
@@ -57,12 +57,7 @@ information about contributing is in the github repository.
 
 """
 
-import contextlib
-import importlib.metadata
-
-with contextlib.suppress(importlib.metadata.PackageNotFoundError):
-    __version__ = importlib.metadata.version(__name__)
-
+from ._version import version as __version__  # noqa: F401
 from .coordinate_frames import *  # noqa: F403
 from .selector import *  # noqa: F403
 from .wcs import *  # noqa: F403

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,6 @@ content-type = "text/x-rst"
 
 [project.license]
 file = "licenses/LICENSE.rst"
-content-type = "text/x-rst"
 
 [project.urls]
 Homepage = "https://github.com/spacetelescope/gwcs"
@@ -77,7 +76,7 @@ upload-dir = "docs/_build/html"
 show-response = 1
 
 [tool.pytest.ini_options]
-minversion = 8
+minversion = "8"
 doctest_plus = true
 doctest_rst = true
 text_file_format = "rst"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "scipy>=1.14.1",
     "asdf_wcs_schemas >= 0.4.0",
     "asdf-astropy >= 0.5.0",
+    "importlib-metadata>=4.11.4 ; python_version<='3.11'",
 ]
 dynamic = [
     "version",
@@ -123,6 +124,8 @@ exclude_lines = [
 ]
 
 [tool.setuptools_scm]
+version_file = "gwcs/_version.py"
+local_scheme = "dirty-tag"
 
 [tool.ruff.lint]
 select = [

--- a/tox.ini
+++ b/tox.ini
@@ -63,7 +63,7 @@ pass_env =
     LOCALE_ARCHIVE
     LC_ALL
     jwst,romancal: CRDS_*
-    romanisim,romancal: WEBBPSF_PATH
+    romanisim,romancal: STPSF_PATH
     romanisim: GALSIM_CAT_PATH
     romanisim: FFTW_DIR
     romanisim: LIBRARY_PATH


### PR DESCRIPTION
The docs are displaying a version scheme that includes a date. This is not ideal, so this PR fixes that issue. It also uses a more standard method of setting the version using an auto generated version file.