### PR TITLE
[SCSB-225] migrate `[tool.pytest.ini_options]` to native TOML

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ docs = [
 ]
 test = [
     "ci-watson>=0.3.0",
-    "pytest>=8.0.0",
+    "pytest>=9.0",
     "pytest-astropy>=0.11.0",
 ]
 
@@ -75,10 +75,10 @@ all_files = "1"
 upload-dir = "docs/_build/html"
 show-response = 1
 
-[tool.pytest.ini_options]
-minversion = "8"
-doctest_plus = true
-doctest_rst = true
+[tool.pytest]
+minversion = "9.0"
+doctest_plus = "enabled"
+doctest_rst = "enabled"
 text_file_format = "rst"
 log_cli_level = "INFO"
 xfail_strict = true


### PR DESCRIPTION
Resolves [SCSB-225](https://jira.stsci.edu/browse/SCSB-225)

Pytest 9.0 includes a native TOML table `[tool.pytest]`, which we should use instead of `[tool.pytest.ini_options]`