### PR TITLE
[SCSB-205] `project.license.file` -> `project.license-files`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "asdf-astropy >= 0.5.0",
     "importlib-metadata>=4.11.4 ; python_version<='3.11'",
 ]
+license-files = ["licenses/LICENSE.rst"]
 dynamic = [
     "version",
 ]
@@ -21,9 +22,6 @@ dynamic = [
 [project.readme]
 file = "README.rst"
 content-type = "text/x-rst"
-
-[project.license]
-file = "licenses/LICENSE.rst"
 
 [project.urls]
 Homepage = "https://github.com/spacetelescope/gwcs"


### PR DESCRIPTION
the `project.license` entry is changing to just use SPDX expressions; license files are moving to `project.license-files` ([PEP 639](https://peps.python.org/pep-0639/))