### PR TITLE
Bugfix for API when frame is None

### DIFF
--- a/changes/684.bugfix.rst
+++ b/changes/684.bugfix.rst
@@ -1,0 +1,1 @@
+Fix gwcs evaluation when the input or output frames are ``None`` or ``EmptyFrame``.

--- a/gwcs/api.py
+++ b/gwcs/api.py
@@ -66,16 +66,21 @@ class GWCSAPIMixin(BaseLowLevelWCS, HighLevelWCSMixin):
         return tuple(unit.to_string(format="vounit") for unit in self.output_frame.unit)
 
     def _remove_quantity_output(self, result, frame):
-        if frame.naxes == 1:
-            result = [result]
+        if frame is not None:
+            if frame.naxes == 1:
+                result = [result]
 
-        result = tuple(
-            r.to_value(unit) if isinstance(r, u.Quantity) else r
-            for r, unit in zip(result, frame.unit, strict=False)
-        )
+            result = tuple(
+                r.to_value(unit) if isinstance(r, u.Quantity) else r
+                for r, unit in zip(result, frame.unit, strict=False)
+            )
 
         # If we only have one output axes, we shouldn't return a tuple.
-        if self.output_frame.naxes == 1 and isinstance(result, tuple):
+        if (
+            self.output_frame is not None
+            and self.output_frame.naxes == 1
+            and isinstance(result, tuple)
+        ):
             return result[0]
         return result
 
@@ -243,6 +248,9 @@ class GWCSAPIMixin(BaseLowLevelWCS, HighLevelWCSMixin):
 
     @property
     def world_axis_object_classes(self):
+        if self.output_frame is None:
+            return None
+
         return self.output_frame.world_axis_object_classes
 
     @property

--- a/gwcs/examples.py
+++ b/gwcs/examples.py
@@ -26,6 +26,15 @@ MODEL_2D_SHIFT = models.Shift(1) & models.Shift(2)
 MODEL_1D_SCALE = models.Scale(2)
 
 
+def gwcs_simple_2d():
+    output_frame = cf.Frame2D(name="world")
+    return wcs.WCS(MODEL_2D_SHIFT, output_frame=output_frame)
+
+
+def gwcs_empty_output_2d():
+    return wcs.WCS(MODEL_2D_SHIFT, output_frame=cf.EmptyFrame(name="world"))
+
+
 def gwcs_2d_quantity_shift():
     frame = cf.CoordinateFrame(
         name="quantity",

--- a/gwcs/tests/conftest.py
+++ b/gwcs/tests/conftest.py
@@ -8,6 +8,16 @@ from gwcs import examples, geometry
 
 
 @pytest.fixture
+def gwcs_simple_2d():
+    return examples.gwcs_simple_2d()
+
+
+@pytest.fixture
+def gwcs_empty_output_2d():
+    return examples.gwcs_empty_output_2d()
+
+
+@pytest.fixture
 def gwcs_2d_quantity_shift():
     return examples.gwcs_2d_quantity_shift()
 

--- a/gwcs/tests/test_api.py
+++ b/gwcs/tests/test_api.py
@@ -632,3 +632,24 @@ def test_mismatched_high_level_types(gwcs_3d_identity_units):
         match="Invalid types were passed.*got.*Quantity.*expected.*SpectralCoord.*",
     ):
         wcs.invert(coord.SkyCoord(1 * u.deg, 2 * u.deg), 10 * u.nm)
+
+
+def test_no_input_frame(gwcs_simple_2d):
+    """Test running the API on the WCS with no input frame."""
+    assert (np.array([2]), np.array([-1])) == gwcs_simple_2d.world_to_pixel_values(
+        np.array([3]), np.array([1])
+    )
+    assert (np.array([4]), np.array([3])) == gwcs_simple_2d.pixel_to_world_values(
+        np.array([3]), np.array([1])
+    )
+
+
+def test_empty_output_frame(gwcs_empty_output_2d):
+    """Test running the API on the WCS with an empty output frame."""
+    assert (np.array([3]), np.array([1])) == gwcs_empty_output_2d.pixel_to_world_values(
+        np.array([2]), np.array([-1])
+    )
+    assert (
+        np.array([2]),
+        np.array([-1]),
+    ) == gwcs_empty_output_2d.world_to_pixel_values(np.array([3]), np.array([1]))

--- a/gwcs/utils.py
+++ b/gwcs/utils.py
@@ -484,7 +484,9 @@ def is_high_level(*args, low_level_wcs):
     Determine if args matches the high level classes as defined by
     ``low_level_wcs``.
     """
-    if len(args) != len(low_level_wcs.world_axis_object_classes):
+    if low_level_wcs.world_axis_object_classes is None or len(args) != len(
+        low_level_wcs.world_axis_object_classes
+    ):
         return False
 
     type_match = [

--- a/gwcs/wcs/_wcs.py
+++ b/gwcs/wcs/_wcs.py
@@ -388,21 +388,18 @@ class WCS(GWCSAPIMixin, Pipeline):
         if with_bounding_box and self.bounding_box is not None:
             result = self.out_of_bounds(result, fill_value=fill_value)
 
-        if self.input_frame is None:
-            msg = "Input frame is not defined."
-            return ValueError(msg)
-
-        if self.input_frame.naxes == 1:
-            result = (result,)
-        result = self._make_output_units_consistent(
-            transform,
-            *result,
-            frame=self.input_frame,
-            input_is_quantity=input_is_quantity,
-            transform_uses_quantity=transform_uses_quantity,
-        )
-        if self.input_frame.naxes == 1:
-            return result[0]
+        if self.input_frame is not None:
+            if self.input_frame.naxes == 1:
+                result = (result,)
+            result = self._make_output_units_consistent(
+                transform,
+                *result,
+                frame=self.input_frame,
+                input_is_quantity=input_is_quantity,
+                transform_uses_quantity=transform_uses_quantity,
+            )
+            if self.input_frame.naxes == 1:
+                return result[0]
         return result
 
     def outside_footprint(self, world_arrays):


### PR DESCRIPTION
<!-- describe the changes comprising this PR here -->

It is possible to define a WCS in gwcs with the input_frame or output_frame being an empty frame or None but the WCS has a forward transform. This leads to an awkward violation of some of our assumptions for units and reshaping outputs. In these bizarre cases we will assume the best and if the transform works we output its value.

This fixes the bug that spacetelescope/stcal#498 is about.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->

## Tasks

- [ ] Update or add relevant `gwcs` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [ ] Does this PR need a changelog entry? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).

<details><summary>News fragment change types:</summary>

- `changes/<PR#>.feature.rst`: new feature
- `changes/<PR#>.breaking.rst`: any change or deprecation of the public API
- `changes/<PR#>.bugfix.rst`: fixes an issue
- `changes/<PR#>.doc.rst`: documentation change
- `changes/<PR#>.misc.rst`: infrastructure or miscellaneous change
</details
