### PR TITLE
LabelMapperArray should use inputs_mapping

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,8 @@
 -------------------
 - Fix the computation of ``lon_pole`` for Zenitahl projections and declination of +/-90 deg. [#616]
 
+- Enable ``inputs_mapping`` in ``selector.LabelMapperArray``. [#626]
+
 0.25.1 (2025-06-20)
 -------------------
 

--- a/gwcs/selector.py
+++ b/gwcs/selector.py
@@ -222,6 +222,13 @@ class _LabelMapper(Model):
         msg = "Subclasses should implement this method."
         raise NotImplementedError(msg)
 
+    def filter_inputs(self, args, inputs_mapping):
+        if self.inputs_mapping is not None:
+            keys = self._inputs_mapping.evaluate(*args)
+        else:
+            keys = args
+        return keys
+
 
 class LabelMapperArray(_LabelMapper):
     """
@@ -260,13 +267,10 @@ class LabelMapperArray(_LabelMapper):
         super().__init__(mapper, _no_label, inputs_mapping=inputs_mapping, name=name, **kwargs)
         self._inputs = inputs
         self._n_inputs = len(inputs)
-        self.outputs = ("label",)
+        self._outputs = ("label",)
 
     def evaluate(self, *args):
-        if self.inputs_mapping is not None:
-            keys = self._inputs_mapping.evaluate(*args)
-        else:
-            keys = args
+        keys = self.filter_inputs(args, self.inputs_mapping)
         keys = tuple([_toindex(a) for a in keys])
         try:
             result = self._mapper[keys[::-1]]
@@ -365,25 +369,7 @@ class LabelMapperDict(_LabelMapper):
         self._input_units_strict = dict.fromkeys(self._inputs, False)
         self._input_units_allow_dimensionless = dict.fromkeys(self._inputs, False)
         super().__init__(mapper, _no_label, inputs_mapping, name=name, **kwargs)
-        self.outputs = ("labels",)
-
-    @property
-    def n_inputs(self):
-        return self._n_inputs
-
-    @property
-    def inputs(self):
-        """
-        The name(s) of the input variable(s) on which a model is evaluated.
-        """
-        return self._inputs
-
-    @inputs.setter
-    def inputs(self, val):
-        """
-        The name(s) of the input variable(s) on which a model is evaluated.
-        """
-        self._inputs = val
+        self._outputs = ("labels",)
 
     @property
     def atol(self):
@@ -397,10 +383,7 @@ class LabelMapperDict(_LabelMapper):
         shape = args[0].shape
         args = [a.flatten() for a in args]
         # if n_inputs > 1, determine which one is to be used as keys
-        if self.inputs_mapping is not None:
-            keys = self._inputs_mapping.evaluate(*args)
-        else:
-            keys = args
+        keys = self.filter_inputs(args, self.inputs_mapping)
         keys = keys.flatten()
         # create an empty array for the results
         res = np.zeros(keys.shape) + self._no_label
@@ -465,25 +448,7 @@ class LabelMapperRange(_LabelMapper):
         self._input_units_strict = dict.fromkeys(self._inputs, False)
         self._input_units_allow_dimensionless = dict.fromkeys(self._inputs, False)
         super().__init__(mapper, _no_label, inputs_mapping, name=name, **kwargs)
-        self.outputs = ("labels",)
-
-    @property
-    def n_inputs(self):
-        return self._n_inputs
-
-    @property
-    def inputs(self):
-        """
-        The name(s) of the input variable(s) on which a model is evaluated.
-        """
-        return self._inputs
-
-    @inputs.setter
-    def inputs(self, val):
-        """
-        The name(s) of the input variable(s) on which a model is evaluated.
-        """
-        self._inputs = val
+        self._outputs = ("labels",)
 
     @staticmethod
     def _has_overlapping(ranges):
@@ -530,10 +495,7 @@ class LabelMapperRange(_LabelMapper):
     def evaluate(self, *args):
         shape = args[0].shape
         args = [a.flatten() for a in args]
-        if self.inputs_mapping is not None:
-            keys = self._inputs_mapping.evaluate(*args)
-        else:
-            keys = args
+        keys = self.filter_inputs(args, self.inputs_mapping)
         keys = keys.flatten()
         # Define an array for the results.
         res = np.zeros(keys.shape) + self._no_label
@@ -715,42 +677,8 @@ class RegionsSelector(Model):
         self._undefined_transform_value = value
 
     @property
-    def outputs(self):
-        """The name(s) of the output(s) of the model."""
-        return self._outputs
-
-    @property
     def selector(self):
         return self._selector
-
-    @property
-    def inputs(self):
-        """
-        The name(s) of the input variable(s) on which a model is evaluated.
-        """
-        return self._inputs
-
-    @inputs.setter
-    def inputs(self, val):
-        """
-        The name(s) of the input variable(s) on which a model is evaluated.
-        """
-        self._inputs = val
-
-    @outputs.setter
-    def outputs(self, val):
-        """
-        The name(s) of the output variable(s).
-        """
-        self._outputs = val
-
-    @property
-    def n_inputs(self):
-        return self._n_inputs
-
-    @property
-    def n_outputs(self):
-        return self._n_outputs
 
 
 class LabelMapper(_LabelMapper):
@@ -797,41 +725,9 @@ class LabelMapper(_LabelMapper):
         self._input_units_strict = dict.fromkeys(self._inputs, False)
         self._input_units_allow_dimensionless = dict.fromkeys(self._inputs, False)
         super(_LabelMapper, self).__init__(name=name, **kwargs)
-        self.outputs = ("label",)
-
-    @property
-    def inputs(self):
-        """
-        The name(s) of the input variable(s) on which a model is evaluated.
-        """
-        return self._inputs
-
-    @inputs.setter
-    def inputs(self, val):
-        """
-        The name(s) of the input variable(s) on which a model is evaluated.
-        """
-        self._inputs = val
-
-    @property
-    def n_inputs(self):
-        return self._n_inputs
-
-    @property
-    def mapper(self):
-        return self._mapper
-
-    @property
-    def inputs_mapping(self):
-        return self._inputs_mapping
-
-    @property
-    def no_label(self):
-        return self._no_label
 
     def evaluate(self, *args):
-        if self.inputs_mapping is not None:
-            args = self.inputs_mapping(*args)
+        args = self.filter_inputs(args, self.inputs_mapping)
         if self.n_outputs == 1:
             args = [args]
         res = self.mapper(*args)

--- a/gwcs/selector.py
+++ b/gwcs/selector.py
@@ -246,27 +246,30 @@ class LabelMapperArray(_LabelMapper):
     values correspond to the IFU slice label.
 
     """
-
-    n_inputs = 2
     n_outputs = 1
 
     linear = False
     fittable = False
 
-    def __init__(self, mapper, inputs_mapping=None, name=None, **kwargs):
+    def __init__(self, mapper, inputs_mapping=None, name=None, inputs=('x', 'y'), **kwargs):
         if mapper.dtype.type is not np.str_:
             mapper = np.asanyarray(mapper, dtype=int)
             _no_label = 0
         else:
             _no_label = ""
-        super().__init__(mapper, _no_label, name=name, **kwargs)
-        self.inputs = ("x", "y")
+        super().__init__(mapper, _no_label, inputs_mapping=inputs_mapping, name=name, **kwargs)
+        self._inputs = inputs
+        self._n_inputs = len(inputs)
         self.outputs = ("label",)
 
     def evaluate(self, *args):
-        args = tuple([_toindex(a) for a in args])
+        if self.inputs_mapping is not None:
+            keys = self._inputs_mapping.evaluate(*args)
+        else:
+            keys = args
+        keys = tuple([_toindex(a) for a in keys])
         try:
-            result = self._mapper[args[::-1]]
+            result = self._mapper[keys[::-1]]
         except IndexError as e:
             raise LabelMapperArrayIndexingError(e) from e
         return result

--- a/gwcs/selector.py
+++ b/gwcs/selector.py
@@ -271,7 +271,7 @@ class LabelMapperArray(_LabelMapper):
 
     def evaluate(self, *args):
         keys = self.filter_inputs(args, self.inputs_mapping)
-        keys = tuple([_toindex(a) for a in keys])
+        keys = tuple(_toindex(a) for a in keys)
         try:
             result = self._mapper[keys[::-1]]
         except IndexError as e:

--- a/gwcs/selector.py
+++ b/gwcs/selector.py
@@ -253,18 +253,23 @@ class LabelMapperArray(_LabelMapper):
     values correspond to the IFU slice label.
 
     """
+
     n_outputs = 1
 
     linear = False
     fittable = False
 
-    def __init__(self, mapper, inputs_mapping=None, name=None, inputs=('x', 'y'), **kwargs):
+    def __init__(
+        self, mapper, inputs_mapping=None, name=None, inputs=("x", "y"), **kwargs
+    ):
         if mapper.dtype.type is not np.str_:
             mapper = np.asanyarray(mapper, dtype=int)
             _no_label = 0
         else:
             _no_label = ""
-        super().__init__(mapper, _no_label, inputs_mapping=inputs_mapping, name=name, **kwargs)
+        super().__init__(
+            mapper, _no_label, inputs_mapping=inputs_mapping, name=name, **kwargs
+        )
         self._inputs = inputs
         self._n_inputs = len(inputs)
         self._outputs = ("label",)

--- a/gwcs/tests/test_region.py
+++ b/gwcs/tests/test_region.py
@@ -296,13 +296,14 @@ def test_unique_labels():
 
 def test_label_mapper_array_mapping():
     """Test LabelMapperArray with inputs_mapping"""
-    mapper=np.zeros((4,5))
-    mapper[1:, 3:4]=2
-    mapper[1:, 1:2]=1
-    lm=selector.LabelMapperArray(mapper,
-                                 inputs_mapping=models.Mapping((0, 1), n_inputs=3),
-                                 inputs=('x', 'y', 'order')
-                                 )
+    mapper = np.zeros((4, 5))
+    mapper[1:, 3:4] = 2
+    mapper[1:, 1:2] = 1
+    lm = selector.LabelMapperArray(
+        mapper,
+        inputs_mapping=models.Mapping((0, 1), n_inputs=3),
+        inputs=("x", "y", "order"),
+    )
     assert lm(3, 1, 1) == 2
     assert lm(1, 1, 1) == 1
     assert_equal(lm([1, 3, 0], [1, 1, 0], 1), [1, 2, 0])

--- a/gwcs/tests/test_region.py
+++ b/gwcs/tests/test_region.py
@@ -292,3 +292,17 @@ def test_unique_labels():
     expected = ["S100A1", "S1600", "S200A2", "S200B1", "S400A1"]
     result = selector.get_unique_regions(labels)
     assert_equal(expected, result)
+
+
+def test_label_mapper_array_mapping():
+    """Test LabelMapperArray with inputs_mapping"""
+    mapper=np.zeros((4,5))
+    mapper[1:, 3:4]=2
+    mapper[1:, 1:2]=1
+    lm=selector.LabelMapperArray(mapper,
+                                 inputs_mapping=models.Mapping((0, 1), n_inputs=3),
+                                 inputs=('x', 'y', 'order')
+                                 )
+    assert lm(3, 1, 1) == 2
+    assert lm(1, 1, 1) == 1
+    assert_equal(lm([1, 3, 0], [1, 1, 0], 1), [1, 2, 0])


### PR DESCRIPTION
The `gwcs.selector.LabelMapperArray` does not currently accept and work with `inputs_mapping`. This is needed for DHS work where for NIRCam multistripe mode the WCS uses a "regions" file to map the individual stripes on the detector. The `RegionsSelector`  in this case needs to accept three arguments - "x", "y" and "order" - and filter out "order" to pass "x" and "y" to `LabelMapperArray`.

There are three unrelated failures in the jwst regression tests
https://github.com/spacetelescope/RegressionTests/actions/runs/17494765779