### PR TITLE
Improve how undefined value arrays are created in region selector

### DIFF
--- a/gwcs/selector.py
+++ b/gwcs/selector.py
@@ -696,7 +696,7 @@ class RegionsSelector(Model):
             else:
                 # If there's no transform for a label, return np.nan
                 result = [
-                    np.empty(inputs[0].shape) + self._undefined_transform_value
+                    np.full(inputs[0].shape, self._undefined_transform_value)
                     for i in range(self.n_outputs)
                 ]
             for j in range(self.n_outputs):


### PR DESCRIPTION
This PR addresses `RuntimeWarning` issue described in https://github.com/spacetelescope/jwst/pull/9518 

Basically it seems like under certain circumstances `np.empty` may create an all zeros array (as it does in my environment locally on Mac OS) and it can create arrays with arbitrary values in other environments (like Linux running JWST regression tests). It looks like that depending on the values of these empty arrays, adding `np.nan` to them triggers `RuntimeWarning`. This PR simply creates arrays that are filled with undefined value.

I do not think it needs a change log entry but if you think it does, let me know and I will add it.

CC: @melanieclarke 