### PR TITLE
Relax numpy lower pin to allow 1.26

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ authors = [
 dependencies = [
     "asdf >= 3.3.0",
     "astropy >= 6.0",
-    "numpy>1.26",
+    "numpy>=1.26",
     "scipy>=1.14.1",
     "asdf_wcs_schemas >= 0.5.0",
     "asdf-astropy >= 0.8.0",


### PR DESCRIPTION
The recent release of gwcs set the numpy lower pin to `numpy>1.26`, which effectively drops support for numpy<2. I think the intention of the pin update was `numpy>=1.26`, which this PR does. Making the PR to see how tests behave.