### PR TITLE
Replace deprecated isiterable

### DIFF
--- a/gwcs/converters/selector.py
+++ b/gwcs/converters/selector.py
@@ -7,7 +7,6 @@ from asdf.tags.core.ndarray import NDArrayType
 from asdf_astropy.converters.transform.core import TransformConverterBase
 from astropy.modeling import models
 from astropy.modeling.core import Model
-from astropy.utils.misc import isiterable
 
 __all__ = ["LabelMapperConverter", "RegionsSelectorConverter"]
 
@@ -56,7 +55,7 @@ class LabelMapperConverter(TransformConverterBase):
             inputs = tuple(inputs)
         labels = mapper.get("labels")
         transforms = mapper.get("models")
-        if isiterable(labels[0]):
+        if np.iterable(labels[0]):
             labels = [tuple(label) for label in labels]
             dict_mapper = dict(zip(labels, transforms, strict=False))
             return LabelMapperRange(inputs, dict_mapper, inputs_mapping)
@@ -88,7 +87,7 @@ class LabelMapperConverter(TransformConverterBase):
             labels = list(model.mapper)
 
             transforms = [model.mapper[k] for k in labels]
-            if isiterable(labels[0]):
+            if np.iterable(labels[0]):
                 labels = [list(label) for label in labels]
             mapper["labels"] = labels
             mapper["models"] = transforms

--- a/gwcs/coordinate_frames.py
+++ b/gwcs/coordinate_frames.py
@@ -228,9 +228,7 @@ import numpy as np
 from astropy import coordinates as coord
 from astropy import time
 from astropy import units as u
-from astropy import utils as astutil
 from astropy.coordinates import StokesCoord
-from astropy.utils.misc import isiterable
 from astropy.wcs.wcsapi.fitswcs import CTYPE_TO_UCD1
 from astropy.wcs.wcsapi.high_level_api import (
     high_level_objects_to_values,
@@ -323,7 +321,7 @@ class FrameProperties:
             raise ValueError(msg)
 
         if self.unit is not None:
-            unit = tuple(self.unit) if astutil.isiterable(self.unit) else (self.unit,)
+            unit = tuple(self.unit) if np.iterable(self.unit) else (self.unit,)
             if len(unit) != naxes:
                 msg = "Number of units does not match number of axes."
                 raise ValueError(msg)
@@ -345,7 +343,7 @@ class FrameProperties:
         if self.axis_physical_types is not None:
             if isinstance(self.axis_physical_types, str):
                 self.axis_physical_types = (self.axis_physical_types,)
-            elif not isiterable(self.axis_physical_types):
+            elif not np.iterable(self.axis_physical_types):
                 msg = (
                     "axis_physical_types must be of type string or iterable of strings"
                 )
@@ -935,7 +933,7 @@ class SpectralFrame(CoordinateFrame):
         name=None,
         axis_physical_types=None,
     ):
-        if not isiterable(unit):
+        if not np.iterable(unit):
             unit = (unit,)
         unit = [u.Unit(un) for un in unit]
         pht = axis_physical_types or self._default_axis_physical_types(unit)


### PR DESCRIPTION
Astropy has deprecated `isiterable`:
https://github.com/astropy/astropy/pull/18053
`np.iterable` is a drop-in replacement:
https://numpy.org/doc/1.23/reference/generated/numpy.iterable.html

This PR switches `isiterable` usage to `np.iterable`.