### PR TITLE
Set warnings as errors in tests to catch when new warnings arise

### DIFF
--- a/gwcs/tests/test_coordinate_systems.py
+++ b/gwcs/tests/test_coordinate_systems.py
@@ -64,13 +64,14 @@ spec4 = cf.SpectralFrame(
     ],
     axes_order=(2,),
 )
-spec5 = cf.SpectralFrame(
-    name="speed",
-    unit=[
-        u.m / u.s,
-    ],
-    axes_order=(2,),
-)
+with pytest.warns(UserWarning, match=r"Physical type may be ambiguous.*"):
+    spec5 = cf.SpectralFrame(
+        name="speed",
+        unit=[
+            u.m / u.s,
+        ],
+        axes_order=(2,),
+    )
 
 comp1 = cf.CompositeFrame([icrs, spec1])
 comp2 = cf.CompositeFrame([focal, spec2])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,7 @@ addopts = [
 ]
 norecursedirs = ["build", "docs/_build", ".tox"]
 filterwarnings = [
+  "error",
   "ignore:Models in math_functions:astropy.utils.exceptions.AstropyUserWarning",
   "ignore:numpy.ndarray size changed:RuntimeWarning",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,8 @@ filterwarnings = [
   "error",
   "ignore:Models in math_functions:astropy.utils.exceptions.AstropyUserWarning",
   "ignore:numpy.ndarray size changed:RuntimeWarning",
+  # Remove when https://github.com/astropy/astropy/issues/19216 is resolved
+  "ignore:The chararray class is deprecated and will be removed in a future release:DeprecationWarning",
 ]
 
 [tool.coverage.run]


### PR DESCRIPTION
This PR turns warnings into errors for unit tests.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->

## Tasks

- [ ] Update or add relevant `gwcs` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [ ] Does this PR need a changelog entry? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).

<details><summary>News fragment change types:</summary>

- `changes/<PR#>.feature.rst`: new feature
- `changes/<PR#>.breaking.rst`: any change or deprecation of the public API
- `changes/<PR#>.bugfix.rst`: fixes an issue
- `changes/<PR#>.doc.rst`: documentation change
- `changes/<PR#>.misc.rst`: infrastructure or miscellaneous change
</details
