### PR TITLE
MAINT: remove outdated dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,6 @@ dependencies = [
     "scipy>=1.14.1",
     "asdf_wcs_schemas >= 0.5.0",
     "asdf-astropy >= 0.8.0",
-    "importlib-metadata>=4.11.4 ; python_version<='3.11'",
 ]
 license-files = ["licenses/LICENSE.rst"]
 dynamic = [


### PR DESCRIPTION
The python requirements have already been bumped to be python 3.11+

(Noticed  this while reviewing the conda-forge build for the new release)