### PR TITLE
Bugfix for round trip serialization of `axes_order` 

### DIFF
--- a/changes/687.bugfix.rst
+++ b/changes/687.bugfix.rst
@@ -1,0 +1,2 @@
+Fix bug with ``axes_order`` permuting the properties of a ``CoordinateFrame`` when
+it is serialized and deserialized from ASDF.

--- a/gwcs/converters/tests/test_wcs.py
+++ b/gwcs/converters/tests/test_wcs.py
@@ -111,6 +111,7 @@ def _frame_factory():
 
     return [
         cf.CelestialFrame(reference_frame=coord.ICRS()),
+        cf.CelestialFrame(reference_frame=coord.ICRS(), axes_order=(1, 0)),
         cf.CelestialFrame(reference_frame=coord.FK5(equinox=time.Time("2010-01-01"))),
         cf.CelestialFrame(
             reference_frame=coord.FK4(
@@ -147,8 +148,27 @@ def _frame_factory():
                 obsgeovel=[2, 1, 8] * (u.m / u.s),
             )
         ),
+        cf.SpectralFrame(name="freq", unit=(u.Hz,), axes_order=(2,)),
+        cf.SpectralFrame(name="wave", unit=(u.m,), axes_order=(2,)),
         cf.StokesFrame(),
+        cf.StokesFrame(name="polarisation", axes_order=(3,)),
         cf.TemporalFrame(time.Time("2011-01-01")),
+        cf.TemporalFrame(time.Time("2011-01-01"), axes_order=(2,)),
+        cf.Frame2D(),
+        cf.Frame2D(name="pixels"),
+        cf.Frame2D(name="detector", axes_order=(1, 0)),
+        cf.Frame2D(name="world", axes_order=(0, 1), unit=(u.m, u.km)),
+        cf.Frame2D(
+            name="reverse_world",
+            axes_order=(1, 0),
+            unit=(u.m, u.km),
+            axes_names=("foo", "bar"),
+        ),
+        cf.CoordinateFrame(
+            naxes=7,
+            axes_type=((cf.AxisType.SPATIAL,) * 4) + ((cf.AxisType.PIXEL,) * 3),
+            axes_order=tuple(range(7)),
+        ),
     ]
 
 

--- a/gwcs/converters/tests/test_wcs.py
+++ b/gwcs/converters/tests/test_wcs.py
@@ -1,6 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 import asdf
+import pytest
 from asdf_astropy.testing.helpers import (
     assert_model_equal,
 )
@@ -66,7 +67,7 @@ def assert_wcs_roundtrip(wcs, tmp_path, version=None):
         _assert_wcs_equal(wcs, af["wcs"])
 
 
-def test_create_wcs(tmp_path):
+def _wcs_factory():
     m1 = models.Shift(12.4) & models.Shift(-2)
     icrs = cf.CelestialFrame(name="icrs", reference_frame=coord.ICRS())
     det = cf.Frame2D(name="detector", axes_order=(0, 1))
@@ -76,13 +77,15 @@ def test_create_wcs(tmp_path):
     gw4 = wcs.WCS(output_frame=icrs, input_frame=det, forward_transform=m1)
     gw4.pixel_shape = (100, 200)
 
-    assert_wcs_roundtrip(gw1, tmp_path)
-    assert_wcs_roundtrip(gw2, tmp_path)
-    assert_wcs_roundtrip(gw3, tmp_path)
-    assert_wcs_roundtrip(gw4, tmp_path)
+    return [gw1, gw2, gw3, gw4]
 
 
-def test_composite_frame(tmp_path):
+@pytest.mark.parametrize("gw", _wcs_factory())
+def test_create_wcs(tmp_path, gw):
+    assert_wcs_roundtrip(gw, tmp_path)
+
+
+def _composite_frame_factory():
     icrs = coord.ICRS()
     fk5 = coord.FK5()
     cel1 = cf.CelestialFrame(reference_frame=icrs)
@@ -95,12 +98,15 @@ def test_composite_frame(tmp_path):
     comp2 = cf.CompositeFrame([cel2, spec2])
     comp = cf.CompositeFrame([comp1, cf.SpectralFrame(axes_order=(3,), unit=(u.m,))])
 
-    assert_frame_roundtrip(comp, tmp_path)
-    assert_frame_roundtrip(comp1, tmp_path)
-    assert_frame_roundtrip(comp2, tmp_path)
+    return [comp1, comp2, comp]
 
 
-def create_test_frames():
+@pytest.mark.parametrize("frame", _composite_frame_factory())
+def test_composite_frame(tmp_path, frame):
+    assert_frame_roundtrip(frame, tmp_path)
+
+
+def _frame_factory():
     """Creates an array of frames to be used for testing."""
 
     return [
@@ -146,10 +152,9 @@ def create_test_frames():
     ]
 
 
-def test_frames(tmp_path):
-    frames = create_test_frames()
-    for f in frames:
-        assert_frame_roundtrip(f, tmp_path)
+@pytest.mark.parametrize("frame", _frame_factory())
+def test_frames(tmp_path, frame):
+    assert_frame_roundtrip(frame, tmp_path)
 
 
 def test_references(tmp_path):

--- a/gwcs/converters/wcs.py
+++ b/gwcs/converters/wcs.py
@@ -13,6 +13,7 @@ __all__ = [
     "CelestialFrameConverter",
     "CompositeFrameConverter",
     "FITSImagingWCSConverter",
+    "Frame2DConverter",
     "FrameConverter",
     "SpectralFrameConverter",
     "StepConverter",

--- a/gwcs/converters/wcs.py
+++ b/gwcs/converters/wcs.py
@@ -1,13 +1,18 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import annotations
 
 import warnings
 from contextlib import suppress
+from typing import TYPE_CHECKING
 
 from asdf.extension import Converter
 from asdf_astropy.converters.transform.core import (
     TransformConverterBase,
     parameter_to_value,
 )
+
+if TYPE_CHECKING:
+    from gwcs.coordinate_frames import CoordinateFrame
 
 __all__ = [
     "CelestialFrameConverter",
@@ -97,7 +102,7 @@ class FrameConverter(Converter):
 
         return kwargs
 
-    def _to_yaml_tree(self, frame, tag, ctx):
+    def _to_yaml_tree(self, frame: CoordinateFrame, tag, ctx):
         from gwcs.coordinate_frames import CoordinateFrame
 
         node = {}
@@ -106,23 +111,25 @@ class FrameConverter(Converter):
 
         # We want to check that it is exactly this type and not a subclass
         if type(frame) is CoordinateFrame:
-            node["axes_type"] = frame.axes_type
+            node["axes_type"] = [
+                str(axis_type) for axis_type in frame.raw_properties.axes_type
+            ]
             node["naxes"] = frame.naxes
 
         if frame.axes_order is not None:
             node["axes_order"] = list(frame.axes_order)
 
-        if frame.axes_names is not None:
-            node["axes_names"] = list(frame.axes_names)
+        if frame.raw_properties.axes_names is not None:
+            node["axes_names"] = list(frame.raw_properties.axes_names)
 
         if frame.reference_frame is not None:
             node["reference_frame"] = frame.reference_frame
 
-        if frame.unit is not None:
-            node["unit"] = list(frame.unit)
+        if frame.raw_properties.unit is not None:
+            node["unit"] = list(frame.raw_properties.unit)
 
-        if frame.axis_physical_types is not None:
-            node["axis_physical_types"] = list(frame.axis_physical_types)
+        if frame.raw_properties.axis_physical_types is not None:
+            node["axis_physical_types"] = list(frame.raw_properties.axis_physical_types)
 
         return node
 

--- a/gwcs/coordinate_frames/_core.py
+++ b/gwcs/coordinate_frames/_core.py
@@ -173,6 +173,11 @@ class CoordinateFrame(BaseCoordinateFrame):
         """
         return False
 
+    @property
+    def raw_properties(self) -> FrameProperties:
+        """The raw FrameProperties object for this frame."""
+        return self._prop
+
     def to_high_level_coordinates(self, *values):
         """
         Convert "values" to high level coordinate objects described by this frame.


### PR DESCRIPTION
<!-- describe the changes comprising this PR here -->

In PR #457 proper support for reordering the axes of a coordinate frame was implemented. This introduced a small bug when serializing frames with multiple axes which have be reordered; namely, the sorted axes were being recorded by the serialization not the order defined by the coordinate frame. This means that if more that one axis is involved in a rearrangement (such as reversal) in a given frame the frame does not round trip instead it is permuted by the `axis_order`.

This PR solves this by recording the exact state of the frame's ordered properties along with the `axes_order` permutation.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->

## Tasks

- [ ] Update or add relevant `gwcs` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [ ] Does this PR need a changelog entry? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).

<details><summary>News fragment change types:</summary>

- `changes/<PR#>.feature.rst`: new feature
- `changes/<PR#>.breaking.rst`: any change or deprecation of the public API
- `changes/<PR#>.bugfix.rst`: fixes an issue
- `changes/<PR#>.doc.rst`: documentation change
- `changes/<PR#>.misc.rst`: infrastructure or miscellaneous change
</details
