### PR TITLE
Compute lon pole at the poles with Zenithal projection 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,7 @@
+0.25.2 (unreleased)
+-------------------
+- Fix the computation of ``lon_pole`` for Zenitahl projections and declination of +/-90 deg. [#616]
+
 0.25.1 (2025-06-20)
 -------------------
 

--- a/gwcs/examples.py
+++ b/gwcs/examples.py
@@ -729,7 +729,7 @@ def fits_wcs_imaging_simple(params):
     w.wcs.crpix = crpix
     w.wcs.crval = crval
     if crval[1] in (90, -90):
-        # following the errata WCS paper 
+        # following the errata WCS paper
         w.wcs.lonpole = 180
     w.wcs.set()
     return gw, w

--- a/gwcs/examples.py
+++ b/gwcs/examples.py
@@ -706,14 +706,15 @@ def gwcs_romanisim():
     return wcs.WCS(pipeline)
 
 
-def fits_wcs_imaging_simple():
+def fits_wcs_imaging_simple(params):
     """A simple FITS WCS imaging transform without distortion."""
+    lon, lat = params
     detector = cf.Frame2D(name="detector", axes_order=(0, 1), unit=(u.pix, u.pix))
     world = cf.CelestialFrame(
         reference_frame=coord.ICRS(), name="world", unit=(u.deg, u.deg)
     )
     projection = models.Pix2Sky_TAN()
-    crval = [5.6, -72.4]
+    crval = [lon, lat]
     crpix = [5, 5]
     fwcs = fitswcs.FITSImagingWCSTransform(projection, crpix=crpix, crval=crval)
     pipeline = [wcs.Step(detector, fwcs), wcs.Step(world, None)]

--- a/gwcs/examples.py
+++ b/gwcs/examples.py
@@ -3,6 +3,7 @@ import numpy as np
 from astropy import coordinates as coord
 from astropy.modeling import models
 from astropy.time import Time
+from astropy.wcs import WCS as ASTWCS
 
 from . import coordinate_frames as cf
 from . import fitswcs, geometry, wcs
@@ -708,7 +709,9 @@ def gwcs_romanisim():
 
 def fits_wcs_imaging_simple(params):
     """A simple FITS WCS imaging transform without distortion."""
+    # Check for several values of cravl2, including at the poles
     lon, lat = params
+    # First, generate a GWCS object
     detector = cf.Frame2D(name="detector", axes_order=(0, 1), unit=(u.pix, u.pix))
     world = cf.CelestialFrame(
         reference_frame=coord.ICRS(), name="world", unit=(u.deg, u.deg)
@@ -718,5 +721,15 @@ def fits_wcs_imaging_simple(params):
     crpix = [5, 5]
     fwcs = fitswcs.FITSImagingWCSTransform(projection, crpix=crpix, crval=crval)
     pipeline = [wcs.Step(detector, fwcs), wcs.Step(world, None)]
+    gw = wcs.WCS(pipeline)
 
-    return wcs.WCS(pipeline)
+    # Generate a FITSWCS object
+    w = ASTWCS(naxis=2)
+    w.wcs.ctype = ["RA---TAN", "DEC--TAN"]
+    w.wcs.crpix = crpix
+    w.wcs.crval = crval
+    if crval[1] in (90, -90):
+        # following the errata WCS paper 
+        w.wcs.lonpole = 180
+    w.wcs.set()
+    return gw, w

--- a/gwcs/tests/conftest.py
+++ b/gwcs/tests/conftest.py
@@ -163,6 +163,14 @@ def gwcs_romanisim():
     return examples.gwcs_romanisim()
 
 
-@pytest.fixture
-def fits_wcs_imaging_simple():
-    return examples.fits_wcs_imaging_simple()
+@pytest.fixture(
+    params=[
+        (5.6, -72.4),
+        (5.6, 90),
+        (5.6, -90),
+        (5.6, 0),
+    ],
+)
+def fits_wcs_imaging_simple(request):
+    params = request.param
+    return examples.fits_wcs_imaging_simple(params)

--- a/gwcs/tests/test_utils.py
+++ b/gwcs/tests/test_utils.py
@@ -62,6 +62,8 @@ def test_lon_pole():
         gwutils._compute_lon_pole((1 * u.rad, 0.34 * u.rad), azp), 180 * u.deg
     )
     assert_allclose(gwutils._compute_lon_pole((1, -34), tan), 180)
+    assert_allclose(gwutils._compute_lon_pole((1, -90), tan), 180)
+    assert_allclose(gwutils._compute_lon_pole((1, 90), tan), 180)
 
 
 def test_unknown_ctype():

--- a/gwcs/tests/test_wcs.py
+++ b/gwcs/tests/test_wcs.py
@@ -9,9 +9,8 @@ from astropy import coordinates as coord
 from astropy import units as u
 from astropy import wcs as astwcs
 from astropy.io import fits
-from astropy.modeling import bind_compound_bounding_box, models
+from astropy.modeling import bind_compound_bounding_box, models, projections
 from astropy.modeling.bounding_box import ModelBoundingBox
-from astropy.modeling import projections
 from astropy.time import Time
 from astropy.utils.introspection import minversion
 from astropy.wcs import wcsapi
@@ -1912,7 +1911,7 @@ def test_fitswcs_imaging(fits_wcs_imaging_simple):
     )
 
 
-@pytest.mark.parametrize(("lon", "lat"), [(0, 90), (0, -90), (83.19300506082001, 90.)])
+@pytest.mark.parametrize(("lon", "lat"), [(0, 90), (0, -90), (83.19300506082001, 90.0)])
 def test_fitswcs_transform(lon, lat):
     # test at the poles
     tan = projections.Pix2Sky_TAN()
@@ -1920,10 +1919,3 @@ def test_fitswcs_transform(lon, lat):
     assert_allclose(fwcs(0, 0), (lon, lat), atol=1e-14)
     assert_allclose(fwcs(0, lat)[0], lon + 180, atol=1e-14)
     assert_allclose(fwcs.inverse(lon, lat), (0, 0), atol=1e-14)
-
-    # fwcs = fitswcs.FITSImagingWCSTransform(tan, crval=[0, -90])
-    # assert fwcs(0, 0) == (0, -90)
-    # assert fwcs(0, -90) == tan(0, -90)
-    #
-    # lon, lat = 83.19300506082001, 90
-    # assert_equal(fwcs(0, 0), (lon, lat))

--- a/gwcs/tests/test_wcs.py
+++ b/gwcs/tests/test_wcs.py
@@ -1898,16 +1898,24 @@ def test_parameterless_transform():
 
 def test_fitswcs_imaging(fits_wcs_imaging_simple):
     """Test simple FITS type imaging WCS."""
-    forward_transform = fits_wcs_imaging_simple.forward_transform
-    ra, dec = fits_wcs_imaging_simple(*forward_transform.crpix)
-    assert_allclose((ra, dec), forward_transform.crval)
-    assert_allclose(fits_wcs_imaging_simple.invert(ra, dec), forward_transform.crpix)
+    gwcs, astwcs = fits_wcs_imaging_simple
+    forward_transform = gwcs.forward_transform
+    crpix = forward_transform.crpix
+    crval = forward_transform.crval
+    ra, dec = gwcs(*crpix)
+    ast_ra, ast_dec = astwcs.wcs_pix2world(crpix[0], crpix[1], 1)
+    assert_allclose((ra, dec), crval)
+    if crval[1] in (90, -90):
+        assert_allclose((ast_ra, ast_dec), crval)
+    else:
+        assert_allclose((ast_ra, ast_dec), crval)
+    assert_allclose(gwcs.invert(ra, dec), forward_transform.crpix)
 
-    sky = fits_wcs_imaging_simple.pixel_to_world(*forward_transform.crpix)
+    sky = gwcs.pixel_to_world(*forward_transform.crpix)
     ra, dec = sky.data.lon.value, sky.data.lat.value
     assert_allclose((ra, dec), forward_transform.crval)
     assert_allclose(
-        fits_wcs_imaging_simple.world_to_pixel(sky), forward_transform.crpix
+        gwcs.world_to_pixel(sky), forward_transform.crpix
     )
 
 

--- a/gwcs/tests/test_wcs.py
+++ b/gwcs/tests/test_wcs.py
@@ -1914,9 +1914,7 @@ def test_fitswcs_imaging(fits_wcs_imaging_simple):
     sky = gwcs.pixel_to_world(*forward_transform.crpix)
     ra, dec = sky.data.lon.value, sky.data.lat.value
     assert_allclose((ra, dec), forward_transform.crval)
-    assert_allclose(
-        gwcs.world_to_pixel(sky), forward_transform.crpix
-    )
+    assert_allclose(gwcs.world_to_pixel(sky), forward_transform.crpix)
 
 
 @pytest.mark.parametrize(("lon", "lat"), [(0, 90), (0, -90), (83.19300506082001, 90.0)])

--- a/gwcs/utils.py
+++ b/gwcs/utils.py
@@ -130,7 +130,6 @@ def _compute_lon_pole(skycoord, projection):
             lat = lat.to_value(u.deg)
             unit = u.deg
 
-    #unit = u.deg
     if isinstance(projection, projections.Zenithal) and lat in (90, -90):
         lonpole = 180
     else:

--- a/gwcs/utils.py
+++ b/gwcs/utils.py
@@ -130,7 +130,7 @@ def _compute_lon_pole(skycoord, projection):
             lat = lat.to_value(u.deg)
             unit = u.deg
 
-    if isinstance(projection, projections.Zenithal) and lat in (90, -90):
+    if isinstance(projection, projections.Zenithal):
         lonpole = 180
     else:
         cel = Celprm()

--- a/gwcs/utils.py
+++ b/gwcs/utils.py
@@ -120,29 +120,31 @@ def _compute_lon_pole(skycoord, projection):
         lon = skycoord.spherical.lon.value
         lat = skycoord.spherical.lat.value
         unit = u.deg
-
     else:
         lon, lat = skycoord
         unit = None
         if isinstance(lon, u.Quantity):
-            lon = lon.to(u.deg).to_value()
+            lon = lon.to_value(u.deg)
             unit = u.deg
-
         if isinstance(lat, u.Quantity):
-            lat = lat.to(u.deg).to_value()
+            lat = lat.to_value(u.deg)
             unit = u.deg
 
-    cel = Celprm()
-    cel.ref = [lon, lat]
-    cel.prj.code = projection.prjprm.code
-    pvrange = projection.prjprm.pvrange
-    if pvrange:
-        i1 = pvrange // 100
-        i2 = i1 + (pvrange % 100) + 1
-        cel.prj.pv = i1 * [None] + list(projection.prjprm.pv[i1:i2])
-    cel.set()
+    #unit = u.deg
+    if isinstance(projection, projections.Zenithal) and lat in (90, -90):
+        lonpole = 180
+    else:
+        cel = Celprm()
+        cel.ref = [lon, lat]
+        cel.prj.code = projection.prjprm.code
+        pvrange = projection.prjprm.pvrange
+        if pvrange:
+            i1 = pvrange // 100
+            i2 = i1 + (pvrange % 100) + 1
+            cel.prj.pv = i1 * [None] + list(projection.prjprm.pv[i1:i2])
+        cel.set()
 
-    lonpole = cel.ref[2]
+        lonpole = cel.ref[2]
     if unit is not None:
         lonpole = lonpole * unit
 


### PR DESCRIPTION
`gwcs.utils._compute_lon_pole` computes the longitude of the celestial pole using wcslib methods. There's a specific case when wcslib does not provide the correct value and that occurs when `delta_0 == theta_0 == +/- 90 deg`. Here `delta_0` is the declination of the tangent point (e.g. FITS: CRVAL2) and `theta_0` is the latitude of the celestial pole in the native system.

The [errata](https://www.atnf.csiro.au/computing/software/wcs/WCS/errata_20130921.pdf) to the [WCS II paper,](http://aanda.org/articles/aa/pdf/2002/45/aah3860.pdf) mentions in sec 2.2, that in that case it's best to set lon_pole to phi_0 + 180 or wcs.cel.ref[2] + 180.

This issue was discovered when testing a new Roman tessellation file and generating a WCS for the north pole. Although a gnomonic projection is used, for which lon_pole is defined as 180 deg, the function returns a value of 0. 

Another option (or perhaps in addition to fixing the above function) is adding a parameter `lon_pole` to `gwcs.fitswcs.FITSImagingTransform`, to allow end users to specify a desired value.