### PR TITLE
Allow generating a HLO from intermediate frames

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,8 @@
 
 - Adjust and fix tests. Replace ``logging`` with `warnings``. [#659]
 
+- Update the legacy API. [#660]
+
 0.26.1 (2025-11-19)
 -------------------
 - Fix an indexing bug in ``spectroscopy.SellmeierZemax`` where the output ``n`` for array-type wavelength

--- a/gwcs/api.py
+++ b/gwcs/api.py
@@ -66,14 +66,13 @@ class GWCSAPIMixin(BaseLowLevelWCS, HighLevelWCSMixin):
         return tuple(unit.to_string(format="vounit") for unit in self.output_frame.unit)
 
     def _remove_quantity_output(self, result, frame):
-        if self.forward_transform.uses_quantity:
-            if frame.naxes == 1:
-                result = [result]
+        if frame.naxes == 1:
+            result = [result]
 
-            result = tuple(
-                r.to_value(unit) if isinstance(r, u.Quantity) else r
-                for r, unit in zip(result, frame.unit, strict=False)
-            )
+        result = tuple(
+            r.to_value(unit) if isinstance(r, u.Quantity) else r
+            for r, unit in zip(result, frame.unit, strict=False)
+        )
 
         # If we only have one output axes, we shouldn't return a tuple.
         if self.output_frame.naxes == 1 and isinstance(result, tuple):
@@ -94,7 +93,6 @@ class GWCSAPIMixin(BaseLowLevelWCS, HighLevelWCSMixin):
         is the vertical coordinate.
         """
         result = self(*pixel_arrays)
-
         return self._remove_quantity_output(result, self.output_frame)
 
     def array_index_to_world_values(self, *index_arrays):

--- a/gwcs/coordinate_frames/_base.py
+++ b/gwcs/coordinate_frames/_base.py
@@ -144,8 +144,7 @@ class BaseCoordinateFrame(abc.ABC):
         if self.naxes == 1 and (np.isscalar(arrays) or isinstance(arrays, u.Quantity)):
             arrays = (arrays,)
 
-        result = tuple(
+        return tuple(
             array.to_value(unit) if isinstance(array, u.Quantity) else array
             for array, unit in zip(arrays, self.unit, strict=True)
         )
-        return result

--- a/gwcs/coordinate_frames/_base.py
+++ b/gwcs/coordinate_frames/_base.py
@@ -128,6 +128,8 @@ class BaseCoordinateFrame(abc.ABC):
         """
         Add units to the arrays
         """
+        if self.naxes == 1 and np.isscalar(arrays):
+            return u.Quantity(arrays, self.unit[0])
         return tuple(
             u.Quantity(array, unit=unit)
             for array, unit in zip(arrays, self.unit, strict=True)
@@ -139,10 +141,11 @@ class BaseCoordinateFrame(abc.ABC):
         """
         Remove units from the input arrays
         """
-        if self.naxes == 1:
+        if self.naxes == 1 and (np.isscalar(arrays) or isinstance(arrays, u.Quantity)):
             arrays = (arrays,)
 
-        return tuple(
+        result = tuple(
             array.to_value(unit) if isinstance(array, u.Quantity) else array
             for array, unit in zip(arrays, self.unit, strict=True)
         )
+        return result

--- a/gwcs/examples.py
+++ b/gwcs/examples.py
@@ -742,3 +742,18 @@ def gwcs_2d_spatial_shift_reverse():
     """
     pipe = [(ICRC_SKY_FRAME, MODEL_2D_SHIFT), (DETECTOR_2D_FRAME, None)]
     return wcs.WCS(pipe)
+
+
+def gwcs_multi_stage():
+    """
+    A 3-step pipeline where the intermediate step is 1D and the final is 2D.
+    """
+    tr1 = models.Shift(10)
+    tr2 = models.Mapping((0, 0)) | models.Scale(-2) & models.Scale(-1)
+    det=cf.CoordinateFrame(name='detector', naxes=1, unit=('pix',),
+        axes_type='SPATIAL', axes_order=(0,))
+    interm = cf.CoordinateFrame(name='interm', naxes=1, unit=('m',),
+        axes_type='SPATIAL', axes_order=(0,))
+    cel = cf.CelestialFrame(name='sky', axes_names=('ra', 'dec'))
+    w = wcs.WCS([(det, tr1), (interm, tr2),(cel, None)])
+    return w

--- a/gwcs/examples.py
+++ b/gwcs/examples.py
@@ -410,7 +410,7 @@ def gwcs_spec_cel_time_4d():
     wcslin = models.Mapping((1, 0)) | (offx & offy) | aff
     tan = models.Pix2Sky_TAN(name="tangent_projection")
     n2c = models.RotateNative2Celestial(*crval, 180, name="sky_rotation")
-    cel_model = wcslin | tan | n2c
+    cel_model = wcslin | tan | n2c | models.Mapping((1, 0))
     icrs = cf.CelestialFrame(
         reference_frame=coord.ICRS(), name="sky", axes_order=(2, 1)
     )
@@ -734,3 +734,11 @@ def fits_wcs_imaging_simple(params):
         w.wcs.lonpole = 180
     w.wcs.set()
     return gw, w
+
+
+def gwcs_2d_spatial_shift_reverse():
+    """
+    A simple one step spatial WCS with forward from sky to detector.
+    """
+    pipe = [(ICRC_SKY_FRAME, MODEL_2D_SHIFT), (DETECTOR_2D_FRAME, None)]
+    return wcs.WCS(pipe)

--- a/gwcs/examples.py
+++ b/gwcs/examples.py
@@ -750,10 +750,12 @@ def gwcs_multi_stage():
     """
     tr1 = models.Shift(10)
     tr2 = models.Mapping((0, 0)) | models.Scale(-2) & models.Scale(-1)
-    det=cf.CoordinateFrame(name='detector', naxes=1, unit=('pix',),
-        axes_type='SPATIAL', axes_order=(0,))
-    interm = cf.CoordinateFrame(name='interm', naxes=1, unit=('m',),
-        axes_type='SPATIAL', axes_order=(0,))
-    cel = cf.CelestialFrame(name='sky', axes_names=('ra', 'dec'))
-    w = wcs.WCS([(det, tr1), (interm, tr2),(cel, None)])
+    det = cf.CoordinateFrame(
+        name="detector", naxes=1, unit=("pix",), axes_type="SPATIAL", axes_order=(0,)
+    )
+    interm = cf.CoordinateFrame(
+        name="interm", naxes=1, unit=("m",), axes_type="SPATIAL", axes_order=(0,)
+    )
+    cel = cf.CelestialFrame(name="sky", axes_names=("ra", "dec"))
+    w = wcs.WCS([(det, tr1), (interm, tr2), (cel, None)])
     return w

--- a/gwcs/examples.py
+++ b/gwcs/examples.py
@@ -757,5 +757,4 @@ def gwcs_multi_stage():
         name="interm", naxes=1, unit=("m",), axes_type="SPATIAL", axes_order=(0,)
     )
     cel = cf.CelestialFrame(name="sky", axes_names=("ra", "dec"))
-    w = wcs.WCS([(det, tr1), (interm, tr2), (cel, None)])
-    return w
+    return wcs.WCS([(det, tr1), (interm, tr2), (cel, None)])

--- a/gwcs/tests/conftest.py
+++ b/gwcs/tests/conftest.py
@@ -174,3 +174,8 @@ def gwcs_romanisim():
 def fits_wcs_imaging_simple(request):
     params = request.param
     return examples.fits_wcs_imaging_simple(params)
+
+
+@pytest.fixture
+def gwcs_2d_spatial_shift_reverse():
+    return examples.gwcs_2d_spatial_shift_reverse()

--- a/gwcs/tests/conftest.py
+++ b/gwcs/tests/conftest.py
@@ -179,3 +179,8 @@ def fits_wcs_imaging_simple(request):
 @pytest.fixture
 def gwcs_2d_spatial_shift_reverse():
     return examples.gwcs_2d_spatial_shift_reverse()
+
+
+@pytest.fixture
+def gwcs_multi_stage():
+    return examples.gwcs_multi_stage()

--- a/gwcs/tests/test_api.py
+++ b/gwcs/tests/test_api.py
@@ -328,7 +328,8 @@ def test_high_level_wrapper(wcsobj, request):
     pix_out1 = hlvl.world_to_pixel(*wc1)
     np.testing.assert_allclose(pix_out1, pixel_input)
     with pytest.raises(TypeError) as e:
-        pix_out2 = wcsobj.invert(*wc1)
+        _ = wcsobj.invert(*wc1)
+    assert "High Level objects are not supported with the native" in str(e)
 
 
 def test_stokes_wrapper(gwcs_stokes_lookup):
@@ -591,7 +592,7 @@ def test_coordinate_frame_api():
     assert isinstance(pixel, float)
 
     with pytest.raises(TypeError):
-        pixel2 = wcs.invert(world)
+        _ = wcs.invert(world)
 
 
 def test_world_axis_object_components_units(gwcs_3d_identity_units):

--- a/gwcs/tests/test_api.py
+++ b/gwcs/tests/test_api.py
@@ -402,6 +402,7 @@ def test_pixel_bounds(wcsobj):
     # Reset the bounding box or this will affect other tests
     wcsobj.bounding_box = None
 
+
 @wcs_objs
 def test_axis_correlation_matrix(wcsobj):
     assert_array_equal(wcsobj.axis_correlation_matrix, np.identity(2))

--- a/gwcs/tests/test_api_consistent.py
+++ b/gwcs/tests/test_api_consistent.py
@@ -272,3 +272,6 @@ def test_reverse_wcs_direction(gwcs_2d_spatial_shift_reverse):
 def test_transfrom_intermediate_1d(gwcs_multi_stage):
     wcsobj = gwcs_multi_stage
     assert wcsobj.transform("detector", "interm", 1) == 11.0
+
+    assert wcsobj.transform("detector", "interm", 1, hlo=False) == 11.0
+    wcsobj.transform("detector", "interm", 1, hlo=True) == 11.0 * u.m

--- a/gwcs/tests/test_api_consistent.py
+++ b/gwcs/tests/test_api_consistent.py
@@ -2,26 +2,24 @@
 """
 Test the API is consistent with units and quantities and follows the rules below.
 
-WCS functions which considered for this work are part of the legacy API:
-wcs(x, y)
-wcs.invert(ra, dec)
-wcs.forward_transform(x,y), wcs.backward_transform() and wcs.get_transform(f1, f2)
-wcs.numerical_inverse(ra, dec) - does not support units
+WCS functions considered part of the legacy API:
+wcs()
+wcs.invert()
+wcs.transform()
 
 Rules:
 
 
 1. Neither transforms nor inputs support units -> the output is clearly numerical
    for all functions above
-2. Transforms support units but inputs do not -> return quantities assuming the
-   units of the coordinate frame
-  - This should work for the wcs methods (wcs(x,y) and wcs.invert
-  - The methods using transforms should follow modeling rules and will require units
-    on the input and raise an exception if not
+2. Transforms support units but inputs do not -> return numbers/arrays
+   Attach the units of the input coordinate frame to the inputs.
+   Evaluate the transforms and strip the output of units
 3. Both transforms and inputs support units -> return quantities
-  - Wcs methods return quantities
-  - Transforms work and return quantities
-4. Transforms do not support units but inputs are quantities -> raise an error
+4. Transforms do not support units but inputs are quantities -> return quantities
+   Strip the units from the inputs after converting to the units of the input frame.
+   Evaluate the transform and attach the units of the output frame.
+5. Inputs are High Level Objects - raise an error
 
 """
 

--- a/gwcs/tests/test_api_consistent.py
+++ b/gwcs/tests/test_api_consistent.py
@@ -267,3 +267,8 @@ def test_reverse_wcs_direction(gwcs_2d_spatial_shift_reverse):
         wcsobj(1 * u.arcsec, 2 * u.arcsec),
         wcsobj(1 * u.arcsec.to(u.deg) * u.deg, 2 * u.arcsec.to(u.deg) * u.deg),
     )
+
+
+def test_transfrom_intermediate_1d(gwcs_multi_stage):
+    wcsobj = gwcs_multi_stage
+    assert wcsobj.transform("detector", "interm", 1) == 11.0

--- a/gwcs/tests/test_api_consistent.py
+++ b/gwcs/tests/test_api_consistent.py
@@ -38,13 +38,13 @@ yq = 2 * u.pix
 
 
 def is_numerical(args):
-    if isinstance(args, numbers.Number):
-        return True
-    return all([isinstance(arg, numbers.Number) or arg is np.ndarray for arg in args])
+    return isinstance(args, numbers.Number) or all(
+        isinstance(arg, numbers.Number) or arg is np.ndarray for arg in args
+    )
 
 
 def is_quantity(args):
-    return all([isinstance(arg, u.Quantity) for arg in args])
+    return all(isinstance(arg, u.Quantity) for arg in args)
 
 
 @pytest.fixture
@@ -143,9 +143,10 @@ def test_no_units_nd(wcsobj):
     sky = wcsobj.pixel_to_world(*inp)
     if not np.iterable(sky):
         sky = (sky,)
-    with pytest.raises(TypeError) as e:
-        inv_sky = wcsobj.invert(*sky)
-    assert "High Level objects are not supported with the native" in str(e)
+    with pytest.raises(
+        TypeError, match=r"High Level objects are not supported with the native"
+    ):
+        wcsobj.invert(*sky)
 
 
 @wcs_with_unit_1d
@@ -184,15 +185,16 @@ def test_transform_with_units(wcsobj):
     # input is quantities, return quantities
     xxq = [1 * u.pix] * n_inputs
     result = wcsobj(*xxq)
-    assert all([type(res) is u.Quantity for res in result])
+    assert all(type(res) is u.Quantity for res in result)
     assert_allclose([r.value for r in result], result_num)
 
     sky = wcsobj.pixel_to_world(*xxq)
     if not np.iterable(sky):
         sky = (sky,)
-    with pytest.raises(TypeError) as e:
-        inv_sky = wcsobj.invert(*sky)
-    assert "High Level objects are not supported with the native" in str(e)
+    with pytest.raises(
+        TypeError, match=r"High Level objects are not supported with the native"
+    ):
+        wcsobj.invert(*sky)
 
 
 @wcs_no_unit_1d

--- a/gwcs/tests/test_api_consistent.py
+++ b/gwcs/tests/test_api_consistent.py
@@ -42,7 +42,6 @@ yq = 2 * u.pix
 def is_numerical(args):
     if isinstance(args, numbers.Number):
         return True
-    # return all([isinstance(arg, numbers.Number) or type(arg) == np.ndarray for arg in args])
     return all([isinstance(arg, numbers.Number) or arg is np.ndarray for arg in args])
 
 
@@ -177,17 +176,17 @@ def test_transform_with_units(wcsobj):
     n_inputs = wcsobj.input_frame.naxes
     xx = [x] * n_inputs
 
-    # input is numerical; return numbers
+    # input is numerical, return numbers
     result_num = wcsobj(*xx)
     assert is_numerical(result_num)
 
     inp = wcsobj.invert(*result_num)
     assert is_numerical(inp)
 
-    # input is quantities; return quantities
+    # input is quantities, return quantities
     xxq = [1 * u.pix] * n_inputs
     result = wcsobj(*xxq)
-    assert all([type(res) == u.Quantity for res in result])
+    assert all([type(res) is u.Quantity for res in result])
     assert_allclose([r.value for r in result], result_num)
 
     sky = wcsobj.pixel_to_world(*xxq)
@@ -241,7 +240,10 @@ def test_remove_units(wcsobj):
 
 
 def test_transform_multistage_wcs(gwcs_with_pipeline_celestial):
-    """Tests that the input and output types match for intermediate frames/transforms."""
+    """
+    Tests that the input and output types match for
+    intermediate frames/transforms.
+    """
     wcsobj = gwcs_with_pipeline_celestial
     frames = wcsobj.available_frames
     result = wcsobj.transform(frames[0], frames[-1], 1 * u.pix, 1 * u.pix)

--- a/gwcs/tests/test_wcs.py
+++ b/gwcs/tests/test_wcs.py
@@ -1735,9 +1735,10 @@ def test_quantities_in_pipeline_backward(gwcs_with_pipeline_celestial):
         20 * u.arcsec + 1 * u.deg,
         15 * u.deg + 2 * u.deg,
     ]
-    with pytest.raises(TypeError) as e:
-        pixel = iwcs.invert(*input_world)
-    assert "High Level objects are not supported with the native" in str(e)
+    with pytest.raises(
+        TypeError, match=r"High Level objects are not supported with the native"
+    ):
+        iwcs.invert(*input_world)
 
     intermediate_world = iwcs.transform(
         "output",

--- a/gwcs/tests/test_wcs.py
+++ b/gwcs/tests/test_wcs.py
@@ -1739,9 +1739,6 @@ def test_quantities_in_pipeline_backward(gwcs_with_pipeline_celestial):
         pixel = iwcs.invert(*input_world)
     assert "High Level objects are not supported with the native" in str(e)
 
-    # assert all(isinstance(p, u.Quantity) for p in pixel)
-    # assert u.allclose(pixel, [1, 1] * u.pix)
-
     intermediate_world = iwcs.transform(
         "output",
         "celestial",

--- a/gwcs/tests/test_wcs.py
+++ b/gwcs/tests/test_wcs.py
@@ -516,7 +516,14 @@ def test_bounding_box_eval():
     pipeline = [
         (
             cf.CoordinateFrame(
-                naxes=3, axes_type=("PIXEL", "PIXEL", "PIXEL",), axes_order=(0, 1, 2), name="detector"
+                naxes=3,
+                axes_type=(
+                    "PIXEL",
+                    "PIXEL",
+                    "PIXEL",
+                ),
+                axes_order=(0, 1, 2),
+                name="detector",
             ),
             trans3,
         ),

--- a/gwcs/tests/test_wcs.py
+++ b/gwcs/tests/test_wcs.py
@@ -516,10 +516,7 @@ def test_bounding_box_eval():
     pipeline = [
         (
             cf.CoordinateFrame(
-                naxes=3,
-                axes_type=("PIXEL", "PIXEL", "PIXEL"),
-                axes_order=(0, 1, 2),
-                name="detector",
+                naxes=3, axes_type=("PIXEL", "PIXEL", "PIXEL",), axes_order=(0, 1, 2), name="detector"
             ),
             trans3,
         ),
@@ -1703,8 +1700,8 @@ def test_quantities_in_pipeline_forward(gwcs_with_pipeline_celestial):
 
     output_world = iwcs(*input_pixel)
 
-    assert output_world[0].unit == u.deg
-    assert output_world[1].unit == u.deg
+    assert output_world[0].unit == u.arcsec
+    assert output_world[1].unit == u.arcsec
     assert u.allclose(output_world[0], 20 * u.arcsec + 1 * u.deg)
     assert u.allclose(output_world[1], 15 * u.deg + 2 * u.deg)
 
@@ -1883,6 +1880,8 @@ def test_parameterless_transform():
     assert gwcs(1 * u.pix, 1 * u.pix) == (1 * u.pix, 1 * u.pix)
 
     assert gwcs.invert(1, 1) == (1, 1)
+    # Strictly speaking it's correct that this fails Because
+    # for this setup the HLO are Quantities
     assert gwcs.invert(1 * u.pix, 1 * u.pix) == (1, 1)
 
 

--- a/gwcs/tests/test_wcs.py
+++ b/gwcs/tests/test_wcs.py
@@ -1728,10 +1728,12 @@ def test_quantities_in_pipeline_backward(gwcs_with_pipeline_celestial):
         20 * u.arcsec + 1 * u.deg,
         15 * u.deg + 2 * u.deg,
     ]
-    pixel = iwcs.invert(*input_world)
+    with pytest.raises(TypeError) as e:
+        pixel = iwcs.invert(*input_world)
+    assert "High Level objects are not supported with the native" in str(e)
 
-    assert all(isinstance(p, u.Quantity) for p in pixel)
-    assert u.allclose(pixel, [1, 1] * u.pix)
+    # assert all(isinstance(p, u.Quantity) for p in pixel)
+    # assert u.allclose(pixel, [1, 1] * u.pix)
 
     intermediate_world = iwcs.transform(
         "output",
@@ -1882,7 +1884,9 @@ def test_parameterless_transform():
     assert gwcs.invert(1, 1) == (1, 1)
     # Strictly speaking it's correct that this fails Because
     # for this setup the HLO are Quantities
-    assert gwcs.invert(1 * u.pix, 1 * u.pix) == (1, 1)
+    with pytest.raises(TypeError) as e:
+        _ = gwcs.invert(1 * u.pix, 1 * u.pix)
+    assert "High Level objects are not supported with the native" in str(e)
 
 
 def test_fitswcs_imaging(fits_wcs_imaging_simple):

--- a/gwcs/wcs/_wcs.py
+++ b/gwcs/wcs/_wcs.py
@@ -159,7 +159,9 @@ class WCS(GWCSAPIMixin, Pipeline):
             msg = "Transform is not defined."
             raise NotImplementedError(msg)
 
-        input_is_quantity, transform_uses_quantity = self._units_are_present(args, transform)
+        input_is_quantity, transform_uses_quantity = self._units_are_present(
+            args, transform
+        )
         args = self._make_input_units_consistent(
             transform,
             *args,
@@ -168,7 +170,9 @@ class WCS(GWCSAPIMixin, Pipeline):
             transform_uses_quantity=transform_uses_quantity,
         )
 
-        result = transform(*args, with_bounding_box=with_bounding_box, fill_value=fill_value, **kwargs)
+        result = transform(
+            *args, with_bounding_box=with_bounding_box, fill_value=fill_value, **kwargs
+        )
         if self.output_frame is not None:
             if self.output_frame.naxes == 1:
                 result = (result,)
@@ -205,7 +209,6 @@ class WCS(GWCSAPIMixin, Pipeline):
         transform_uses_quantity = not (transform is None or not transform.uses_quantity)
         return input_is_quantity, transform_uses_quantity
 
-
     def _make_input_units_consistent(
         self,
         transform,
@@ -222,17 +225,18 @@ class WCS(GWCSAPIMixin, Pipeline):
         # # Validate that the input type matches what the transform expects
         # input_is_quantity = any(isinstance(a, u.Quantity) for a in args)
         # transform_uses_quantity = not (transform is None or not transform.uses_quantity)
-        if not input_is_quantity and not transform_uses_quantity:
+        if (not input_is_quantity and not transform_uses_quantity) or (
+            input_is_quantity and transform_uses_quantity
+        ):
             return args
-        elif input_is_quantity and transform_uses_quantity:
-            return args
-        elif (
+        if (
             not input_is_quantity
-            and (transform_uses_quantity
-            or transform.parameters.size) # possibly remove this, check is in _units_are_present
+            and (
+                transform_uses_quantity or transform.parameters.size
+            )  # possibly remove this, check is in _units_are_present
         ):
             return self._add_units_input(args, frame)
-        elif not transform_uses_quantity and input_is_quantity:
+        if not transform_uses_quantity and input_is_quantity:
             return self._remove_units_input(args, frame)
 
     def _make_output_units_consistent(
@@ -251,13 +255,11 @@ class WCS(GWCSAPIMixin, Pipeline):
         if not input_is_quantity and not transform_uses_quantity:
             return args
 
-        elif input_is_quantity and transform_uses_quantity:
+        if input_is_quantity and transform_uses_quantity:
             # make sure the output is returned in the units of the output frame
             return self._add_units_input(args, frame)
-        elif (
-            not input_is_quantity
-            and (transform_uses_quantity
-            or transform.parameters.size)
+        if not input_is_quantity and (
+            transform_uses_quantity or transform.parameters.size
         ):
             result = self._remove_units_input(args, frame)
         elif not transform_uses_quantity and input_is_quantity:
@@ -358,7 +360,9 @@ class WCS(GWCSAPIMixin, Pipeline):
         if with_bounding_box and self.bounding_box is not None:
             args = self.outside_footprint(args)
 
-        input_is_quantity, transform_uses_quantity = self._units_are_present(args, transform)
+        input_is_quantity, transform_uses_quantity = self._units_are_present(
+            args, transform
+        )
 
         args = self._make_input_units_consistent(
             transform,
@@ -369,7 +373,12 @@ class WCS(GWCSAPIMixin, Pipeline):
         )
         if transform is not None:
             akwargs = {k: v for k, v in kwargs.items() if k not in _ITER_INV_KWARGS}
-            result = transform(*args, with_bounding_box=with_bounding_box, fill_value=fill_value, **akwargs)
+            result = transform(
+                *args,
+                with_bounding_box=with_bounding_box,
+                fill_value=fill_value,
+                **akwargs,
+            )
         else:
             # Always strip units for numerical inverse
             args = self._remove_units_input(args, self.output_frame)
@@ -1114,7 +1123,7 @@ class WCS(GWCSAPIMixin, Pipeline):
         *args,
         with_bounding_box: bool = True,
         fill_value: float | np.number = np.nan,
-        **kwargs
+        **kwargs,
     ):
         """
         Transform positions between two frames.
@@ -1141,15 +1150,21 @@ class WCS(GWCSAPIMixin, Pipeline):
         transform = self.get_transform(from_step.step.frame, to_step.step.frame)
 
         # If frames are of type ``str``, set the object to ``None``.
-        from_frame_obj = getattr(self, from_frame) if isinstance(from_frame, str) else from_frame
+        from_frame_obj = (
+            getattr(self, from_frame) if isinstance(from_frame, str) else from_frame
+        )
         if isinstance(from_frame_obj, EmptyFrame):
             from_frame_obj = None
 
-        to_frame_obj = getattr(self, to_frame) if isinstance(to_frame, str) else to_frame
+        to_frame_obj = (
+            getattr(self, to_frame) if isinstance(to_frame, str) else to_frame
+        )
         if isinstance(to_frame_obj, EmptyFrame):
             to_frame_obj = None
 
-        input_is_quantity, transform_uses_quantity = self._units_are_present(args, transform)
+        input_is_quantity, transform_uses_quantity = self._units_are_present(
+            args, transform
+        )
         args = self._make_input_units_consistent(
             transform,
             *args,
@@ -1158,7 +1173,9 @@ class WCS(GWCSAPIMixin, Pipeline):
             transform_uses_quantity=transform_uses_quantity,
         )
 
-        result = transform(*args, with_bounding_box=with_bounding_box, fill_value=fill_value, **kwargs)
+        result = transform(
+            *args, with_bounding_box=with_bounding_box, fill_value=fill_value, **kwargs
+        )
         if to_frame_obj is not None:
             if to_frame_obj.naxes == 1:
                 result = (result,)

--- a/gwcs/wcs/_wcs.py
+++ b/gwcs/wcs/_wcs.py
@@ -222,22 +222,18 @@ class WCS(GWCSAPIMixin, Pipeline):
         Adds or removes units from the arguments as needed so that the transform
         can be successfully evaluated.
         """
-        # # Validate that the input type matches what the transform expects
-        # input_is_quantity = any(isinstance(a, u.Quantity) for a in args)
-        # transform_uses_quantity = not (transform is None or not transform.uses_quantity)
+        # Validate that the input type matches what the transform expects
         if (not input_is_quantity and not transform_uses_quantity) or (
             input_is_quantity and transform_uses_quantity
         ):
             return args
-        if (
-            not input_is_quantity
-            and (
-                transform_uses_quantity or transform.parameters.size
-            )  # possibly remove this, check is in _units_are_present
+        if not input_is_quantity and (
+            transform_uses_quantity or transform.parameters.size
         ):
             return self._add_units_input(args, frame)
         if not transform_uses_quantity and input_is_quantity:
             return self._remove_units_input(args, frame)
+        return args
 
     def _make_output_units_consistent(
         self,
@@ -249,8 +245,8 @@ class WCS(GWCSAPIMixin, Pipeline):
         **kwargs,
     ):
         """
-        Adds or removes units from the arguments as needed so that the type of the output
-        matches the input.
+        Adds or removes units from the arguments as needed so that
+        the type of the output matches the input.
         """
         if not input_is_quantity and not transform_uses_quantity:
             return args
@@ -261,10 +257,10 @@ class WCS(GWCSAPIMixin, Pipeline):
         if not input_is_quantity and (
             transform_uses_quantity or transform.parameters.size
         ):
-            result = self._remove_units_input(args, frame)
-        elif not transform_uses_quantity and input_is_quantity:
-            result = self._add_units_input(args, frame)
-        return result
+            return self._remove_units_input(args, frame)
+        if not transform_uses_quantity and input_is_quantity:
+            return self._add_units_input(args, frame)
+        return args
 
     def in_image(self, *args, **kwargs):
         """
@@ -352,7 +348,6 @@ class WCS(GWCSAPIMixin, Pipeline):
             transform = None
 
         if is_high_level(*args, low_level_wcs=self):
-            # args = high_level_objects_to_values(*args, low_level_wcs=self)
             message = "High Level objects are not supported with the native API. \
                        Please use the `world_to_pixel` method."
             raise TypeError(message)

--- a/gwcs/wcs/_wcs.py
+++ b/gwcs/wcs/_wcs.py
@@ -1118,6 +1118,7 @@ class WCS(GWCSAPIMixin, Pipeline):
         *args,
         with_bounding_box: bool = True,
         fill_value: float | np.number = np.nan,
+        hlo: bool = False,
         **kwargs,
     ):
         """
@@ -1132,11 +1133,13 @@ class WCS(GWCSAPIMixin, Pipeline):
         args : float or array-like
             Inputs in ``from_frame``, separate inputs for each dimension.
         with_bounding_box : bool, optional
-             If True(default) values in the result which correspond to any of
+             If True (default) values in the result which correspond to any of
              the inputs being outside the bounding_box are set to ``fill_value``.
         fill_value : float, optional
             Output value for inputs outside the bounding_box
             (default is np.nan).
+        hlo : bool, optional
+            If True, return a high level object.
         """
         # Pull the steps and their indices from the pipeline
         # -> this also turns the frame name strings into frame objects
@@ -1181,6 +1184,14 @@ class WCS(GWCSAPIMixin, Pipeline):
                 input_is_quantity=input_is_quantity,
                 transform_uses_quantity=transform_uses_quantity,
             )
+
+        if hlo and to_frame_obj is not None:
+            result = values_to_high_level_objects(
+                *result,
+                low_level_wcs=self,
+                object_classes=to_frame_obj.world_axis_object_classes,
+                object_components=to_frame_obj.world_axis_object_components)
+
         if to_frame_obj is not None and to_frame_obj.naxes == 1:
             return result[0]
         return result

--- a/gwcs/wcs/_wcs.py
+++ b/gwcs/wcs/_wcs.py
@@ -189,7 +189,7 @@ class WCS(GWCSAPIMixin, Pipeline):
 
     def _units_are_present(self, args, transform):
         """
-        Determining if the inputs to a transform are quantities and the transform
+        Determine if the inputs to a transform are quantities and the transform
         supports units.
 
         Parameters
@@ -1181,7 +1181,7 @@ class WCS(GWCSAPIMixin, Pipeline):
                 input_is_quantity=input_is_quantity,
                 transform_uses_quantity=transform_uses_quantity,
             )
-        if self.output_frame is not None and self.output_frame.naxes == 1:
+        if to_frame_obj is not None and to_frame_obj.naxes == 1:
             return result[0]
         return result
 

--- a/gwcs/wcs/_wcs.py
+++ b/gwcs/wcs/_wcs.py
@@ -348,7 +348,7 @@ class WCS(GWCSAPIMixin, Pipeline):
             transform = self.backward_transform
         except NotImplementedError:
             transform = None
-            # TODO raise error?
+
         if is_high_level(*args, low_level_wcs=self):
             # args = high_level_objects_to_values(*args, low_level_wcs=self)
             message = "High Level objects are not supported with the native API. \
@@ -1112,7 +1112,9 @@ class WCS(GWCSAPIMixin, Pipeline):
         from_frame: str | CoordinateFrame,
         to_frame: str | CoordinateFrame,
         *args,
-        **kwargs,
+        with_bounding_box: bool = True,
+        fill_value: float | np.number = np.nan,
+        **kwargs
     ):
         """
         Transform positions between two frames.
@@ -1128,15 +1130,15 @@ class WCS(GWCSAPIMixin, Pipeline):
         with_bounding_box : bool, optional
              If True(default) values in the result which correspond to any of
              the inputs being outside the bounding_box are set to ``fill_value``.
+        fill_value : float, optional
+            Output value for inputs outside the bounding_box
+            (default is np.nan).
         """
         # Pull the steps and their indices from the pipeline
         # -> this also turns the frame name strings into frame objects
         from_step = self._get_step(from_frame)
         to_step = self._get_step(to_frame)
         transform = self.get_transform(from_step.step.frame, to_step.step.frame)
-
-        with_bounding_box = kwargs.get("with_bounding_box", None)
-        fill_value = kwargs.get("fill_value", np.nan)
 
         # If frames are of type ``str``, set the object to ``None``.
         from_frame_obj = getattr(self, from_frame) if isinstance(from_frame, str) else from_frame

--- a/gwcs/wcs/_wcs.py
+++ b/gwcs/wcs/_wcs.py
@@ -29,6 +29,7 @@ from gwcs.coordinate_frames import (
     CelestialFrame,
     CompositeFrame,
     CoordinateFrame,
+    EmptyFrame,
     get_ctype_from_ucd,
 )
 from gwcs.utils import _compute_lon_pole, is_high_level, to_index
@@ -157,41 +158,135 @@ class WCS(GWCSAPIMixin, Pipeline):
         if transform is None:
             msg = "Transform is not defined."
             raise NotImplementedError(msg)
+        # move this to an evaluate_funciton, called by forward, transform and invert
+        # input_is_quantity = any(isinstance(a, u.Quantity) for a in args)
+        # transform_uses_quantity = not (transform is None or not transform.uses_quantity)
+
+        input_is_quantity, transform_uses_quantity = self._units_are_present(args, transform)
         args = self._make_input_units_consistent(
+            transform,
             *args,
-            transform=transform,
-            from_frame=self.input_frame,
-            to_frame=self.output_frame,
+            frame=self.input_frame,
+            input_is_quantity=input_is_quantity,
+            transform_uses_quantity=transform_uses_quantity,
         )
 
-        return self._call_forward(
-            *args, with_bounding_box=with_bounding_box, fill_value=fill_value, **kwargs
-        )
+        result = transform(*args, with_bounding_box=with_bounding_box, fill_value=fill_value, **kwargs)
+        if self.output_frame is not None:
+            if self.output_frame.naxes == 1:
+                result = (result,)
+            result = self._make_output_units_consistent(
+                transform,
+                *result,
+                frame=self.output_frame,
+                input_is_quantity=input_is_quantity,
+                transform_uses_quantity=transform_uses_quantity,
+            )
+        if self.output_frame is not None and self.output_frame.naxes == 1:
+            return result[0]
+        return result
+
+    def _units_are_present(self, args, transform):
+        """
+        Determing if the inputs to a transform are quantities and the transform
+        supports units.
+
+        Parameters
+        ----------
+        args : a tuple of scalars or ndarray-like objects
+            Inputs to a transform.
+        transform : `~astropy.modeling.Model`
+            Transform to be evaluated.
+
+        Returns
+        -------
+        input_is_quantity, transform_uses_quantity : bool
+
+        """
+        # Validate that the input type matches what the transform expects
+        input_is_quantity = any(isinstance(a, u.Quantity) for a in args)
+        transform_uses_quantity = not (transform is None or not transform.uses_quantity)
+        return input_is_quantity, transform_uses_quantity
+
 
     def _make_input_units_consistent(
         self,
-        *args,
         transform,
-        from_frame: CoordinateFrame | None = None,
-        to_frame: CoordinateFrame | None = None,
+        *args,
+        frame: CoordinateFrame | None = None,
+        input_is_quantity=False,
+        transform_uses_quantity=False,
         **kwargs,
     ):
         """
         Adds or removes units from the arguments as needed so that the transform
         can be successfully evaluated.
         """
-        # Validate that the input type matches what the transform expects
-        input_is_quantity = any(isinstance(a, u.Quantity) for a in args)
-        transform_uses_quantity = not (transform is None or not transform.uses_quantity)
-        if (
+        # # Validate that the input type matches what the transform expects
+        # input_is_quantity = any(isinstance(a, u.Quantity) for a in args)
+        # transform_uses_quantity = not (transform is None or not transform.uses_quantity)
+        if not input_is_quantity and not transform_uses_quantity:
+            return args
+        elif input_is_quantity and transform_uses_quantity:
+            return args
+        elif (
             not input_is_quantity
-            and transform_uses_quantity
-            and transform.parameters.size
+            and (transform_uses_quantity
+            or transform.parameters.size) # possibly remove this, check is in _units_are_present
         ):
-            return self._add_units_input(args, from_frame)
-        if not transform_uses_quantity and input_is_quantity:
-            return self._remove_units_input(args, from_frame)
-        return args
+            return self._add_units_input(args, frame)
+        elif not transform_uses_quantity and input_is_quantity:
+            return self._remove_units_input(args, frame)
+        #return args
+
+    def _make_output_units_consistent(
+        self,
+        transform,
+        *args,
+        frame: CoordinateFrame | None = None,
+        input_is_quantity=False,
+        transform_uses_quantity=False,
+        **kwargs,
+    ):
+        """
+        Adds or removes units from the arguments as needed so that the type of the output
+        matches the input.
+        """
+        if not input_is_quantity and not transform_uses_quantity:
+            return args
+
+        elif input_is_quantity and transform_uses_quantity:
+            # make sure the output is returned in the units of the output frame
+            return self._add_units_input(args, frame)
+        elif (
+            not input_is_quantity
+            and (transform_uses_quantity
+            or transform.parameters.size)
+        ):
+            result = self._remove_units_input(args, frame)
+        elif not transform_uses_quantity and input_is_quantity:
+            result = self._add_units_input(args, frame)
+        return result
+
+    def _get_transform(
+        self,
+        *args,
+        from_frame: CoordinateFrame | None = None,
+        to_frame: CoordinateFrame | None = None,
+        **kwargs,
+    ):
+        """
+        Executes the forward transform, but values only.
+        """
+        if from_frame is None and to_frame is None:
+            transform = self.forward_transform
+        else:
+            transform = self.get_transform(from_frame, to_frame)
+
+        if transform is None:
+            msg = "WCS.forward_transform is not implemented."
+            raise NotImplementedError(msg)
+        return transform
 
     def _evaluate_transform(
         self,
@@ -260,41 +355,6 @@ class WCS(GWCSAPIMixin, Pipeline):
                 return _transform(*self._add_units_input(args, from_frame))
 
             raise
-
-    def _call_forward(
-        self,
-        *args,
-        from_frame: CoordinateFrame | None = None,
-        to_frame: CoordinateFrame | None = None,
-        with_bounding_box: bool = True,
-        fill_value: float | np.number = np.nan,
-        **kwargs,
-    ):
-        """
-        Executes the forward transform, but values only.
-        """
-        if from_frame is None and to_frame is None:
-            transform = self.forward_transform
-        else:
-            transform = self.get_transform(from_frame, to_frame)
-        if from_frame is None:
-            from_frame = self.input_frame
-        if to_frame is None:
-            to_frame = self.output_frame
-
-        if transform is None:
-            msg = "WCS.forward_transform is not implemented."
-            raise NotImplementedError(msg)
-
-        return self._evaluate_transform(
-            transform,
-            from_frame,
-            to_frame,
-            *args,
-            with_bounding_box=with_bounding_box,
-            fill_value=fill_value,
-            **kwargs,
-        )
 
     def in_image(self, *args, **kwargs):
         """
@@ -380,46 +440,28 @@ class WCS(GWCSAPIMixin, Pipeline):
             transform = self.backward_transform
         except NotImplementedError:
             transform = None
+            # TODO raise error?
         if is_high_level(*args, low_level_wcs=self):
-            args = high_level_objects_to_values(*args, low_level_wcs=self)
-        args = self._make_input_units_consistent(
-            *args,
-            transform=transform,
-            from_frame=self.output_frame,
-            to_frame=self.input_frame,
-        )
-
-        return self._call_backward(
-            *args, with_bounding_box=with_bounding_box, fill_value=fill_value, **kwargs
-        )
-
-    def _call_backward(
-        self,
-        *args,
-        with_bounding_box: bool = True,
-        fill_value: float | np.number = np.nan,
-        **kwargs,
-    ):
-        try:
-            transform = self.backward_transform
-        except NotImplementedError:
-            transform = None
+            # args = high_level_objects_to_values(*args, low_level_wcs=self)
+            message = "High Level objects are not supported with the native API. \
+                       Please use the `world_to_pixel` method."
+            raise TypeError(message)
 
         if with_bounding_box and self.bounding_box is not None:
             args = self.outside_footprint(args)
 
+        input_is_quantity, transform_uses_quantity = self._units_are_present(args, transform)
+
+        args = self._make_input_units_consistent(
+            transform,
+            *args,
+            frame=self.output_frame,
+            input_is_quantity=input_is_quantity,
+            transform_uses_quantity=transform_uses_quantity,
+        )
         if transform is not None:
-            # remove iterative inverse-specific keyword arguments:
             akwargs = {k: v for k, v in kwargs.items() if k not in _ITER_INV_KWARGS}
-            result = self._evaluate_transform(
-                transform,
-                self.output_frame,
-                self.input_frame,
-                *args,
-                with_bounding_box=with_bounding_box,
-                fill_value=fill_value,
-                **akwargs,
-            )
+            result = transform(*args, with_bounding_box=with_bounding_box, fill_value=fill_value, **akwargs)
         else:
             # Always strip units for numerical inverse
             args = self._remove_units_input(args, self.output_frame)
@@ -430,10 +472,20 @@ class WCS(GWCSAPIMixin, Pipeline):
                 **kwargs,
             )
 
-        # deal with values outside the bounding box
         if with_bounding_box and self.bounding_box is not None:
             result = self.out_of_bounds(result, fill_value=fill_value)
 
+        if self.input_frame.naxes == 1:
+            result = (result,)
+        result = self._make_output_units_consistent(
+            transform,
+            *result,
+            frame=self.input_frame,
+            input_is_quantity=input_is_quantity,
+            transform_uses_quantity=transform_uses_quantity,
+        )
+        if self.input_frame.naxes == 1:
+            return result[0]
         return result
 
     def outside_footprint(self, world_arrays):
@@ -1175,16 +1227,41 @@ class WCS(GWCSAPIMixin, Pipeline):
         to_step = self._get_step(to_frame)
         transform = self.get_transform(from_step.step.frame, to_step.step.frame)
 
-        if not transform.uses_quantity and is_high_level(
-            *args, low_level_wcs=from_step.step.frame
-        ):
-            args = high_level_objects_to_values(
-                *args, low_level_wcs=from_step.step.frame
-            )
+        with_bounding_box = kwargs.get("with_bounding_box", None)
+        fill_value = kwargs.get("fill_value", np.nan)
 
-        return self._evaluate_transform(
-            transform, from_step.step.frame, to_step.step.frame, *args, **kwargs
+        # If frames are of type ``str``, set the object to ``None``.
+        from_frame_obj = getattr(self, from_frame) if isinstance(from_frame, str) else from_frame
+        if isinstance(from_frame_obj, EmptyFrame):
+            from_frame_obj = None
+
+        to_frame_obj = getattr(self, to_frame) if isinstance(to_frame, str) else to_frame
+        if isinstance(to_frame_obj, EmptyFrame):
+            to_frame_obj = None
+
+        input_is_quantity, transform_uses_quantity = self._units_are_present(args, transform)
+        args = self._make_input_units_consistent(
+            transform,
+            *args,
+            frame=from_frame_obj,
+            input_is_quantity=input_is_quantity,
+            transform_uses_quantity=transform_uses_quantity,
         )
+
+        result = transform(*args, with_bounding_box=with_bounding_box, fill_value=fill_value, **kwargs)
+        if to_frame_obj is not None:
+            if to_frame_obj.naxes == 1:
+                result = (result,)
+            result = self._make_output_units_consistent(
+                transform,
+                *result,
+                frame=to_frame_obj,
+                input_is_quantity=input_is_quantity,
+                transform_uses_quantity=transform_uses_quantity,
+            )
+        if self.output_frame is not None and self.output_frame.naxes == 1:
+            return result[0]
+        return result
 
     @property
     def name(self) -> str:

--- a/gwcs/wcs/_wcs.py
+++ b/gwcs/wcs/_wcs.py
@@ -189,7 +189,7 @@ class WCS(GWCSAPIMixin, Pipeline):
 
     def _units_are_present(self, args, transform):
         """
-        Determing if the inputs to a transform are quantities and the transform
+        Determining if the inputs to a transform are quantities and the transform
         supports units.
 
         Parameters


### PR DESCRIPTION
This implements the request in https://github.com/spacetelescope/gwcs/issues/644#issuecomment-3493642003. provide an option to generate a. high level objest when evaluating a transform between intermediate frames.
The implementation needs a change in astropy ([PR here)](https://github.com/astropy/astropy/pull/19064).

This PR is based on #660.
The requested functionality is shown in [test_transform_intermediate_1d test](https://github.com/spacetelescope/gwcs/compare/master...nden:gwcs:hlo-transform?expand=1#diff-acb5e1ba424d60bd34ab6da1d76a898e1b632c297c09041b83b7eab6c17fcdaeR272).