### PR TITLE
TST: New api 2

### DIFF
--- a/gwcs/api.py
+++ b/gwcs/api.py
@@ -66,14 +66,13 @@ class GWCSAPIMixin(BaseLowLevelWCS, HighLevelWCSMixin):
         return tuple(unit.to_string(format="vounit") for unit in self.output_frame.unit)
 
     def _remove_quantity_output(self, result, frame):
-        if self.forward_transform.uses_quantity:
-            if frame.naxes == 1:
-                result = [result]
+        if frame.naxes == 1:
+            result = [result]
 
-            result = tuple(
-                r.to_value(unit) if isinstance(r, u.Quantity) else r
-                for r, unit in zip(result, frame.unit, strict=False)
-            )
+        result = tuple(
+            r.to_value(unit) if isinstance(r, u.Quantity) else r
+            for r, unit in zip(result, frame.unit, strict=False)
+        )
 
         # If we only have one output axes, we shouldn't return a tuple.
         if self.output_frame.naxes == 1 and isinstance(result, tuple):
@@ -94,7 +93,6 @@ class GWCSAPIMixin(BaseLowLevelWCS, HighLevelWCSMixin):
         is the vertical coordinate.
         """
         result = self(*pixel_arrays)
-
         return self._remove_quantity_output(result, self.output_frame)
 
     def array_index_to_world_values(self, *index_arrays):

--- a/gwcs/api.py
+++ b/gwcs/api.py
@@ -250,14 +250,6 @@ class GWCSAPIMixin(BaseLowLevelWCS, HighLevelWCSMixin):
         return self.output_frame.world_axis_object_components
 
     @property
-    def input_axis_object_classes(self):
-        return self.input_frame.world_axis_object_classes
-
-    @property
-    def input_axis_object_components(self):
-        return self.input_frame.world_axis_object_components
-
-    @property
     def pixel_axis_names(self):
         """
         An iterable of strings describing the name for each pixel axis.

--- a/gwcs/api.py
+++ b/gwcs/api.py
@@ -250,6 +250,14 @@ class GWCSAPIMixin(BaseLowLevelWCS, HighLevelWCSMixin):
         return self.output_frame.world_axis_object_components
 
     @property
+    def input_axis_object_classes(self):
+        return self.input_frame.world_axis_object_classes
+
+    @property
+    def input_axis_object_components(self):
+        return self.input_frame.world_axis_object_components
+
+    @property
     def pixel_axis_names(self):
         """
         An iterable of strings describing the name for each pixel axis.

--- a/gwcs/coordinate_frames/_base.py
+++ b/gwcs/coordinate_frames/_base.py
@@ -144,8 +144,7 @@ class BaseCoordinateFrame(abc.ABC):
         if self.naxes == 1 and (np.isscalar(arrays) or isinstance(arrays, u.Quantity)):
             arrays = (arrays,)
 
-        result = tuple(
+        return tuple(
             array.to_value(unit) if isinstance(array, u.Quantity) else array
             for array, unit in zip(arrays, self.unit, strict=True)
         )
-        return result

--- a/gwcs/coordinate_frames/_base.py
+++ b/gwcs/coordinate_frames/_base.py
@@ -128,6 +128,8 @@ class BaseCoordinateFrame(abc.ABC):
         """
         Add units to the arrays
         """
+        if self.naxes == 1 and np.isscalar(arrays):
+            return u.Quantity(arrays, self.unit[0])
         return tuple(
             u.Quantity(array, unit=unit)
             for array, unit in zip(arrays, self.unit, strict=True)
@@ -139,10 +141,11 @@ class BaseCoordinateFrame(abc.ABC):
         """
         Remove units from the input arrays
         """
-        if self.naxes == 1:
+        if self.naxes == 1 and (np.isscalar(arrays) or isinstance(arrays, u.Quantity)):
             arrays = (arrays,)
 
-        return tuple(
+        result = tuple(
             array.to_value(unit) if isinstance(array, u.Quantity) else array
             for array, unit in zip(arrays, self.unit, strict=True)
         )
+        return result

--- a/gwcs/coordinate_frames/_celestial.py
+++ b/gwcs/coordinate_frames/_celestial.py
@@ -106,3 +106,8 @@ class CelestialFrame(CoordinateFrame):
             ("celestial", 0, lambda sc: sc.spherical.lon.to_value(self._prop.unit[0])),
             ("celestial", 1, lambda sc: sc.spherical.lat.to_value(self._prop.unit[1])),
         ]
+        # result = [
+        #     ("celestial", 0, lambda sc: sc.spherical.lon.to_value(self._prop.unit[self.axes_order[0]])),
+        #     ("celestial", 1, lambda sc: sc.spherical.lat.to_value(self._prop.unit[self.axes_order[1]])),
+        # ]
+        # return result

--- a/gwcs/coordinate_frames/_celestial.py
+++ b/gwcs/coordinate_frames/_celestial.py
@@ -106,8 +106,3 @@ class CelestialFrame(CoordinateFrame):
             ("celestial", 0, lambda sc: sc.spherical.lon.to_value(self._prop.unit[0])),
             ("celestial", 1, lambda sc: sc.spherical.lat.to_value(self._prop.unit[1])),
         ]
-        # result = [
-        #     ("celestial", 0, lambda sc: sc.spherical.lon.to_value(self._prop.unit[self.axes_order[0]])),
-        #     ("celestial", 1, lambda sc: sc.spherical.lat.to_value(self._prop.unit[self.axes_order[1]])),
-        # ]
-        # return result

--- a/gwcs/examples.py
+++ b/gwcs/examples.py
@@ -410,7 +410,7 @@ def gwcs_spec_cel_time_4d():
     wcslin = models.Mapping((1, 0)) | (offx & offy) | aff
     tan = models.Pix2Sky_TAN(name="tangent_projection")
     n2c = models.RotateNative2Celestial(*crval, 180, name="sky_rotation")
-    cel_model = wcslin | tan | n2c
+    cel_model = wcslin | tan | n2c | models.Mapping((1,0))
     icrs = cf.CelestialFrame(
         reference_frame=coord.ICRS(), name="sky", axes_order=(2, 1)
     )
@@ -734,3 +734,11 @@ def fits_wcs_imaging_simple(params):
         w.wcs.lonpole = 180
     w.wcs.set()
     return gw, w
+
+
+def gwcs_2d_spatial_shift_reverse():
+    """
+    A simple one step spatial WCS with forward from sky to detector.
+    """
+    pipe = [(ICRC_SKY_FRAME, MODEL_2D_SHIFT), (DETECTOR_2D_FRAME, None)]
+    return wcs.WCS(pipe)

--- a/gwcs/examples.py
+++ b/gwcs/examples.py
@@ -410,7 +410,7 @@ def gwcs_spec_cel_time_4d():
     wcslin = models.Mapping((1, 0)) | (offx & offy) | aff
     tan = models.Pix2Sky_TAN(name="tangent_projection")
     n2c = models.RotateNative2Celestial(*crval, 180, name="sky_rotation")
-    cel_model = wcslin | tan | n2c | models.Mapping((1,0))
+    cel_model = wcslin | tan | n2c | models.Mapping((1, 0))
     icrs = cf.CelestialFrame(
         reference_frame=coord.ICRS(), name="sky", axes_order=(2, 1)
     )

--- a/gwcs/tests/conftest.py
+++ b/gwcs/tests/conftest.py
@@ -174,3 +174,8 @@ def gwcs_romanisim():
 def fits_wcs_imaging_simple(request):
     params = request.param
     return examples.fits_wcs_imaging_simple(params)
+
+
+@pytest.fixture
+def gwcs_2d_spatial_shift_reverse():
+    return examples.gwcs_2d_spatial_shift_reverse()

--- a/gwcs/tests/test_api.py
+++ b/gwcs/tests/test_api.py
@@ -328,7 +328,8 @@ def test_high_level_wrapper(wcsobj, request):
     pix_out1 = hlvl.world_to_pixel(*wc1)
     np.testing.assert_allclose(pix_out1, pixel_input)
     with pytest.raises(TypeError) as e:
-        pix_out2 = wcsobj.invert(*wc1)
+        _ = wcsobj.invert(*wc1)
+    assert "High Level objects are not supported with the native" in str(e)
 
 
 def test_stokes_wrapper(gwcs_stokes_lookup):
@@ -591,7 +592,7 @@ def test_coordinate_frame_api():
     assert isinstance(pixel, float)
 
     with pytest.raises(TypeError):
-        pixel2 = wcs.invert(world)
+        _ = wcs.invert(world)
 
 
 def test_world_axis_object_components_units(gwcs_3d_identity_units):

--- a/gwcs/tests/test_api.py
+++ b/gwcs/tests/test_api.py
@@ -312,7 +312,12 @@ def test_high_level_wrapper(wcsobj, request):
     wc2 = wcsobj(*pixel_input)
     results = wcsobj._remove_units_input(wc2, wcsobj.output_frame)
 
-    wc2 = values_to_high_level_objects(*results, low_level_wcs=wcsobj)
+    wc2 = values_to_high_level_objects(
+        *results,
+        low_level_wcs=wcsobj,
+        object_classes=wcsobj.world_axis_object_classes,
+        object_components=wcsobj.world_axis_object_components
+        )
     if len(wc2) == 1:
         wc2 = wc2[0]
     assert type(wc1) is type(wc2)

--- a/gwcs/tests/test_api.py
+++ b/gwcs/tests/test_api.py
@@ -9,8 +9,10 @@ import numpy as np
 import pytest
 from astropy import coordinates as coord
 from astropy import time
+from astropy.tests.helper import assert_quantity_allclose
 from astropy.wcs.wcsapi import HighLevelWCSWrapper
 from astropy.wcs.wcsapi.high_level_api import values_to_high_level_objects
+# from gwcs.utils import values_to_high_level_objects
 from numpy.testing import assert_allclose, assert_array_equal
 
 import gwcs
@@ -326,10 +328,11 @@ def test_high_level_wrapper(wcsobj, request):
         wc1 = (wc1,)
 
     pix_out1 = hlvl.world_to_pixel(*wc1)
+
     np.testing.assert_allclose(pix_out1, pixel_input)
-    with pytest.raises(TypeError) as e:
-        _ = wcsobj.invert(*wc1)
-    assert "High Level objects are not supported with the native" in str(e)
+    result = wcsobj.invert(*wc1)
+    inpq = [pix * un for pix, un in zip(pixel_input, wcsobj.input_frame.unit)]
+    assert_quantity_allclose(result, inpq)
 
 
 def test_stokes_wrapper(gwcs_stokes_lookup):
@@ -591,8 +594,8 @@ def test_coordinate_frame_api():
     pixel = wcs.world_to_pixel(world)
     assert isinstance(pixel, float)
 
-    with pytest.raises(TypeError):
-        _ = wcs.invert(world)
+    result = wcs.invert(world)
+    assert_quantity_allclose(result, 0*u.pix)
 
 
 def test_world_axis_object_components_units(gwcs_3d_identity_units):

--- a/gwcs/tests/test_api_consistent.py
+++ b/gwcs/tests/test_api_consistent.py
@@ -32,7 +32,7 @@ from astropy import units as u
 from astropy.tests.helper import assert_quantity_allclose
 
 import pytest
-from .conftest import gwcs_with_pipeline_celestial
+from .conftest import gwcs_with_pipeline_celestial, gwcs_2d_spatial_shift_reverse
 
 x = 1
 y = 2
@@ -127,10 +127,11 @@ def test_no_units_nd(wcsobj):
     inp_new = wcsobj.invert(*result)
     _ = [assert_allclose(i, j) for i, j in zip(inp_new, inpq, strict=True)]
 
-    # input is HLO - raise an Error
     sky = wcsobj.pixel_to_world(*inp)
-    with pytest.raises(TypeError) as e:
-        wcsobj.invert(*sky)
+    if not np.iterable(sky):
+        sky=(sky,)
+    inv_sky = wcsobj.invert(*sky)
+    assert_quantity_allclose(inv_sky, inpq)
 
 
 @wcs_with_unit_1d
@@ -172,10 +173,11 @@ def test_transform_with_units(wcsobj):
     assert all([type(res)==u.Quantity for res in result])
     assert_allclose([r.value for r in result], result_num)
 
-    # input is HLO; raise an error
     sky = wcsobj.pixel_to_world(*xxq)
-    with pytest.raises(TypeError) as e:
-        wcsobj.invert(*sky)
+    if not np.iterable(sky):
+        sky=(sky,)
+    inv_sky = wcsobj.invert(*sky)
+    assert_quantity_allclose(inv_sky, xxq)
 
 
 @wcs_no_unit_1d
@@ -213,6 +215,7 @@ def test_remove_units(wcsobj):
 
 
 def test_transform_multistage_wcs(gwcs_with_pipeline_celestial):
+    """Tests that the input and output types match for intermediate frames/transforms."""
     wcsobj = gwcs_with_pipeline_celestial
     frames = wcsobj.available_frames
     result = wcsobj.transform(frames[0], frames[-1], 1*u.pix, 1*u.pix)
@@ -227,3 +230,12 @@ def test_transform_multistage_wcs(gwcs_with_pipeline_celestial):
     assert_quantity_allclose(interm_result, tr(1*u.pix, 1*u.pix))
     ninterm_result = wcsobj.transform(frames[0], frames[1], 1, 1)
     assert_allclose([r.value for r in interm_result], ninterm_result)
+
+
+def test_reverse_wcs_direction(gwcs_2d_spatial_shift_reverse):
+    """Test that input quantities are converted to the units of the input frame."""
+    wcsobj = gwcs_2d_spatial_shift_reverse
+    assert_quantity_allclose(
+        wcsobj(1*u.arcsec, 2*u.arcsec),
+        wcsobj(1*u.arcsec.to(u.deg)*u.deg, 2*u.arcsec.to(u.deg)*u.deg)
+        )

--- a/gwcs/tests/test_wcs.py
+++ b/gwcs/tests/test_wcs.py
@@ -516,10 +516,7 @@ def test_bounding_box_eval():
     pipeline = [
         (
             cf.CoordinateFrame(
-                naxes=3,
-                axes_type=("PIXEL", "PIXEL", "PIXEL"),
-                axes_order=(0, 1, 2),
-                name="detector",
+                naxes=3, axes_type=("PIXEL", "PIXEL", "PIXEL",), axes_order=(0, 1, 2), name="detector"
             ),
             trans3,
         ),
@@ -1703,8 +1700,8 @@ def test_quantities_in_pipeline_forward(gwcs_with_pipeline_celestial):
 
     output_world = iwcs(*input_pixel)
 
-    assert output_world[0].unit == u.deg
-    assert output_world[1].unit == u.deg
+    assert output_world[0].unit == u.arcsec
+    assert output_world[1].unit == u.arcsec
     assert u.allclose(output_world[0], 20 * u.arcsec + 1 * u.deg)
     assert u.allclose(output_world[1], 15 * u.deg + 2 * u.deg)
 
@@ -1883,6 +1880,8 @@ def test_parameterless_transform():
     assert gwcs(1 * u.pix, 1 * u.pix) == (1 * u.pix, 1 * u.pix)
 
     assert gwcs.invert(1, 1) == (1, 1)
+    # Strictly speaking it's correct that this fails Because
+    # for this setup the HLO are Quantities
     assert gwcs.invert(1 * u.pix, 1 * u.pix) == (1, 1)
 
 

--- a/gwcs/tests/test_wcs.py
+++ b/gwcs/tests/test_wcs.py
@@ -1728,10 +1728,12 @@ def test_quantities_in_pipeline_backward(gwcs_with_pipeline_celestial):
         20 * u.arcsec + 1 * u.deg,
         15 * u.deg + 2 * u.deg,
     ]
-    pixel = iwcs.invert(*input_world)
+    with pytest.raises(TypeError) as e:
+        pixel = iwcs.invert(*input_world)
+    assert "High Level objects are not supported with the native" in str(e)
 
-    assert all(isinstance(p, u.Quantity) for p in pixel)
-    assert u.allclose(pixel, [1, 1] * u.pix)
+    # assert all(isinstance(p, u.Quantity) for p in pixel)
+    # assert u.allclose(pixel, [1, 1] * u.pix)
 
     intermediate_world = iwcs.transform(
         "output",
@@ -1882,7 +1884,9 @@ def test_parameterless_transform():
     assert gwcs.invert(1, 1) == (1, 1)
     # Strictly speaking it's correct that this fails Because
     # for this setup the HLO are Quantities
-    assert gwcs.invert(1 * u.pix, 1 * u.pix) == (1, 1)
+    with pytest.raises(TypeError) as e:
+        _ = gwcs.invert(1 * u.pix, 1 * u.pix)
+    assert "High Level objects are not supported with the native" in str(e)
 
 
 def test_fitswcs_imaging(fits_wcs_imaging_simple):

--- a/gwcs/tests/test_wcs.py
+++ b/gwcs/tests/test_wcs.py
@@ -12,9 +12,11 @@ from astropy.io import fits
 from astropy.modeling import bind_compound_bounding_box, models, projections
 from astropy.modeling.bounding_box import ModelBoundingBox
 from astropy.time import Time
+from astropy.tests.helper import assert_quantity_allclose
 from astropy.utils.introspection import minversion
 from astropy.wcs import wcsapi
 from astropy.wcs.wcsapi.high_level_api import values_to_high_level_objects
+# from gwcs.utils import values_to_high_level_objects
 from numpy.testing import assert_allclose, assert_equal
 
 from gwcs import coordinate_frames as cf
@@ -1728,12 +1730,10 @@ def test_quantities_in_pipeline_backward(gwcs_with_pipeline_celestial):
         20 * u.arcsec + 1 * u.deg,
         15 * u.deg + 2 * u.deg,
     ]
-    with pytest.raises(TypeError) as e:
-        pixel = iwcs.invert(*input_world)
-    assert "High Level objects are not supported with the native" in str(e)
 
-    # assert all(isinstance(p, u.Quantity) for p in pixel)
-    # assert u.allclose(pixel, [1, 1] * u.pix)
+    pixel = iwcs.invert(*input_world)
+    assert all(isinstance(p, u.Quantity) for p in pixel)
+    assert u.allclose(pixel, [1, 1] * u.pix)
 
     intermediate_world = iwcs.transform(
         "output",
@@ -1882,11 +1882,9 @@ def test_parameterless_transform():
     assert gwcs(1 * u.pix, 1 * u.pix) == (1 * u.pix, 1 * u.pix)
 
     assert gwcs.invert(1, 1) == (1, 1)
-    # Strictly speaking it's correct that this fails Because
-    # for this setup the HLO are Quantities
-    with pytest.raises(TypeError) as e:
-        _ = gwcs.invert(1 * u.pix, 1 * u.pix)
-    assert "High Level objects are not supported with the native" in str(e)
+
+    assert_quantity_allclose(gwcs.invert(1 * u.pix, 1 * u.pix), (1*u.pix, 1*u.pix))
+
 
 
 def test_fitswcs_imaging(fits_wcs_imaging_simple):

--- a/gwcs/utils.py
+++ b/gwcs/utils.py
@@ -479,17 +479,17 @@ def create_projection_transform(projcode):
     return projklass(**projparams)
 
 
-def is_high_level(*args, low_level_wcs, frame="output"):
+def is_high_level(
+    *args,
+    low_level_wcs,
+    object_classes=None,
+    object_components=None
+    ):
     """
     Determine if args matches the high level classes as defined by
     ``low_level_wcs``.
     """
-    if frame == "output" and low_level_wcs.output_frame is not None:
-        object_classes = low_level_wcs.world_axis_object_classes
-    elif frame == "input" and low_level_wcs.input_frame is not None:
-        object_classes = low_level_wcs.input_axis_object_classes
-    else:
-        # raise ValueError(f"Unrecognized value for frame - {frame}")
+    if object_classes is None:
         return False
     if len(args) != len(object_classes):
         return False

--- a/gwcs/utils.py
+++ b/gwcs/utils.py
@@ -3,7 +3,7 @@
 Utility function for WCS
 
 """
-
+from collections import OrderedDict, defaultdict
 import functools
 import re
 import warnings
@@ -479,18 +479,25 @@ def create_projection_transform(projcode):
     return projklass(**projparams)
 
 
-def is_high_level(*args, low_level_wcs):
+def is_high_level(*args, low_level_wcs, frame="output"):
     """
     Determine if args matches the high level classes as defined by
     ``low_level_wcs``.
     """
-    if len(args) != len(low_level_wcs.world_axis_object_classes):
+    if frame == "output" and low_level_wcs.output_frame is not None:
+        object_classes = low_level_wcs.world_axis_object_classes
+    elif frame == "input" and low_level_wcs.input_frame is not None:
+        object_classes = low_level_wcs.input_axis_object_classes
+    else:
+        # raise ValueError(f"Unrecognized value for frame - {frame}")
+        return False
+    if len(args) != len(object_classes):
         return False
 
     type_match = [
         (type(arg), waoc[0])
         for arg, waoc in zip(
-            args, low_level_wcs.world_axis_object_classes.values(), strict=False
+            args, object_classes.values(), strict=False
         )
     ]
 
@@ -508,3 +515,213 @@ def is_high_level(*args, low_level_wcs):
         raise TypeError(msg)
 
     return False
+
+
+def high_level_objects_to_values(*world_objects, low_level_wcs, frame="output"):
+    """
+    Convert the input high level object to low level values.
+
+    This function uses the information in ``wcs.world_axis_object_classes`` and
+    ``wcs.world_axis_object_components`` to convert the high level objects
+    (such as `~.SkyCoord`) to low level "values" which should be scalars or
+    Numpy arrays.
+
+    This is used in `.HighLevelWCSMixin.world_to_pixel`, but provided as a
+    separate function for use in other places where needed.
+
+    Parameters
+    ----------
+    *world_objects: object
+        High level coordinate objects.
+
+    low_level_wcs: `.BaseLowLevelWCS`
+        The WCS object to use to interpret the coordinates.
+    """
+    # Cache the classes and components since this may be expensive
+    if frame == "output":
+        serialized_classes = low_level_wcs.world_axis_object_classes
+        components = low_level_wcs.world_axis_object_components
+    elif frame == "input":
+        serialized_classes = low_level_wcs.input_axis_object_classes
+        components = low_level_wcs.input_axis_object_components
+
+    # Deserialize world_axis_object_classes using the default order
+    classes = OrderedDict()
+    for key in default_order(components):
+        if low_level_wcs.serialized_classes:
+            classes[key] = deserialize_class(serialized_classes[key], construct=False)
+        else:
+            classes[key] = serialized_classes[key]
+
+    # Check that the number of classes matches the number of inputs
+    if len(world_objects) != len(classes):
+        raise ValueError(
+            f"Number of world inputs ({len(world_objects)}) does not match expected"
+            f" ({len(classes)})"
+        )
+
+    # Determine whether the classes are uniquely matched, that is we check
+    # whether there is only one of each class.
+    world_by_key = {}
+    unique_match = True
+    for w in world_objects:
+        matches = []
+        for key, (klass, *_) in classes.items():
+            if isinstance(w, klass):
+                matches.append(key)
+        if len(matches) == 1:
+            world_by_key[matches[0]] = w
+        else:
+            unique_match = False
+            break
+
+    # If the match is not unique, the order of the classes needs to match,
+    # whereas if all classes are unique, we can still intelligently match
+    # them even if the order is wrong.
+
+    objects = {}
+
+    if unique_match:
+        for key, (klass, args, kwargs, *rest) in classes.items():
+            if len(rest) == 0:
+                klass_gen = klass
+            elif len(rest) == 1:
+                klass_gen = rest[0]
+            else:
+                raise ValueError(
+                    "Tuples in world_axis_object_classes should have length 3 or 4"
+                )
+
+            # FIXME: For now SkyCoord won't auto-convert upon initialization
+            # https://github.com/astropy/astropy/issues/7689
+            from astropy.coordinates import SkyCoord
+
+            if isinstance(world_by_key[key], SkyCoord):
+                if "frame" in kwargs:
+                    objects[key] = world_by_key[key].transform_to(kwargs["frame"])
+                else:
+                    objects[key] = world_by_key[key]
+            else:
+                objects[key] = klass_gen(world_by_key[key], *args, **kwargs)
+
+    else:
+        for ikey, key in enumerate(classes):
+            klass, args, kwargs, *rest = classes[key]
+
+            if len(rest) == 0:
+                klass_gen = klass
+            elif len(rest) == 1:
+                klass_gen = rest[0]
+            else:
+                raise ValueError(
+                    "Tuples in world_axis_object_classes should have length 3 or 4"
+                )
+
+            w = world_objects[ikey]
+            if not isinstance(w, klass):
+                raise ValueError(
+                    "Expected the following order of world arguments:"
+                    f" {', '.join([k.__name__ for (k, *_) in classes.values()])}"
+                )
+
+            # FIXME: For now SkyCoord won't auto-convert upon initialization
+            # https://github.com/astropy/astropy/issues/7689
+            from astropy.coordinates import SkyCoord
+
+            if isinstance(w, SkyCoord):
+                if "frame" in kwargs:
+                    objects[key] = w.transform_to(kwargs["frame"])
+                else:
+                    objects[key] = w
+            else:
+                objects[key] = klass_gen(w, *args, **kwargs)
+
+    # We now extract the attributes needed for the world values
+    world = []
+    for key, _, attr in components:
+        if callable(attr):
+            world.append(attr(objects[key]))
+        else:
+            world.append(rec_getattr(objects[key], attr))
+
+    # Check the type of the return values - should be scalars or plain Numpy
+    # arrays, not e.g. Quantity. Note that we deliberately use type(w) because
+    # we don't want to match Numpy subclasses.
+    for w in world:
+        if not isinstance(w, numbers.Number) and not type(w) == np.ndarray:
+            raise TypeError(
+                f"WCS world_axis_object_components results in "
+                f"values which are not scalars or plain Numpy "
+                f"arrays (got {type(w)})"
+            )
+    return world
+
+
+def values_to_high_level_objects(*world_values, low_level_wcs, frame="output"):
+    """
+    Convert low level values into high level objects.
+
+    This function uses the information in ``wcs.world_axis_object_classes`` and
+    ``wcs.world_axis_object_components`` to convert low level "values"
+    `~.Quantity` objects, to high level objects (such as `~.SkyCoord`).
+
+    This is used in `.HighLevelWCSMixin.pixel_to_world`, but provided as a
+    separate function for use in other places where needed.
+
+    Parameters
+    ----------
+    *world_values: object
+        Low level, "values" representations of the world coordinates.
+
+    low_level_wcs: `.BaseLowLevelWCS`
+        The WCS object to use to interpret the coordinates.
+    """
+    # Check the type of the input values - should be scalars or plain Numpy
+    # arrays, not e.g. Quantity. Note that we deliberately use type(w) because
+    # we don't want to match Numpy subclasses.
+    for w in world_values:
+        if not isinstance(w, numbers.Number) and not type(w) == np.ndarray:
+            raise TypeError(
+                f"Expected world coordinates as scalars or plain Numpy "
+                f"arrays (got {type(w)})"
+            )
+    # Cache the classes and components since this may be expensive
+    if frame == "output":
+        components = low_level_wcs.world_axis_object_components
+        classes = low_level_wcs.world_axis_object_classes
+    elif frame == "input":
+        components = low_level_wcs.input_axis_object_components
+        classes = low_level_wcs.input_axis_object_classes
+
+    # Deserialize classes
+    if low_level_wcs.serialized_classes:
+        classes_new = {}
+        for key, value in classes.items():
+            classes_new[key] = deserialize_class(value, construct=False)
+        classes = classes_new
+
+    args = defaultdict(list)
+    kwargs = defaultdict(dict)
+
+    for i, (key, attr, _) in enumerate(components):
+        if isinstance(attr, str):
+            kwargs[key][attr] = world_values[i]
+        else:
+            while attr > len(args[key]) - 1:
+                args[key].append(None)
+            args[key][attr] = world_values[i]
+
+    result = []
+    for key in default_order(components):
+        klass, ar, kw, *rest = classes[key]
+        if len(rest) == 0:
+            klass_gen = klass
+        elif len(rest) == 1:
+            klass_gen = rest[0]
+        else:
+            raise ValueError(
+                "Tuples in world_axis_object_classes should have length 3 or 4"
+            )
+        result.append(klass_gen(*args[key], *ar, **kwargs[key], **kw))
+
+    return result

--- a/gwcs/utils.py
+++ b/gwcs/utils.py
@@ -3,7 +3,7 @@
 Utility function for WCS
 
 """
-from collections import OrderedDict, defaultdict
+
 import functools
 import re
 import warnings
@@ -479,12 +479,7 @@ def create_projection_transform(projcode):
     return projklass(**projparams)
 
 
-def is_high_level(
-    *args,
-    low_level_wcs,
-    object_classes=None,
-    object_components=None
-    ):
+def is_high_level(*args, low_level_wcs, object_classes=None, object_components=None):
     """
     Determine if args matches the high level classes as defined by
     ``low_level_wcs``.
@@ -496,9 +491,7 @@ def is_high_level(
 
     type_match = [
         (type(arg), waoc[0])
-        for arg, waoc in zip(
-            args, object_classes.values(), strict=False
-        )
+        for arg, waoc in zip(args, object_classes.values(), strict=False)
     ]
 
     types_are_high_level = [argt is t for argt, t in type_match]
@@ -515,213 +508,3 @@ def is_high_level(
         raise TypeError(msg)
 
     return False
-
-
-def high_level_objects_to_values(*world_objects, low_level_wcs, frame="output"):
-    """
-    Convert the input high level object to low level values.
-
-    This function uses the information in ``wcs.world_axis_object_classes`` and
-    ``wcs.world_axis_object_components`` to convert the high level objects
-    (such as `~.SkyCoord`) to low level "values" which should be scalars or
-    Numpy arrays.
-
-    This is used in `.HighLevelWCSMixin.world_to_pixel`, but provided as a
-    separate function for use in other places where needed.
-
-    Parameters
-    ----------
-    *world_objects: object
-        High level coordinate objects.
-
-    low_level_wcs: `.BaseLowLevelWCS`
-        The WCS object to use to interpret the coordinates.
-    """
-    # Cache the classes and components since this may be expensive
-    if frame == "output":
-        serialized_classes = low_level_wcs.world_axis_object_classes
-        components = low_level_wcs.world_axis_object_components
-    elif frame == "input":
-        serialized_classes = low_level_wcs.input_axis_object_classes
-        components = low_level_wcs.input_axis_object_components
-
-    # Deserialize world_axis_object_classes using the default order
-    classes = OrderedDict()
-    for key in default_order(components):
-        if low_level_wcs.serialized_classes:
-            classes[key] = deserialize_class(serialized_classes[key], construct=False)
-        else:
-            classes[key] = serialized_classes[key]
-
-    # Check that the number of classes matches the number of inputs
-    if len(world_objects) != len(classes):
-        raise ValueError(
-            f"Number of world inputs ({len(world_objects)}) does not match expected"
-            f" ({len(classes)})"
-        )
-
-    # Determine whether the classes are uniquely matched, that is we check
-    # whether there is only one of each class.
-    world_by_key = {}
-    unique_match = True
-    for w in world_objects:
-        matches = []
-        for key, (klass, *_) in classes.items():
-            if isinstance(w, klass):
-                matches.append(key)
-        if len(matches) == 1:
-            world_by_key[matches[0]] = w
-        else:
-            unique_match = False
-            break
-
-    # If the match is not unique, the order of the classes needs to match,
-    # whereas if all classes are unique, we can still intelligently match
-    # them even if the order is wrong.
-
-    objects = {}
-
-    if unique_match:
-        for key, (klass, args, kwargs, *rest) in classes.items():
-            if len(rest) == 0:
-                klass_gen = klass
-            elif len(rest) == 1:
-                klass_gen = rest[0]
-            else:
-                raise ValueError(
-                    "Tuples in world_axis_object_classes should have length 3 or 4"
-                )
-
-            # FIXME: For now SkyCoord won't auto-convert upon initialization
-            # https://github.com/astropy/astropy/issues/7689
-            from astropy.coordinates import SkyCoord
-
-            if isinstance(world_by_key[key], SkyCoord):
-                if "frame" in kwargs:
-                    objects[key] = world_by_key[key].transform_to(kwargs["frame"])
-                else:
-                    objects[key] = world_by_key[key]
-            else:
-                objects[key] = klass_gen(world_by_key[key], *args, **kwargs)
-
-    else:
-        for ikey, key in enumerate(classes):
-            klass, args, kwargs, *rest = classes[key]
-
-            if len(rest) == 0:
-                klass_gen = klass
-            elif len(rest) == 1:
-                klass_gen = rest[0]
-            else:
-                raise ValueError(
-                    "Tuples in world_axis_object_classes should have length 3 or 4"
-                )
-
-            w = world_objects[ikey]
-            if not isinstance(w, klass):
-                raise ValueError(
-                    "Expected the following order of world arguments:"
-                    f" {', '.join([k.__name__ for (k, *_) in classes.values()])}"
-                )
-
-            # FIXME: For now SkyCoord won't auto-convert upon initialization
-            # https://github.com/astropy/astropy/issues/7689
-            from astropy.coordinates import SkyCoord
-
-            if isinstance(w, SkyCoord):
-                if "frame" in kwargs:
-                    objects[key] = w.transform_to(kwargs["frame"])
-                else:
-                    objects[key] = w
-            else:
-                objects[key] = klass_gen(w, *args, **kwargs)
-
-    # We now extract the attributes needed for the world values
-    world = []
-    for key, _, attr in components:
-        if callable(attr):
-            world.append(attr(objects[key]))
-        else:
-            world.append(rec_getattr(objects[key], attr))
-
-    # Check the type of the return values - should be scalars or plain Numpy
-    # arrays, not e.g. Quantity. Note that we deliberately use type(w) because
-    # we don't want to match Numpy subclasses.
-    for w in world:
-        if not isinstance(w, numbers.Number) and not type(w) == np.ndarray:
-            raise TypeError(
-                f"WCS world_axis_object_components results in "
-                f"values which are not scalars or plain Numpy "
-                f"arrays (got {type(w)})"
-            )
-    return world
-
-
-def values_to_high_level_objects(*world_values, low_level_wcs, frame="output"):
-    """
-    Convert low level values into high level objects.
-
-    This function uses the information in ``wcs.world_axis_object_classes`` and
-    ``wcs.world_axis_object_components`` to convert low level "values"
-    `~.Quantity` objects, to high level objects (such as `~.SkyCoord`).
-
-    This is used in `.HighLevelWCSMixin.pixel_to_world`, but provided as a
-    separate function for use in other places where needed.
-
-    Parameters
-    ----------
-    *world_values: object
-        Low level, "values" representations of the world coordinates.
-
-    low_level_wcs: `.BaseLowLevelWCS`
-        The WCS object to use to interpret the coordinates.
-    """
-    # Check the type of the input values - should be scalars or plain Numpy
-    # arrays, not e.g. Quantity. Note that we deliberately use type(w) because
-    # we don't want to match Numpy subclasses.
-    for w in world_values:
-        if not isinstance(w, numbers.Number) and not type(w) == np.ndarray:
-            raise TypeError(
-                f"Expected world coordinates as scalars or plain Numpy "
-                f"arrays (got {type(w)})"
-            )
-    # Cache the classes and components since this may be expensive
-    if frame == "output":
-        components = low_level_wcs.world_axis_object_components
-        classes = low_level_wcs.world_axis_object_classes
-    elif frame == "input":
-        components = low_level_wcs.input_axis_object_components
-        classes = low_level_wcs.input_axis_object_classes
-
-    # Deserialize classes
-    if low_level_wcs.serialized_classes:
-        classes_new = {}
-        for key, value in classes.items():
-            classes_new[key] = deserialize_class(value, construct=False)
-        classes = classes_new
-
-    args = defaultdict(list)
-    kwargs = defaultdict(dict)
-
-    for i, (key, attr, _) in enumerate(components):
-        if isinstance(attr, str):
-            kwargs[key][attr] = world_values[i]
-        else:
-            while attr > len(args[key]) - 1:
-                args[key].append(None)
-            args[key][attr] = world_values[i]
-
-    result = []
-    for key in default_order(components):
-        klass, ar, kw, *rest = classes[key]
-        if len(rest) == 0:
-            klass_gen = klass
-        elif len(rest) == 1:
-            klass_gen = rest[0]
-        else:
-            raise ValueError(
-                "Tuples in world_axis_object_classes should have length 3 or 4"
-            )
-        result.append(klass_gen(*args[key], *ar, **kwargs[key], **kw))
-
-    return result

--- a/gwcs/wcs/_wcs.py
+++ b/gwcs/wcs/_wcs.py
@@ -407,7 +407,6 @@ class WCS(GWCSAPIMixin, Pipeline):
             input_is_quantity=input_is_quantity,
             transform_uses_quantity=transform_uses_quantity,
         )
-        print(f"args {args}")
         if transform is not None:
             akwargs = {k: v for k, v in kwargs.items() if k not in _ITER_INV_KWARGS}
             result = transform(*args, with_bounding_box=with_bounding_box, fill_value=fill_value, **akwargs)

--- a/gwcs/wcs/_wcs.py
+++ b/gwcs/wcs/_wcs.py
@@ -160,13 +160,25 @@ class WCS(GWCSAPIMixin, Pipeline):
             msg = "Transform is not defined."
             raise NotImplementedError(msg)
 
-        input_is_high_level = is_high_level(*args, low_level_wcs=self, frame="input")
+        if self.input_frame is not None:
+            input_is_high_level = is_high_level(
+                *args,
+                low_level_wcs=self,
+                object_classes=self.input_axis_object_classes,
+                object_components=self.input_axis_object_components)
+        else:
+            input_is_high_level = False
             # message = "High Level objects are not supported with the native API. \
             #            Please use the `pixel_to_world` method."
             # raise TypeError(message)
         input_is_quantity, transform_uses_quantity = self._units_are_present(args, transform)
         if input_is_high_level and not input_is_quantity:
-            args = high_level_objects_to_values(*args, low_level_wcs=self, frame="input")
+            args = high_level_objects_to_values(
+                *args,
+                low_level_wcs=self,
+                object_classes=self.input_axis_object_classes,
+                object_components=self.input_axis_object_components
+                )
 
         # input_is_quantity, transform_uses_quantity = self._units_are_present(args, transform)
         args = self._make_input_units_consistent(
@@ -361,7 +373,16 @@ class WCS(GWCSAPIMixin, Pipeline):
         except NotImplementedError:
             transform = None
             # TODO raise error?
-        input_is_high_level = is_high_level(*args, low_level_wcs=self, frame="output")
+
+        if self.output_frame is not None:
+            input_is_high_level = is_high_level(
+                *args,
+                low_level_wcs=self,
+                object_classes=self.world_axis_object_classes,
+                object_components=self.world_axis_object_components
+                )
+        else:
+            input_is_high_level = False
             # args = high_level_objects_to_values(*args, low_level_wcs=self)
             # message = "High Level objects are not supported with the native API. \
             #            Please use the `world_to_pixel` method."
@@ -369,7 +390,12 @@ class WCS(GWCSAPIMixin, Pipeline):
 
         input_is_quantity, transform_uses_quantity = self._units_are_present(args, transform)
         if input_is_high_level: # and not input_is_quantity:
-            args = high_level_objects_to_values(*args, low_level_wcs=self, frame="output")
+            args = high_level_objects_to_values(
+                *args,
+                low_level_wcs=self,
+                object_classes=self.world_axis_object_classes,
+                object_components=self.world_axis_object_components
+                )
 
         if with_bounding_box and self.bounding_box is not None:
             args = self.outside_footprint(args)
@@ -381,6 +407,7 @@ class WCS(GWCSAPIMixin, Pipeline):
             input_is_quantity=input_is_quantity,
             transform_uses_quantity=transform_uses_quantity,
         )
+        print(f"args {args}")
         if transform is not None:
             akwargs = {k: v for k, v in kwargs.items() if k not in _ITER_INV_KWARGS}
             result = transform(*args, with_bounding_box=with_bounding_box, fill_value=fill_value, **akwargs)
@@ -408,7 +435,12 @@ class WCS(GWCSAPIMixin, Pipeline):
         )
         if input_is_high_level and not input_is_quantity:
             # values_to_hlo expects as input numbers or arrays
-            result = values_to_high_level_objects(*result, low_level_wcs=self, frame="input")
+            result = values_to_high_level_objects(
+                *result,
+                low_level_wcs=self,
+                object_classes=self.input_axis_object_classes,
+                object_components=self.input_axis_object_components
+                )
         if self.input_frame.naxes == 1:
             return result[0]
         return result
@@ -420,7 +452,12 @@ class WCS(GWCSAPIMixin, Pipeline):
         axes_phys_types = self.world_axis_physical_types
         footprint = self.footprint()
         not_numerical = False
-        if is_high_level(world_arrays[0], low_level_wcs=self, frame="output"):
+        if is_high_level(
+            world_arrays[0],
+            low_level_wcs=self,
+            object_classes=self.world_axis_object_classes,
+            object_components=self.world_axis_object_components
+            ):
             not_numerical = True
             world_arrays = high_level_objects_to_values(
                 *world_arrays, low_level_wcs=self

--- a/gwcs/wcs/_wcs.py
+++ b/gwcs/wcs/_wcs.py
@@ -29,6 +29,7 @@ from gwcs.coordinate_frames import (
     CelestialFrame,
     CompositeFrame,
     CoordinateFrame,
+    EmptyFrame,
     get_ctype_from_ucd,
 )
 from gwcs.utils import _compute_lon_pole, is_high_level, to_index
@@ -157,41 +158,135 @@ class WCS(GWCSAPIMixin, Pipeline):
         if transform is None:
             msg = "Transform is not defined."
             raise NotImplementedError(msg)
+        # move this to an evaluate_funciton, called by forward, transform and invert
+        # input_is_quantity = any(isinstance(a, u.Quantity) for a in args)
+        # transform_uses_quantity = not (transform is None or not transform.uses_quantity)
+
+        input_is_quantity, transform_uses_quantity = self._units_are_present(args, transform)
         args = self._make_input_units_consistent(
+            transform,
             *args,
-            transform=transform,
-            from_frame=self.input_frame,
-            to_frame=self.output_frame,
+            frame=self.input_frame,
+            input_is_quantity=input_is_quantity,
+            transform_uses_quantity=transform_uses_quantity,
         )
 
-        return self._call_forward(
-            *args, with_bounding_box=with_bounding_box, fill_value=fill_value, **kwargs
-        )
+        result = transform(*args, with_bounding_box=with_bounding_box, fill_value=fill_value, **kwargs)
+        if self.output_frame is not None:
+            if self.output_frame.naxes == 1:
+                result = (result,)
+            result = self._make_output_units_consistent(
+                transform,
+                *result,
+                frame=self.output_frame,
+                input_is_quantity=input_is_quantity,
+                transform_uses_quantity=transform_uses_quantity,
+            )
+        if self.output_frame is not None and self.output_frame.naxes == 1:
+            return result[0]
+        return result
+
+    def _units_are_present(self, args, transform):
+        """
+        Determing if the inputs to a transform are quantities and the transform
+        supports units.
+
+        Parameters
+        ----------
+        args : a tuple of scalars or ndarray-like objects
+            Inputs to a transform.
+        transform : `~astropy.modeling.Model`
+            Transform to be evaluated.
+
+        Returns
+        -------
+        input_is_quantity, transform_uses_quantity : bool
+
+        """
+        # Validate that the input type matches what the transform expects
+        input_is_quantity = any(isinstance(a, u.Quantity) for a in args)
+        transform_uses_quantity = not (transform is None or not transform.uses_quantity)
+        return input_is_quantity, transform_uses_quantity
+
 
     def _make_input_units_consistent(
         self,
-        *args,
         transform,
-        from_frame: CoordinateFrame | None = None,
-        to_frame: CoordinateFrame | None = None,
+        *args,
+        frame: CoordinateFrame | None = None,
+        input_is_quantity=False,
+        transform_uses_quantity=False,
         **kwargs,
     ):
         """
         Adds or removes units from the arguments as needed so that the transform
         can be successfully evaluated.
         """
-        # Validate that the input type matches what the transform expects
-        input_is_quantity = any(isinstance(a, u.Quantity) for a in args)
-        transform_uses_quantity = not (transform is None or not transform.uses_quantity)
-        if (
+        # # Validate that the input type matches what the transform expects
+        # input_is_quantity = any(isinstance(a, u.Quantity) for a in args)
+        # transform_uses_quantity = not (transform is None or not transform.uses_quantity)
+        if not input_is_quantity and not transform_uses_quantity:
+            return args
+        elif input_is_quantity and transform_uses_quantity:
+            return args
+        elif (
             not input_is_quantity
-            and transform_uses_quantity
-            and transform.parameters.size
+            and (transform_uses_quantity
+            or transform.parameters.size) # possibly remove this, check is in _units_are_present
         ):
-            return self._add_units_input(args, from_frame)
-        if not transform_uses_quantity and input_is_quantity:
-            return self._remove_units_input(args, from_frame)
-        return args
+            return self._add_units_input(args, frame)
+        elif not transform_uses_quantity and input_is_quantity:
+            return self._remove_units_input(args, frame)
+        #return args
+
+    def _make_output_units_consistent(
+        self,
+        transform,
+        *args,
+        frame: CoordinateFrame | None = None,
+        input_is_quantity=False,
+        transform_uses_quantity=False,
+        **kwargs,
+    ):
+        """
+        Adds or removes units from the arguments as needed so that the type of the output
+        matches the input.
+        """
+        if not input_is_quantity and not transform_uses_quantity:
+            return args
+
+        elif input_is_quantity and transform_uses_quantity:
+            # make sure the output is returned in the units of the output frame
+            return self._add_units_input(args, frame)
+        elif (
+            not input_is_quantity
+            and (transform_uses_quantity
+            or transform.parameters.size)
+        ):
+            result = self._remove_units_input(args, frame)
+        elif not transform_uses_quantity and input_is_quantity:
+            result = self._add_units_input(args, frame)
+        return result
+
+    def _get_transform(
+        self,
+        *args,
+        from_frame: CoordinateFrame | None = None,
+        to_frame: CoordinateFrame | None = None,
+        **kwargs,
+    ):
+        """
+        Executes the forward transform, but values only.
+        """
+        if from_frame is None and to_frame is None:
+            transform = self.forward_transform
+        else:
+            transform = self.get_transform(from_frame, to_frame)
+
+        if transform is None:
+            msg = "WCS.forward_transform is not implemented."
+            raise NotImplementedError(msg)
+        return transform
 
     def _evaluate_transform(
         self,
@@ -260,41 +355,6 @@ class WCS(GWCSAPIMixin, Pipeline):
                 return _transform(*self._add_units_input(args, from_frame))
 
             raise
-
-    def _call_forward(
-        self,
-        *args,
-        from_frame: CoordinateFrame | None = None,
-        to_frame: CoordinateFrame | None = None,
-        with_bounding_box: bool = True,
-        fill_value: float | np.number = np.nan,
-        **kwargs,
-    ):
-        """
-        Executes the forward transform, but values only.
-        """
-        if from_frame is None and to_frame is None:
-            transform = self.forward_transform
-        else:
-            transform = self.get_transform(from_frame, to_frame)
-        if from_frame is None:
-            from_frame = self.input_frame
-        if to_frame is None:
-            to_frame = self.output_frame
-
-        if transform is None:
-            msg = "WCS.forward_transform is not implemented."
-            raise NotImplementedError(msg)
-
-        return self._evaluate_transform(
-            transform,
-            from_frame,
-            to_frame,
-            *args,
-            with_bounding_box=with_bounding_box,
-            fill_value=fill_value,
-            **kwargs,
-        )
 
     def in_image(self, *args, **kwargs):
         """
@@ -380,46 +440,28 @@ class WCS(GWCSAPIMixin, Pipeline):
             transform = self.backward_transform
         except NotImplementedError:
             transform = None
+            # TODO raise error?
         if is_high_level(*args, low_level_wcs=self):
-            args = high_level_objects_to_values(*args, low_level_wcs=self)
-        args = self._make_input_units_consistent(
-            *args,
-            transform=transform,
-            from_frame=self.output_frame,
-            to_frame=self.input_frame,
-        )
-
-        return self._call_backward(
-            *args, with_bounding_box=with_bounding_box, fill_value=fill_value, **kwargs
-        )
-
-    def _call_backward(
-        self,
-        *args,
-        with_bounding_box: bool = True,
-        fill_value: float | np.number = np.nan,
-        **kwargs,
-    ):
-        try:
-            transform = self.backward_transform
-        except NotImplementedError:
-            transform = None
+            # args = high_level_objects_to_values(*args, low_level_wcs=self)
+            message = "High Level objects are not supported with the native API. \
+                       Please use the `world_to_pixel` method."
+            raise TypeError(message)
 
         if with_bounding_box and self.bounding_box is not None:
             args = self.outside_footprint(args)
 
+        input_is_quantity, transform_uses_quantity = self._units_are_present(args, transform)
+
+        args = self._make_input_units_consistent(
+            transform,
+            *args,
+            frame=self.output_frame,
+            input_is_quantity=input_is_quantity,
+            transform_uses_quantity=transform_uses_quantity,
+        )
         if transform is not None:
-            # remove iterative inverse-specific keyword arguments:
             akwargs = {k: v for k, v in kwargs.items() if k not in _ITER_INV_KWARGS}
-            result = self._evaluate_transform(
-                transform,
-                self.output_frame,
-                self.input_frame,
-                *args,
-                with_bounding_box=with_bounding_box,
-                fill_value=fill_value,
-                **akwargs,
-            )
+            result = transform(*args, with_bounding_box=with_bounding_box, fill_value=fill_value, **akwargs)
         else:
             # Always strip units for numerical inverse
             args = self._remove_units_input(args, self.output_frame)
@@ -430,10 +472,20 @@ class WCS(GWCSAPIMixin, Pipeline):
                 **kwargs,
             )
 
-        # deal with values outside the bounding box
         if with_bounding_box and self.bounding_box is not None:
             result = self.out_of_bounds(result, fill_value=fill_value)
 
+        if self.input_frame.naxes == 1:
+            result = (result,)
+        result = self._make_output_units_consistent(
+            transform,
+            *result,
+            frame=self.input_frame,
+            input_is_quantity=input_is_quantity,
+            transform_uses_quantity=transform_uses_quantity,
+        )
+        if self.input_frame.naxes == 1:
+            return result[0]
         return result
 
     def outside_footprint(self, world_arrays):
@@ -1175,16 +1227,41 @@ class WCS(GWCSAPIMixin, Pipeline):
         to_step = self._get_step(to_frame)
         transform = self.get_transform(from_step.step.frame, to_step.step.frame)
 
-        if not transform.uses_quantity and is_high_level(
-            *args, low_level_wcs=from_step.step.frame
-        ):
-            args = high_level_objects_to_values(
-                *args, low_level_wcs=from_step.step.frame
-            )
+        with_bounding_box = kwargs.get("with_bounding_box", None)
+        fill_value = kwargs.get("fill_value", np.nan)
 
-        return self._evaluate_transform(
-            transform, from_step.step.frame, to_step.step.frame, *args, **kwargs
+        # If frames are of type ``str``, set the object to ``None``.
+        from_frame_obj = getattr(self, from_frame) if isinstance(from_frame, str) else from_frame
+        if isinstance(from_frame_obj, EmptyFrame):
+            from_frame_obj = None
+
+        to_frame_obj = getattr(self, to_frame) if isinstance(to_frame, str) else to_frame
+        if isinstance(to_frame_obj, EmptyFrame):
+            to_frame_obj = None
+
+        input_is_quantity, transform_uses_quantity = self._units_are_present(args, transform)
+        args = self._make_input_units_consistent(
+            transform,
+            *args,
+            frame=from_frame_obj,
+            input_is_quantity=input_is_quantity,
+            transform_uses_quantity=transform_uses_quantity,
         )
+
+        result = transform(*args, with_bounding_box=with_bounding_box, fill_value=fill_value, **kwargs)
+        if to_frame_obj is not None:
+            if to_frame_obj.naxes == 1:
+                result = (result,)
+            result = self._make_output_units_consistent(
+                transform,
+                *result,
+                frame=to_frame_obj,
+                input_is_quantity=input_is_quantity,
+                transform_uses_quantity=transform_uses_quantity,
+            )
+        if self.output_frame is not None and self.output_frame.naxes == 1:
+            return result[0]
+        return result
 
     @property
     def name(self) -> str:

--- a/gwcs/wcs/_wcs.py
+++ b/gwcs/wcs/_wcs.py
@@ -164,23 +164,19 @@ class WCS(GWCSAPIMixin, Pipeline):
             input_is_high_level = is_high_level(
                 *args,
                 low_level_wcs=self,
-                object_classes=self.input_axis_object_classes,
-                object_components=self.input_axis_object_components)
+                object_classes=self.input_frame.world_axis_object_classes,
+                object_components=self.input_frame.world_axis_object_components)
         else:
             input_is_high_level = False
-            # message = "High Level objects are not supported with the native API. \
-            #            Please use the `pixel_to_world` method."
-            # raise TypeError(message)
         input_is_quantity, transform_uses_quantity = self._units_are_present(args, transform)
         if input_is_high_level and not input_is_quantity:
             args = high_level_objects_to_values(
                 *args,
                 low_level_wcs=self,
-                object_classes=self.input_axis_object_classes,
-                object_components=self.input_axis_object_components
+                object_classes=self.input_frame.world_axis_object_classes,
+                object_components=self.input_frame.world_axis_object_components
                 )
 
-        # input_is_quantity, transform_uses_quantity = self._units_are_present(args, transform)
         args = self._make_input_units_consistent(
             transform,
             *args,
@@ -372,7 +368,6 @@ class WCS(GWCSAPIMixin, Pipeline):
             transform = self.backward_transform
         except NotImplementedError:
             transform = None
-            # TODO raise error?
 
         if self.output_frame is not None:
             input_is_high_level = is_high_level(
@@ -383,13 +378,9 @@ class WCS(GWCSAPIMixin, Pipeline):
                 )
         else:
             input_is_high_level = False
-            # args = high_level_objects_to_values(*args, low_level_wcs=self)
-            # message = "High Level objects are not supported with the native API. \
-            #            Please use the `world_to_pixel` method."
-            #raise TypeError(message)
 
         input_is_quantity, transform_uses_quantity = self._units_are_present(args, transform)
-        if input_is_high_level: # and not input_is_quantity:
+        if input_is_high_level:
             args = high_level_objects_to_values(
                 *args,
                 low_level_wcs=self,
@@ -433,12 +424,11 @@ class WCS(GWCSAPIMixin, Pipeline):
             transform_uses_quantity=transform_uses_quantity,
         )
         if input_is_high_level and not input_is_quantity:
-            # values_to_hlo expects as input numbers or arrays
             result = values_to_high_level_objects(
                 *result,
                 low_level_wcs=self,
-                object_classes=self.input_axis_object_classes,
-                object_components=self.input_axis_object_components
+                object_classes=self.input_frame.world_axis_object_classes,
+                object_components=self.input_frame.world_axis_object_components
                 )
         if self.input_frame.naxes == 1:
             return result[0]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,8 @@ authors = [
 ]
 dependencies = [
     "asdf >= 3.3.0",
-    "astropy >= 6.0",
+    # "astropy >= 6.0",
+    astropy @ git+https://github.com/nden/astropy.git@wcsapi-hov
     "numpy>=1.25",
     "scipy>=1.14.1",
     "asdf_wcs_schemas >= 0.5.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ authors = [
 dependencies = [
     "asdf >= 3.3.0",
     # "astropy >= 6.0",
-    astropy @ git+https://github.com/nden/astropy.git@wcsapi-hov
+    "astropy @ git+https://github.com/nden/astropy.git@wcsapi-hov",
     "numpy>=1.25",
     "scipy>=1.14.1",
     "asdf_wcs_schemas >= 0.5.0",


### PR DESCRIPTION
JWST regression tests: https://github.com/spacetelescope/RegressionTests/actions/runs/20268196432
Roman regression tests: https://github.com/spacetelescope/RegressionTests/actions/runs/20270632739/job/58206279655
The failing Roman test matches the failure on main.

The romanisim failure is due to a mixup of units in romanisim and galsim. This PR enforces unit conversion and revealed the issue. Fix is in https://github.com/spacetelescope/romanisim/pull/290

This is an alternative to #660. #660 ensures the return type is the same as the input type but does not allow using high level objects (HLO) with the legacy functions. This PR removes the restriction. A summary:

| type of inputs    | #660                   | #662| 
|---------------- |----------------- |-------------------|
| numerical           | Return numbers | Return numbers.   |  
| quantities           | Return quantities | Return quantities |
| HLO.                   | Raise an error     | Return HLO. |

A typical example showing the difference between the two PRs is below. Note that HLO is by definition the type defined in `wcs.world_axis_object_components`.

```
from gwcs import examples
w=examples.gwcs_with_pipeline_celestial()
w.forward_transform.uses_quantity
Out[3]: True

sky=w.pixel_to_world(1,1)
print(sky) # HLO is defined as Quantities
[<Quantity 3620. arcsec>, <Quantity 61200. arcsec>]
``` 
With #660 
```
w.invert(*sky)
TypeError: High Level objects are not supported with the native API.                        
Please use the `world_to_pixel` method.
```
With #662
```
w.invert(*sky)
(<Quantity 1. pix>, <Quantity 1. pix>)
```

Example 2:
```
w=examples.gwcs_spec_cel_time_4d()
w.forward_transform.uses_quantity
Out[16]: False

world=w.pixel_to_world(1,1,1,1)
print(world)
[<SpectralCoord 5.2 m>, <SkyCoord (ICRS): (ra, dec) in deg
    (5.62930741, -72.0499035)>, <Time object: scale='utc' format='isot' value=2010-01-01T00:00:01.000>]
```

With #660 
```
w.invert(*sky)
TypeError: High Level objects are not supported with the native API.                        
Please use the `world_to_pixel` method.
```

With #662
```
w.invert(*world)
Out[19]: (<Quantity 1. pix>, <Quantity 1. pix>, <Quantity 1. pix>, <Quantity 1. pix>)
```
