### PR TITLE
Standardize the data necessary to init GWCS

### DIFF
--- a/changes/692.breaking.rst
+++ b/changes/692.breaking.rst
@@ -1,0 +1,11 @@
+Update the ``init`` for the ``WCS`` so that it requires either:
+
+- All of ``input_frame``, ``output_frame``, and ``forward_transform`` to be properly
+  provided.
+- The ``forward_transform`` provided in the form of a "pipeline", i.e., a list of
+  tuples of (frame name or CoordinateFrame, transform (or None for the final step)).
+
+This is a breaking change due to the fact that before one could make ``input_frame``
+and/or ``forward_transform`` optional (``None``). Now they are required so that
+the WCS has a well-defined place to lookup the metadata for handing the input/output
+values to the WCS.

--- a/docs/gwcs/api.rst
+++ b/docs/gwcs/api.rst
@@ -3,6 +3,9 @@
 API
 ===
 
+.. automodapi:: gwcs.api
+  :inherited-members:
+
 .. automodapi:: gwcs.wcs
   :inherited-members:
 

--- a/gwcs/converters/tests/test_wcs.py
+++ b/gwcs/converters/tests/test_wcs.py
@@ -72,12 +72,11 @@ def _wcs_factory():
     icrs = cf.CelestialFrame(name="icrs", reference_frame=coord.ICRS())
     det = cf.Frame2D(name="detector", axes_order=(0, 1))
     gw1 = wcs.WCS(output_frame="icrs", input_frame="detector", forward_transform=m1)
-    gw2 = wcs.WCS(output_frame="icrs", forward_transform=m1)
+    gw2 = wcs.WCS(output_frame=icrs, input_frame=det, forward_transform=m1)
     gw3 = wcs.WCS(output_frame=icrs, input_frame=det, forward_transform=m1)
-    gw4 = wcs.WCS(output_frame=icrs, input_frame=det, forward_transform=m1)
-    gw4.pixel_shape = (100, 200)
+    gw3.pixel_shape = (100, 200)
 
-    return [gw1, gw2, gw3, gw4]
+    return [gw1, gw2, gw3]
 
 
 @pytest.mark.parametrize("gw", _wcs_factory())

--- a/gwcs/coordinate_frames/_core.py
+++ b/gwcs/coordinate_frames/_core.py
@@ -38,7 +38,7 @@ class CoordinateFrame(BaseCoordinateFrame):
 
     def __init__(
         self,
-        naxes,
+        naxes: int,
         axes_type,
         axes_order,
         reference_frame=None,
@@ -112,7 +112,7 @@ class CoordinateFrame(BaseCoordinateFrame):
         self._name = val
 
     @property
-    def naxes(self):
+    def naxes(self) -> int:
         """The number of axes in this frame."""
         return self._naxes
 

--- a/gwcs/examples.py
+++ b/gwcs/examples.py
@@ -28,11 +28,16 @@ MODEL_1D_SCALE = models.Scale(2)
 
 def gwcs_simple_2d():
     output_frame = cf.Frame2D(name="world")
-    return wcs.WCS(MODEL_2D_SHIFT, output_frame=output_frame)
+    input_frame = cf.Frame2D(name="detector")
+    return wcs.WCS(MODEL_2D_SHIFT, input_frame=input_frame, output_frame=output_frame)
 
 
 def gwcs_empty_output_2d():
-    return wcs.WCS(MODEL_2D_SHIFT, output_frame=cf.EmptyFrame(name="world"))
+    return wcs.WCS(
+        MODEL_2D_SHIFT,
+        input_frame=cf.EmptyFrame(name="detector"),
+        output_frame=cf.EmptyFrame(name="world"),
+    )
 
 
 def gwcs_2d_quantity_shift():

--- a/gwcs/tests/test_region.py
+++ b/gwcs/tests/test_region.py
@@ -241,7 +241,11 @@ def test_RegionsSelector():
     reg_selector.undefined_transform_value = -100
     assert_equal(reg_selector(0, 0), [-100, -100])
 
-    wcs = WCS(forward_transform=reg_selector, output_frame=cf.Frame2D())
+    wcs = WCS(
+        forward_transform=reg_selector,
+        input_frame="detector",
+        output_frame=cf.Frame2D(),
+    )
     out = wcs(1, 1)
     assert out == (-100, -100)
 

--- a/gwcs/tests/test_wcs.py
+++ b/gwcs/tests/test_wcs.py
@@ -100,39 +100,6 @@ def test_create_wcs():
     assert_allclose(gw3(1, 2), res)
 
 
-def test_init_no_transform():
-    """
-    Test initializing a WCS object without a forward_transform.
-    """
-    gw = wcs.WCS(output_frame="icrs")
-    assert len(gw._pipeline) == 2
-    assert gw.pipeline[0].frame.name == "detector"
-    with pytest.warns(
-        DeprecationWarning, match="Indexing a WCS.pipeline step is deprecated."
-    ):
-        assert gw.pipeline[0][0].name == "detector"
-    assert gw.pipeline[1].frame.name == "icrs"
-    with pytest.warns(
-        DeprecationWarning, match="Indexing a WCS.pipeline step is deprecated."
-    ):
-        assert gw.pipeline[1][0].name == "icrs"
-    assert np.isin(gw.available_frames, ["detector", "icrs"]).all()
-    gw = wcs.WCS(output_frame=icrs, input_frame=detector)
-    assert gw._pipeline[0].frame.name == "detector"
-    with pytest.warns(
-        DeprecationWarning, match="Indexing a WCS.pipeline step is deprecated."
-    ):
-        assert gw._pipeline[0][0].name == "detector"
-    assert gw._pipeline[1].frame.name == "icrs"
-    with pytest.warns(
-        DeprecationWarning, match="Indexing a WCS.pipeline step is deprecated."
-    ):
-        assert gw._pipeline[1][0].name == "icrs"
-    assert np.isin(gw.available_frames, ["detector", "icrs"]).all()
-    with pytest.raises(NotImplementedError):
-        gw(1, 2)
-
-
 def test_init_no_output_frame():
     """
     Test initializing a WCS without an output_frame raises an error.
@@ -1520,8 +1487,33 @@ def test_spatial_spectral_stokes():
 
 
 def test_wcs_str():
-    w = wcs.WCS(output_frame="icrs")
-    assert "icrs" in str(w)
+    gw = wcs.WCS(forward_transform=m1, output_frame="icrs")
+    assert "icrs" in str(gw)
+    assert len(gw._pipeline) == 2
+    assert gw.pipeline[0].frame.name == "detector"
+    with pytest.warns(
+        DeprecationWarning, match="Indexing a WCS.pipeline step is deprecated."
+    ):
+        assert gw.pipeline[0][0].name == "detector"
+    assert gw.pipeline[1].frame.name == "icrs"
+    with pytest.warns(
+        DeprecationWarning, match="Indexing a WCS.pipeline step is deprecated."
+    ):
+        assert gw.pipeline[1][0].name == "icrs"
+    assert np.isin(gw.available_frames, ["detector", "icrs"]).all()
+
+    gw = wcs.WCS(forward_transform=m1, output_frame=icrs, input_frame=detector)
+    assert gw._pipeline[0].frame.name == "detector"
+    with pytest.warns(
+        DeprecationWarning, match="Indexing a WCS.pipeline step is deprecated."
+    ):
+        assert gw._pipeline[0][0].name == "detector"
+    assert gw._pipeline[1].frame.name == "icrs"
+    with pytest.warns(
+        DeprecationWarning, match="Indexing a WCS.pipeline step is deprecated."
+    ):
+        assert gw._pipeline[1][0].name == "icrs"
+    assert np.isin(gw.available_frames, ["detector", "icrs"]).all()
 
 
 def test_bounding_box_is_returned_F():

--- a/gwcs/tests/test_wcs.py
+++ b/gwcs/tests/test_wcs.py
@@ -819,11 +819,12 @@ def test_to_fits_sip_pc_normalization(gwcs_simple_imaging_units, matrix_type):
 
     wcs_forward = wcslin | tan | n2c
 
+    detector = cf.Frame2D(name="detector")
     sky_cs = cf.CelestialFrame(reference_frame=coord.ICRS(), name="sky")
-    pipeline = [("detector", wcs_forward), (sky_cs, None)]
+    pipeline = [(detector, wcs_forward), (sky_cs, None)]
 
     wcs_lin = wcs.WCS(
-        input_frame=cf.Frame2D(name="detector"),
+        input_frame=detector,
         output_frame=sky_cs,
         forward_transform=pipeline,
     )

--- a/gwcs/wcs/_exception.py
+++ b/gwcs/wcs/_exception.py
@@ -64,6 +64,12 @@ class GwcsFrameExistsError(ValueError):
     """
 
 
+class GwcsTransformDoesNotExistError(ValueError):
+    """
+    An error used to report when a transform does not exist in a pipeline.
+    """
+
+
 class GwcsBoundingBoxWarning(UserWarning):
     """
     A warning class to report issues with bounding boxes in GWCS.

--- a/gwcs/wcs/_pipeline.py
+++ b/gwcs/wcs/_pipeline.py
@@ -6,7 +6,7 @@ from astropy.modeling import Model
 from astropy.modeling.bounding_box import CompoundBoundingBox, ModelBoundingBox
 from astropy.units import Unit
 
-from gwcs.coordinate_frames import CoordinateFrame, EmptyFrame
+from gwcs.coordinate_frames import CoordinateFrame
 from gwcs.utils import CoordinateFrameError
 
 from ._exception import GwcsBoundingBoxWarning, GwcsFrameExistsError
@@ -105,6 +105,22 @@ class Pipeline:
         """
         return [step.frame.name for step in self._pipeline]
 
+    def get_frame(self, frame: str | CoordinateFrame) -> CoordinateFrame:
+        """
+        Return the frame object corresponding to the given frame name.
+
+        Parameters
+        ----------
+        frame : str or `~gwcs.coordinate_frames.CoordinateFrame`
+            Name of the frame or the frame object.
+
+        Returns
+        -------
+        frame : `~gwcs.coordinate_frames.CoordinateFrame`
+            The frame object corresponding to the given name.
+        """
+        return self._pipeline[self._frame_index(frame)].frame
+
     def _wrap_step(
         self, step: Step | StepTuple, *, replace_index: int | None = None
     ) -> Step:
@@ -167,30 +183,19 @@ class Pipeline:
 
         self._check_last_step()
 
-    @staticmethod
-    def _handle_empty_frame(frame: CoordinateFrame | None) -> CoordinateFrame | None:
-        """
-        Handle the case where the frame is an EmptyFrame.
-        """
-        return None if isinstance(frame, EmptyFrame) else frame
-
     @property
-    def input_frame(self) -> CoordinateFrame | None:
+    def input_frame(self) -> CoordinateFrame:
         """
         Return the input frame name of the pipeline.
         """
-        return self._handle_empty_frame(
-            self._pipeline[0].frame if self._pipeline else None
-        )
+        return self._pipeline[0].frame
 
     @property
-    def output_frame(self) -> CoordinateFrame | None:
+    def output_frame(self) -> CoordinateFrame:
         """
         Return the output frame name of the pipeline.
         """
-        return self._handle_empty_frame(
-            self._pipeline[-1].frame if self._pipeline else None
-        )
+        return self._pipeline[-1].frame
 
     @property
     def unit(self) -> Unit | None:

--- a/gwcs/wcs/_pipeline.py
+++ b/gwcs/wcs/_pipeline.py
@@ -15,7 +15,7 @@ from ._step import IndexedStep, Step, StepTuple
 __all__ = ["ForwardTransform", "Pipeline"]
 
 # Type aliases due to the use of the `|` for type hints not working with Model
-ForwardTransform: TypeAlias = Union[Model, list[Step | StepTuple], None]  # noqa: UP007
+ForwardTransform: TypeAlias = Union[Model, list[Step | StepTuple]]  # noqa: UP007
 Mdl: TypeAlias = Union[Model, None]  # noqa: UP007
 
 
@@ -30,7 +30,8 @@ class Pipeline:
 
     def __init__(
         self,
-        forward_transform: ForwardTransform = None,
+        forward_transform: ForwardTransform,
+        *,
         input_frame: str | CoordinateFrame | None = None,
         output_frame: str | CoordinateFrame | None = None,
     ) -> None:
@@ -64,18 +65,6 @@ class Pipeline:
         -------
         An initialized pipeline.
         """
-        if forward_transform is None:
-            # Initialize a WCS without a forward_transform - allows building a
-            # WCS programmatically.
-            if output_frame is None:
-                msg = "An output_frame must be specified if forward_transform is None."
-                raise CoordinateFrameError(msg)
-
-            forward_transform = [
-                Step(input_frame, None),
-                Step(output_frame, None),
-            ]
-
         if isinstance(forward_transform, Model):
             if output_frame is None:
                 msg = (
@@ -90,7 +79,7 @@ class Pipeline:
 
         if not isinstance(forward_transform, list):
             msg = (
-                "Expected forward_transform to be a None, model, or a "
+                "Expected forward_transform to be Model, or a "
                 f"(frame, transform) list, got {type(forward_transform)}"
             )
             raise TypeError(msg)

--- a/gwcs/wcs/_pipeline.py
+++ b/gwcs/wcs/_pipeline.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import warnings
 from functools import reduce
 from typing import TypeAlias, Union
@@ -10,13 +12,12 @@ from gwcs.coordinate_frames import CoordinateFrame
 from gwcs.utils import CoordinateFrameError
 
 from ._exception import GwcsBoundingBoxWarning, GwcsFrameExistsError
-from ._step import IndexedStep, Step, StepTuple
+from ._step import IndexedStep, Mdl, Step, StepTuple
 
 __all__ = ["ForwardTransform", "Pipeline"]
 
 # Type aliases due to the use of the `|` for type hints not working with Model
 ForwardTransform: TypeAlias = Union[Model, list[Step | StepTuple]]  # noqa: UP007
-Mdl: TypeAlias = Union[Model, None]  # noqa: UP007
 
 
 class Pipeline:
@@ -69,6 +70,12 @@ class Pipeline:
             if output_frame is None:
                 msg = (
                     "An output_frame must be specified if forward_transform is a model."
+                )
+                raise CoordinateFrameError(msg)
+
+            if input_frame is None:
+                msg = (
+                    "An input_frame must be specified if forward_transform is a model."
                 )
                 raise CoordinateFrameError(msg)
 

--- a/gwcs/wcs/_step.py
+++ b/gwcs/wcs/_step.py
@@ -37,13 +37,13 @@ class Step:
         self.transform = transform
 
     @property
-    def frame(self):
+    def frame(self) -> CoordinateFrame:
         return self._frame
 
     @frame.setter
-    def frame(self, val):
-        if not isinstance(val, CoordinateFrame | str):
-            msg = '"frame" should be an instance of CoordinateFrame or a string.'
+    def frame(self, val: CoordinateFrame):
+        if not isinstance(val, CoordinateFrame):
+            msg = '"frame" should be an instance of CoordinateFrame.'
             raise TypeError(msg)
 
         self._frame = val

--- a/gwcs/wcs/_step.py
+++ b/gwcs/wcs/_step.py
@@ -7,11 +7,13 @@ from gwcs.coordinate_frames import CoordinateFrame, EmptyFrame
 
 __all__ = [
     "IndexedStep",
+    "Mdl",
     "Step",
     "StepTuple",
 ]
 
 
+Mdl: TypeAlias = Union[Model, None]  # noqa: UP007
 StepTuple: TypeAlias = tuple[CoordinateFrame, Union[Model, None]]  # noqa: UP007
 
 
@@ -28,7 +30,7 @@ class Step:
         The transform of the last step should be `None`.
     """
 
-    def __init__(self, frame: str | CoordinateFrame | None, transform=None):
+    def __init__(self, frame: str | CoordinateFrame, transform: Mdl = None):
         # Allow for a string to be passed in for the frame but be turned into a
         # frame object
         self.frame = (

--- a/gwcs/wcs/_wcs.py
+++ b/gwcs/wcs/_wcs.py
@@ -107,12 +107,16 @@ class WCS(Pipeline, WCSAPIMixin):
 
     def __init__(
         self,
-        forward_transform: ForwardTransform = None,
+        forward_transform: ForwardTransform,
         input_frame: CoordinateFrame | None = None,
         output_frame: CoordinateFrame | None = None,
         name: str | None = None,
     ) -> None:
-        super().__init__(forward_transform, input_frame, output_frame)
+        super().__init__(
+            forward_transform=forward_transform,
+            input_frame=input_frame,
+            output_frame=output_frame,
+        )
 
         self._approx_inverse = None
         self._name = "" if name is None else name

--- a/gwcs/wcs/_wcs.py
+++ b/gwcs/wcs/_wcs.py
@@ -24,7 +24,7 @@ from astropy.wcs.wcsapi.high_level_api import (
 )
 from scipy import optimize
 
-from gwcs.api import GWCSAPIMixin
+from gwcs.api import WCSAPIMixin
 from gwcs.coordinate_frames import (
     AxisType,
     CelestialFrame,
@@ -84,7 +84,7 @@ class _WorldAxisInfo:
         self.input_axes = input_axes
 
 
-class WCS(GWCSAPIMixin, Pipeline):
+class WCS(Pipeline, WCSAPIMixin):
     """
     Basic WCS class.
 
@@ -112,7 +112,7 @@ class WCS(GWCSAPIMixin, Pipeline):
         output_frame: CoordinateFrame | None = None,
         name: str | None = None,
     ) -> None:
-        super(GWCSAPIMixin, self).__init__(forward_transform, input_frame, output_frame)
+        super().__init__(forward_transform, input_frame, output_frame)
 
         self._approx_inverse = None
         self._name = "" if name is None else name
@@ -1291,7 +1291,7 @@ class WCS(GWCSAPIMixin, Pipeline):
                 [self._remove_units_input(b, self.input_frame) for b in bb]
             )
         else:
-            vertices = np.array(list(itertools.product(*bb))).T
+            vertices = np.array(list(itertools.product(*bb))).T  # type: ignore[assignment]
 
         # workaround an issue with bbox with quantity, interval needs to be a cquantity,
         # not a list of quantities strip units

--- a/gwcs/wcs/_wcs.py
+++ b/gwcs/wcs/_wcs.py
@@ -1,14 +1,17 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import annotations
+
 import functools
 import itertools
 import sys
 import warnings
 from copy import copy
+from typing import overload
 
 import astropy.units as u
 import numpy as np
 from astropy.io import fits
-from astropy.modeling import fix_inputs, projections
+from astropy.modeling import Model, fix_inputs, projections
 from astropy.modeling.bounding_box import ModelBoundingBox as Bbox
 from astropy.modeling.models import (
     Mapping,
@@ -37,6 +40,7 @@ from gwcs.utils import _compute_lon_pole, is_high_level, to_index
 
 from ._exception import NoConvergence
 from ._pipeline import ForwardTransform, Pipeline
+from ._step import Step, StepTuple
 from ._utils import (
     fit_2D_poly,
     fix_transform_inputs,
@@ -105,17 +109,36 @@ class WCS(Pipeline, WCSAPIMixin):
 
     """
 
+    @overload
+    def __init__(
+        self,
+        forward_transform: Model,
+        input_frame: str | CoordinateFrame,
+        output_frame: str | CoordinateFrame,
+        name: str | None = None,
+    ) -> None: ...
+
+    @overload
+    def __init__(
+        self,
+        forward_transform: list[Step | StepTuple],
+        input_frame: None = None,
+        output_frame: None = None,
+        name: str | None = None,
+    ) -> None: ...
+
     def __init__(
         self,
         forward_transform: ForwardTransform,
-        input_frame: CoordinateFrame | None = None,
-        output_frame: CoordinateFrame | None = None,
+        input_frame: str | CoordinateFrame | None = None,
+        output_frame: str | CoordinateFrame | None = None,
         name: str | None = None,
     ) -> None:
         super().__init__(
             forward_transform=forward_transform,
-            input_frame=input_frame,
-            output_frame=output_frame,
+            # mypy for some reason isn't able to infer the correct overload here
+            input_frame=input_frame,  # type: ignore[arg-type]
+            output_frame=output_frame,  # type: ignore[arg-type]
         )
 
         self._approx_inverse = None


### PR DESCRIPTION
<!-- describe the changes comprising this PR here -->

This PR simplifies the API for initializing GWCS so that users must supply at least an `input_frame`, `output_frame`, and `forward_transform` in some fashion to the GWCS in order to initialize it. In particular it reduces the API to two modes.

1. Supply a `forward_transform` in the form of a "pipeline", list of ordered pairs of (frame, transform from that frame).
2. Supply the `input_frame`, `output_frame`, and the `forward_transform` from the `input_frame` to the `output_frame`.

This makes it so that GWCS can reduce its internal handling complexities so that it can assume that it:

1. Always has a forward transform and that model's associated metadata.
2. Always have a frame and its associated meta data to infer how to handle the input and output information for evaluating a GWCS.

Since all realistic applications require all of this information to be functional and useful and virtually all use cases for this ultimately involve creating "simple" GWCS for unit testing, I believe this will benefit GWCS by constraining the API and making it easier to maintain functionality.

Fixes #685

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->

## Tasks

- [ ] Update or add relevant `gwcs` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [ ] Does this PR need a changelog entry? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).

<details><summary>News fragment change types:</summary>

- `changes/<PR#>.feature.rst`: new feature
- `changes/<PR#>.breaking.rst`: any change or deprecation of the public API
- `changes/<PR#>.bugfix.rst`: fixes an issue
- `changes/<PR#>.doc.rst`: documentation change
- `changes/<PR#>.misc.rst`: infrastructure or miscellaneous change
</details
