### PR TITLE
update ci workflow

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,4 +9,4 @@ git+https://github.com/asdf-format/asdf-wcs-schemas
 astropy>=0.0.dev0
 
 numpy>=0.0.dev0
-# scipy>=0.0.dev0
+scipy>=0.0.dev0


### PR DESCRIPTION
This adds Python 3.14 to the test matrix. 
The failure with the `dev` versions is due to the development version of scipy and may be in astropy.modeling. I commented out `scipy-dev` for this PR.
Edit: The issue with scipy-dev was fixed in astropy. 

@zacharyburnett Can you look at the downstream dependencies failures? Some are due to CRDS not available.