### PR TITLE
reorder downstream CI romanisim data cache name to prevent duplicate cache construction

### DIFF
--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -48,7 +48,7 @@ jobs:
       cache-path: ${{ needs.environment.outputs.data_path }}/crds
       cache-key: crds-${{ needs.crds_contexts.outputs.jwst }}
       envs: |
-        - linux: py311-test-jwst-cov
+        - linux: py311-test-jwst
 
   romancal:
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@9f1fedda61294df4c004c05519a3fbf3b8e1f32f  # v2.3.1
@@ -62,7 +62,7 @@ jobs:
       cache-path: ${{ needs.environment.outputs.data_path }}/crds
       cache-key: crds-${{ needs.crds_contexts.outputs.jwst }}
       envs: |
-        - linux: py311-test-romancal-cov-xdist
+        - linux: py311-test-romancal
 
   romanisim_data:
     needs: [ environment ]
@@ -91,7 +91,7 @@ jobs:
       cache-restore-keys: |
         ${{ needs.romanisim_data.outputs.cache_key }}
       envs: |
-        - linux: py311-test-romanisim-cov-xdist
+        - linux: py311-test-romanisim-xdist
 
   astropy:
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@9f1fedda61294df4c004c05519a3fbf3b8e1f32f  # v2.3.1


### PR DESCRIPTION
the new `romanisim` cache solution (including CRDS) had a bug where caching the CRDS files would create a new cache every time with a longer name. This fixes that for the downstream tests

this change is the same as https://github.com/spacetelescope/romanisim/pull/283