### PR TITLE
Fixed some documentation typos

### DIFF
--- a/docs/gwcs/constructing_gwcs_models.rst
+++ b/docs/gwcs/constructing_gwcs_models.rst
@@ -30,7 +30,7 @@ and the physical type of the axis (e.g., wavelength), as well as keeping
 track of the axis order.
 
 Since it is often useful to obtain coordinates in an intermediate frame of
-reference, GWCS allows to consist of multiple steps each with its own transformo,
+reference, GWCS allows to consist of multiple steps each with its own transform,
 which itself may be a compound transform consisting of multiple elemental
 transforms.
 For example, for spectrographs, it is useful to have access to coordinates
@@ -115,7 +115,7 @@ becomes:
 
   >>> det2sky = pixelshift | pixelscale | tangent_projection | celestial_rotation
 
-The remaining elements to defining the WCS are he input and output
+The remaining elements to defining the WCS are the input and output
 frames of reference. While the GWCS scheme allows intermediate frames
 of reference, this example doesn't have any. The output frame is
 expressed with no associated transform

--- a/docs/gwcs/user_introduction.rst
+++ b/docs/gwcs/user_introduction.rst
@@ -99,7 +99,7 @@ to ra, dec of (30, 45) in degrees.
         -500.0   -500.0 2.777777777777778e-05 ...  45.0      180.0)>
   >>> wcs.output_frame
   <CelestialFrame(name="icrs", unit=(Unit("deg"), Unit("deg")), axes_names=('lon', 'lat'), axes_order=(0, 1), reference_frame=<ICRS Frame>)>
-  >>> wcs(500, 600) # Compute the world coordinates of pixel (500, 500),
+  >>> wcs(500, 500) # Compute the world coordinates of pixel (500, 500),
   >>>               # which is the reference pixel.
   (29.999999999999993, 45.00000000000001)
   >>> sky = wcs(700, 300) # (x, y) corresponding to python image index [300, 700]


### PR DESCRIPTION
There were several typos in user_introduction and constructing_gwcs_models. Not positive if the value correction constructing_gwcs_models is desired but the comments and description did not match.