### PR TITLE
Avoid changing array shape in-place

### DIFF
--- a/gwcs/selector.py
+++ b/gwcs/selector.py
@@ -403,8 +403,8 @@ class LabelMapperDict(_LabelMapper):
             ind = np.isclose(key, keys, atol=self._atol)
             inputs = [a[ind] for a in args]
             res[ind] = self.mapper[key](*inputs)
-        res.shape = shape
-        return res
+
+        return np.reshape(res, shape)
 
 
 class LabelMapperRange(_LabelMapper):
@@ -522,7 +522,7 @@ class LabelMapperRange(_LabelMapper):
                 res[ind] = self.mapper[tuple(val_range)](*inputs)
             else:
                 continue
-        res.shape = shape
+        res = np.reshape(res, shape)
         if len(np.nonzero(res)[0]) == 0:
             warnings.warn(
                 f"All data is outside the valid range - {self.name}.", stacklevel=2

--- a/gwcs/tests/test_wcs.py
+++ b/gwcs/tests/test_wcs.py
@@ -476,8 +476,7 @@ def test_wcs_from_points():
     assert_allclose(newra, ra)
     assert_allclose(newdec, dec)
 
-    n = rng.standard_normal(ra.size)
-    n.shape = ra.shape
+    n = rng.standard_normal(size=ra.shape)
     nra = n * 10**-2
     ndec = n * 10**-2
     w = wcs_from_points(


### PR DESCRIPTION
This PR addresses the issue of deprecation of changing array shape in-place via setting `np.ndarray.shape` attribute, see https://numpy.org/devdocs/release/notes-towncrier.html#setting-the-shape-attribute-is-deprecated.

Regression test: https://github.com/spacetelescope/RegressionTests/actions/runs/20889574665
