### PR TITLE
Remove strings as coordinate frames

### DIFF
--- a/changes/693.breaking.rst
+++ b/changes/693.breaking.rst
@@ -1,0 +1,11 @@
+Remove ability to use ``str`` as a frame when initializing a GWCS ``WCS``. This
+is theoretically a breaking change, but the only practical impacts should be felt
+on test code that was relying on this behavior for convenience.
+
+The rational for this change is to ensure that the metadata provided by frames
+is always available to the WCS. This makes the entire WCS a more robust object.
+
+Note that we still sort of support this but only when reading from an ASDF file.
+In that case, a clear warning is issued that will indicate that the WCS will not
+be fully functional until the frame is properly replaced with an actual coordinate
+frame object.

--- a/gwcs/converters/tests/test_wcs.py
+++ b/gwcs/converters/tests/test_wcs.py
@@ -71,12 +71,11 @@ def _wcs_factory():
     m1 = models.Shift(12.4) & models.Shift(-2)
     icrs = cf.CelestialFrame(name="icrs", reference_frame=coord.ICRS())
     det = cf.Frame2D(name="detector", axes_order=(0, 1))
-    gw1 = wcs.WCS(output_frame="icrs", input_frame="detector", forward_transform=m1)
+    gw1 = wcs.WCS(output_frame=icrs, input_frame=det, forward_transform=m1)
     gw2 = wcs.WCS(output_frame=icrs, input_frame=det, forward_transform=m1)
-    gw3 = wcs.WCS(output_frame=icrs, input_frame=det, forward_transform=m1)
-    gw3.pixel_shape = (100, 200)
+    gw2.pixel_shape = (100, 200)
 
-    return [gw1, gw2, gw3]
+    return [gw1, gw2]
 
 
 @pytest.mark.parametrize("gw", _wcs_factory())

--- a/gwcs/converters/wcs.py
+++ b/gwcs/converters/wcs.py
@@ -12,6 +12,8 @@ from asdf_astropy.converters.transform.core import (
 )
 
 if TYPE_CHECKING:
+    from typing import Any
+
     from gwcs.coordinate_frames import CoordinateFrame
 
 __all__ = [
@@ -63,7 +65,7 @@ class StepConverter(Converter):
         from gwcs.coordinate_frames import EmptyFrame
         from gwcs.wcs import Step
 
-        frame: CoordinateFrame | str = node["frame"]
+        frame = node["frame"]
         if isinstance(frame, str):
             frame = EmptyFrame(name=frame)
 
@@ -110,7 +112,7 @@ class FrameConverter(Converter):
     def _to_yaml_tree(self, frame: CoordinateFrame, tag, ctx):
         from gwcs.coordinate_frames import CoordinateFrame
 
-        node = {}
+        node: dict[str, Any] = {}
 
         node["name"] = frame.name
 

--- a/gwcs/converters/wcs.py
+++ b/gwcs/converters/wcs.py
@@ -60,9 +60,14 @@ class StepConverter(Converter):
     types = ("gwcs.wcs.Step",)
 
     def from_yaml_tree(self, node, tag, ctx):
+        from gwcs.coordinate_frames import EmptyFrame
         from gwcs.wcs import Step
 
-        return Step(frame=node["frame"], transform=node.get("transform", None))
+        frame: CoordinateFrame | str = node["frame"]
+        if isinstance(frame, str):
+            frame = EmptyFrame(name=frame)
+
+        return Step(frame=frame, transform=node.get("transform", None))
 
     def to_yaml_tree(self, step, tag, ctx):
         from gwcs.coordinate_frames import EmptyFrame

--- a/gwcs/coordinate_frames/_base.py
+++ b/gwcs/coordinate_frames/_base.py
@@ -133,16 +133,18 @@ class BaseCoordinateFrame(abc.ABC):
         """
         Add units to the arrays
         """
-        if self.naxes == 1 and np.isscalar(arrays):
-            return u.Quantity(arrays, self.unit[0])
-
-        return tuple(
+        output = tuple(
             array if unit is None else u.Quantity(array, unit=unit)
             # zip_longest is used here to support "non-coordinate" inputs/outputs
             #   This implicitly assumes that the "non-coordinate" inputs/outputs
             #   are tacked onto the end of the tuple of "coordinate" inputs/outputs.
             for array, unit in zip_longest(arrays, self.unit)
         )
+
+        if self.naxes == 1 and np.isscalar(arrays):
+            return output[0]
+
+        return output
 
     def remove_units(
         self, arrays: u.Quantity | np.ndarray | list[float]

--- a/gwcs/coordinate_frames/_core.py
+++ b/gwcs/coordinate_frames/_core.py
@@ -44,7 +44,7 @@ class CoordinateFrame(BaseCoordinateFrame):
         reference_frame=None,
         unit=None,
         axes_names=None,
-        name=None,
+        name: str | None = None,
         axis_physical_types=None,
     ):
         self._naxes = naxes
@@ -102,12 +102,12 @@ class CoordinateFrame(BaseCoordinateFrame):
         return tuple([t[0] for t in sorted_prop])
 
     @property
-    def name(self):
+    def name(self) -> str:
         """A custom name of this frame."""
         return self._name
 
     @name.setter
-    def name(self, val):
+    def name(self, val: str):
         """A custom name of this frame."""
         self._name = val
 

--- a/gwcs/coordinate_frames/_empty.py
+++ b/gwcs/coordinate_frames/_empty.py
@@ -1,3 +1,5 @@
+import warnings
+
 from ._core import CoordinateFrame
 
 __all__ = ["EmptyFrame"]
@@ -11,6 +13,14 @@ class EmptyFrame(CoordinateFrame):
 
     def __init__(self, name=None):
         self._name = "detector" if name is None else name
+
+        msg = (
+            "The use of strings in place of a proper CoordinateFrame has been removed."
+            " Support for this has been removed, so your GWCS object may not function"
+            " as expected. The EmptyFrame object is only provided so that existing"
+            " ASDF files can still be read."
+        )
+        warnings.warn(msg, DeprecationWarning, stacklevel=2)
 
     def __repr__(self):
         return f'<{type(self).__name__}(name="{self.name}")>'

--- a/gwcs/coordinate_frames/_properties.py
+++ b/gwcs/coordinate_frames/_properties.py
@@ -30,7 +30,7 @@ class FrameProperties:
             if len(unit) != naxes:
                 msg = "Number of units does not match number of axes."
                 raise ValueError(msg)
-            self.unit = tuple(u.Unit(au) for au in unit)
+            self.unit = tuple(au if au is None else u.Unit(au) for au in unit)
         else:
             self.unit = tuple(u.dimensionless_unscaled for na in range(naxes))
 

--- a/gwcs/examples.py
+++ b/gwcs/examples.py
@@ -32,14 +32,6 @@ def gwcs_simple_2d():
     return wcs.WCS(MODEL_2D_SHIFT, input_frame=input_frame, output_frame=output_frame)
 
 
-def gwcs_empty_output_2d():
-    return wcs.WCS(
-        MODEL_2D_SHIFT,
-        input_frame=cf.EmptyFrame(name="detector"),
-        output_frame=cf.EmptyFrame(name="world"),
-    )
-
-
 def gwcs_2d_quantity_shift():
     frame = cf.CoordinateFrame(
         name="quantity",
@@ -302,12 +294,6 @@ def gwcs_3spectral_orders():
     m = models.Mapping((0, 1, 1)) | MODEL_2D_SHIFT & MODEL_1D_SCALE
 
     return wcs.WCS([(detector_frame, m), (comp1, None)])
-
-
-def gwcs_with_frames_strings():
-    transform = models.Shift(1) & models.Shift(1) & models.Polynomial2D(1)
-    pipe = [("detector", transform), ("world", None)]
-    return wcs.WCS(pipe)
 
 
 def sellmeier_glass():

--- a/gwcs/tests/conftest.py
+++ b/gwcs/tests/conftest.py
@@ -13,11 +13,6 @@ def gwcs_simple_2d():
 
 
 @pytest.fixture
-def gwcs_empty_output_2d():
-    return examples.gwcs_empty_output_2d()
-
-
-@pytest.fixture
 def gwcs_2d_quantity_shift():
     return examples.gwcs_2d_quantity_shift()
 
@@ -85,11 +80,6 @@ def gwcs_stokes_lookup():
 @pytest.fixture
 def gwcs_3spectral_orders():
     return examples.gwcs_3spectral_orders()
-
-
-@pytest.fixture
-def gwcs_with_frames_strings():
-    return examples.gwcs_with_frames_strings()
 
 
 @pytest.fixture

--- a/gwcs/tests/test_api.py
+++ b/gwcs/tests/test_api.py
@@ -308,7 +308,7 @@ def test_high_level_wrapper(wcsobj, request):
     # uses the mixin class and __call__ calls values_to_high_level_objects
     wc1 = hlvl.pixel_to_world(*pixel_input)
     wc2 = wcsobj(*pixel_input)
-    results = wcsobj._remove_units_input(wc2, wcsobj.output_frame)
+    results = wcsobj.output_frame.remove_units(wc2)
 
     wc2 = values_to_high_level_objects(*results, low_level_wcs=wcsobj)
     if len(wc2) == 1:

--- a/gwcs/tests/test_api.py
+++ b/gwcs/tests/test_api.py
@@ -548,12 +548,6 @@ def test_world_to_array_index_values(gwcs_simple_imaging, sky_ra_dec):
     )
 
 
-def test_ndim_str_frames(gwcs_with_frames_strings):
-    wcsobj = gwcs_with_frames_strings
-    assert wcsobj.pixel_n_dim == 4
-    assert wcsobj.world_n_dim == 3
-
-
 def test_composite_many_base_frame():
     q_frame_1 = cf.CoordinateFrame(
         name="distance", axes_order=(0,), naxes=1, axes_type="SPATIAL", unit=(u.m,)
@@ -642,14 +636,3 @@ def test_no_input_frame(gwcs_simple_2d):
     assert (np.array([4]), np.array([3])) == gwcs_simple_2d.pixel_to_world_values(
         np.array([3]), np.array([1])
     )
-
-
-def test_empty_output_frame(gwcs_empty_output_2d):
-    """Test running the API on the WCS with an empty output frame."""
-    assert (np.array([3]), np.array([1])) == gwcs_empty_output_2d.pixel_to_world_values(
-        np.array([2]), np.array([-1])
-    )
-    assert (
-        np.array([2]),
-        np.array([-1]),
-    ) == gwcs_empty_output_2d.world_to_pixel_values(np.array([3]), np.array([1]))

--- a/gwcs/tests/test_api_consistent.py
+++ b/gwcs/tests/test_api_consistent.py
@@ -200,20 +200,17 @@ def test_transform_with_units(wcsobj):
 @wcs_no_unit_1d
 def test_add_units(wcsobj):
     if wcsobj.input_frame.naxes == 1:
-        assert (
-            wcsobj._add_units_input((1,), wcsobj.input_frame)
-            == 1 * wcsobj.input_frame.unit[0]
-        )
+        assert wcsobj.input_frame.add_units((1,)) == 1 * wcsobj.input_frame.unit[0]
         assert_allclose(
-            wcsobj._add_units_input(([1, 1],), wcsobj.input_frame),
+            wcsobj.input_frame.add_units(([1, 1],)),
             ([1, 1] * wcsobj.input_frame.unit[0],),
         )
     elif wcsobj.input_frame.naxes == 2:
         assert_quantity_allclose(
-            wcsobj._add_units_input((1, 1), wcsobj.input_frame), (1 * u.pix, 1 * u.pix)
+            wcsobj.input_frame.add_units((1, 1)), (1 * u.pix, 1 * u.pix)
         )
         assert_quantity_allclose(
-            wcsobj._add_units_input(([1, 1], [1, 1]), wcsobj.input_frame),
+            wcsobj.input_frame.add_units(([1, 1], [1, 1])),
             ([1, 1] * u.pix, [1, 1] * u.pix),
         )
 
@@ -222,19 +219,15 @@ def test_add_units(wcsobj):
 def test_remove_units(wcsobj):
     if wcsobj.input_frame.naxes == 1:
         unit = wcsobj.input_frame.unit[0]
-        assert wcsobj._remove_units_input(1 * unit, wcsobj.input_frame) == (1,)
-        assert_allclose(
-            wcsobj._remove_units_input(([1, 1] * unit,), wcsobj.input_frame), ([1, 1],)
-        )
+        assert wcsobj.input_frame.remove_units((1 * unit,)) == (1,)
+        assert_allclose(wcsobj.input_frame.remove_units(([1, 1] * unit,)), ([1, 1],))
     elif wcsobj.input_frame.naxes == 2:
         assert_quantity_allclose(
-            wcsobj._remove_units_input((1 * u.pix, 1 * u.pix), wcsobj.input_frame),
+            wcsobj.input_frame.remove_units((1 * u.pix, 1 * u.pix)),
             (1, 1),
         )
         assert_quantity_allclose(
-            wcsobj._remove_units_input(
-                ([1, 1] * u.pix, [1, 1] * u.pix), wcsobj.input_frame
-            ),
+            wcsobj.input_frame.remove_units(([1, 1] * u.pix, [1, 1] * u.pix)),
             ([1, 1], [1, 1]),
         )
 

--- a/gwcs/tests/test_region.py
+++ b/gwcs/tests/test_region.py
@@ -243,8 +243,8 @@ def test_RegionsSelector():
 
     wcs = WCS(
         forward_transform=reg_selector,
-        input_frame="detector",
-        output_frame=cf.Frame2D(),
+        input_frame=cf.Frame2D(name="detector"),
+        output_frame=cf.Frame2D(name="world"),
     )
     out = wcs(1, 1)
     assert out == (-100, -100)

--- a/gwcs/tests/test_wcs.py
+++ b/gwcs/tests/test_wcs.py
@@ -78,7 +78,7 @@ def test_create_wcs():
     Test initializing a WCS object.
     """
     # use only frame names
-    gw1 = wcs.WCS(output_frame="icrs", input_frame="detector", forward_transform=m)
+    gw1 = wcs.WCS(output_frame=icrs, input_frame=detector, forward_transform=m)
     # use CoordinateFrame objects
     gw2 = wcs.WCS(output_frame=icrs, input_frame=detector, forward_transform=m)
     # use a pipeline to initialize
@@ -106,7 +106,7 @@ def test_init_no_output_frame():
 
 def test_insert_transform():
     """Test inserting a transform."""
-    gw = wcs.WCS(output_frame="icrs", input_frame="detector", forward_transform=m1)
+    gw = wcs.WCS(output_frame=icrs, input_frame=detector, forward_transform=m1)
     assert_allclose(gw.forward_transform(1, 2), m1(1, 2))
     gw.insert_transform(frame="icrs", transform=m2)
     assert_allclose(gw.forward_transform(1, 2), (m1 | m2)(1, 2))
@@ -179,8 +179,8 @@ def test_backward_transform():
     poly = models.Polynomial1D(1, c0=4)
     w = wcs.WCS(
         forward_transform=poly & models.Scale(2),
-        input_frame="detector",
-        output_frame="sky",
+        input_frame=cf.Frame2D(name="detector"),
+        output_frame=cf.Frame2D(name="sky"),
     )
     with pytest.raises(NotImplementedError):
         _ = w.backward_transform
@@ -189,8 +189,8 @@ def test_backward_transform():
     poly.inverse = models.Shift(-4)
     w = wcs.WCS(
         forward_transform=poly & models.Scale(2),
-        input_frame="detector",
-        output_frame="sky",
+        input_frame=cf.Frame2D(name="detector"),
+        output_frame=cf.Frame2D(name="sky"),
     )
     assert_allclose(w.backward_transform(1, 2), (-3, 1))
 
@@ -205,7 +205,7 @@ def test_backward_transform_has_inverse():
     )  # this is NOT the actual inverse of poly
     w = wcs.WCS(
         forward_transform=poly & models.Scale(2),
-        input_frame="detector",
+        input_frame=cf.Frame2D(name="detector"),
         output_frame=icrs,
     )
     assert_allclose(w.backward_transform.inverse(1, 2), w(1, 2))
@@ -257,18 +257,28 @@ def test_from_fiducial_frame2d():
 
 def test_bounding_box():
     trans3 = models.Shift(10) & models.Scale(2) & models.Shift(-1)
-    pipeline = [("detector", trans3), ("sky", None)]
+    detector = cf.CompositeFrame([cf.Frame2D(), spec], name="detector")
+    sky = cf.CompositeFrame([icrs, spec], name="sky")
+    pipeline = [(detector, trans3), (sky, None)]
     w = wcs.WCS(pipeline)
     bb = ((-1, 10), (6, 15))
     with pytest.raises(ValueError):  # noqa: PT011
         w.bounding_box = bb
     trans2 = models.Shift(10) & models.Scale(2)
-    pipeline = [("detector", trans2), ("sky", None)]
+    detector = cf.Frame2D(name="detector")
+    sky = cf.Frame2D(name="sky")
+    pipeline = [(detector, trans2), (sky, None)]
     w = wcs.WCS(pipeline)
     w.bounding_box = bb
     assert w.bounding_box == w.forward_transform.bounding_box
 
-    pipeline = [("detector", models.Shift(2)), ("sky", None)]
+    detector = cf.CoordinateFrame(
+        naxes=1, axes_type=(cf.AxisType.SPATIAL,), axes_order=(0,), name="detector"
+    )
+    sky = cf.CoordinateFrame(
+        naxes=1, axes_type=(cf.AxisType.SPATIAL,), axes_order=(0,), name="sky"
+    )
+    pipeline = [(detector, models.Shift(2)), (sky, None)]
     w = wcs.WCS(pipeline)
     w.bounding_box = (1, 5)
     assert w.bounding_box == w.forward_transform.bounding_box
@@ -280,7 +290,9 @@ def test_bounding_box_units():
     # Test that bounding_box with quantities can be assigned and evaluates
     bb = ((1 * u.pix, 5 * u.pix), (2 * u.pix, 6 * u.pix))
     trans = models.Shift(10 * u.pix) & models.Shift(2 * u.pix)
-    pipeline = [("detector", trans), ("sky", None)]
+    detector = cf.Frame2D(name="detector", unit=None)
+    sky = cf.Frame2D(name="sky", unit=None)
+    pipeline = [(detector, trans), (sky, None)]
     w = wcs.WCS(pipeline)
     w.bounding_box = bb
     world = w(-1 * u.pix, -1 * u.pix)
@@ -289,7 +301,9 @@ def test_bounding_box_units():
 
 def test_compound_bounding_box():
     trans3 = models.Shift(10) & models.Scale(2) & models.Shift(-1)
-    pipeline = [("detector", trans3), ("sky", None)]
+    detector = cf.CompositeFrame([cf.Frame2D(), spec], name="detector")
+    sky = cf.CompositeFrame([icrs, spec], name="sky")
+    pipeline = [(detector, trans3), (sky, None)]
     w = wcs.WCS(pipeline)
     cbb = {
         1: ((-1, 10), (6, 15)),
@@ -318,7 +332,9 @@ def test_compound_bounding_box():
 
     # Test that bounding_box with quantities can be assigned and evaluates
     trans = models.Shift(10 * u.pix) & models.Shift(2 * u.pix)
-    pipeline = [("detector", trans), ("sky", None)]
+    detector = cf.Frame2D(name="detector", unit=None)
+    sky = cf.Frame2D(name="sky", unit=None)
+    pipeline = [(detector, trans), (sky, None)]
     w = wcs.WCS(pipeline)
     cbb = {1 * u.pix: (1 * u.pix, 5 * u.pix), 2 * u.pix: (2 * u.pix, 6 * u.pix)}
     w.attach_compound_bounding_box(cbb, [("x1",)])
@@ -534,7 +550,13 @@ def test_format_output():
     points = np.arange(5)
     values = np.array([1.5, 3.4, 6.7, 7, 32])
     t = models.Tabular1D(points, values)
-    pipe = [("detector", t), ("world", None)]
+    detector = cf.CoordinateFrame(
+        naxes=1, axes_type=(cf.AxisType.SPATIAL,), axes_order=(0,), name="detector"
+    )
+    world = cf.CoordinateFrame(
+        naxes=1, axes_type=(cf.AxisType.SPATIAL,), axes_order=(0,), name="world"
+    )
+    pipe = [(detector, t), (world, None)]
     w = wcs.WCS(pipe)
     assert_allclose(w(1), 3.4)
     assert_allclose(w([1, 2]), [3.4, 6.7])
@@ -559,7 +581,8 @@ def test_footprint():
     )
     world = cf.CompositeFrame([icrs, spec])
     transform = (models.Shift(10) & models.Shift(-1)) & models.Scale(2)
-    pipe = [("det", transform), (world, None)]
+    detector = cf.CompositeFrame([cf.Frame2D(), spec], name="det")
+    pipe = [(detector, transform), (world, None)]
     w = wcs.WCS(pipe)
 
     with pytest.raises(TypeError):
@@ -1421,9 +1444,16 @@ def test_initialize_wcs_with_list():
     # make pipeline consisting of tuples and Steps
     shift1 = models.Shift(10 * u.pix) & models.Shift(2 * u.pix)
     shift2 = models.Shift(3 * u.pix)
-    pipeline = [("detector", shift1), wcs.Step("extra_step", shift2)]
+    detector = cf.Frame2D(name="detector", axes_order=(0, 1))
+    extra_step = cf.CoordinateFrame(
+        naxes=1, axes_type=(cf.AxisType.SPATIAL,), axes_order=(0,), name="extra_step"
+    )
+    pipeline = [(detector, shift1), wcs.Step(extra_step, shift2)]
 
-    end_step = ("end_step", None)
+    end_step = cf.CoordinateFrame(
+        naxes=1, axes_type=(cf.AxisType.SPATIAL,), axes_order=(0,), name="end_step"
+    )
+    end_step = (end_step, None)
     pipeline.append(end_step)
 
     # make sure no warnings occur when creating wcs with this pipeline
@@ -1517,7 +1547,9 @@ def test_spatial_spectral_stokes():
 
 
 def test_wcs_str():
-    gw = wcs.WCS(forward_transform=m1, input_frame="detector", output_frame="icrs")
+    input_frame = cf.Frame2D(name="detector")
+    icrs = cf.CelestialFrame(reference_frame=coord.ICRS(), name="icrs")
+    gw = wcs.WCS(forward_transform=m1, input_frame=input_frame, output_frame=icrs)
     assert "icrs" in str(gw)
     assert len(gw._pipeline) == 2
     assert gw.pipeline[0].frame.name == "detector"

--- a/gwcs/wcs/_pipeline.py
+++ b/gwcs/wcs/_pipeline.py
@@ -273,6 +273,10 @@ class Pipeline:
         """
         Combine a list of transforms into a single transform.
         """
+        if any(t is None for t in transforms):
+            msg = "Can not combine transforms if any are None."
+            raise NotImplementedError(msg)
+
         return reduce(lambda x, y: x | y, transforms)
 
     @staticmethod
@@ -342,7 +346,7 @@ class Pipeline:
         # Moving backwards over the pipeline
         if to_index < from_index:
             transforms = [
-                step.transform.inverse
+                step.inverse_transform
                 for step in self._pipeline[to_index:from_index][::-1]
             ]
 
@@ -575,7 +579,7 @@ class Pipeline:
 
     def attach_compound_bounding_box(
         self, cbbox: dict[tuple[str], tuple], selector_args: tuple[str]
-    ):
+    ) -> None:
         """
         Attach a compound bounding box dictionary to the pipeline.
 

--- a/gwcs/wcs/_pipeline.py
+++ b/gwcs/wcs/_pipeline.py
@@ -34,8 +34,8 @@ class Pipeline:
         self,
         forward_transform: Model,
         *,
-        input_frame: str | CoordinateFrame,
-        output_frame: str | CoordinateFrame,
+        input_frame: CoordinateFrame,
+        output_frame: CoordinateFrame,
     ) -> None: ...
 
     @overload
@@ -51,8 +51,8 @@ class Pipeline:
         self,
         forward_transform: ForwardTransform,
         *,
-        input_frame: str | CoordinateFrame | None = None,
-        output_frame: str | CoordinateFrame | None = None,
+        input_frame: CoordinateFrame | None = None,
+        output_frame: CoordinateFrame | None = None,
     ) -> None:
         self._pipeline: list[Step] = []
         self._initialize_pipeline(forward_transform, input_frame, output_frame)
@@ -60,8 +60,8 @@ class Pipeline:
     def _initialize_pipeline(
         self,
         forward_transform: ForwardTransform,
-        input_frame: str | CoordinateFrame | None,
-        output_frame: str | CoordinateFrame | None,
+        input_frame: CoordinateFrame | None,
+        output_frame: CoordinateFrame | None,
     ) -> None:
         """
         Initialize a pipeline from a forward transform specification.
@@ -431,9 +431,9 @@ class Pipeline:
 
     def insert_frame(
         self,
-        input_frame: str | CoordinateFrame,
+        input_frame: CoordinateFrame,
         transform: Model,
-        output_frame: str | CoordinateFrame,
+        output_frame: CoordinateFrame,
     ) -> None:
         """
         Insert a new frame into an existing pipeline. This frame must be
@@ -453,7 +453,7 @@ class Pipeline:
             Coordinate frame at end of new transform
         """
 
-        def get_index(frame: str | CoordinateFrame) -> int | None:
+        def get_index(frame: CoordinateFrame) -> int | None:
             try:
                 index = self._frame_index(frame)
             except CoordinateFrameError as err:

--- a/gwcs/wcs/_step.py
+++ b/gwcs/wcs/_step.py
@@ -3,7 +3,7 @@ from typing import NamedTuple, TypeAlias, Union
 
 from astropy.modeling.core import Model
 
-from gwcs.coordinate_frames import CoordinateFrame, EmptyFrame
+from gwcs.coordinate_frames import CoordinateFrame
 
 __all__ = [
     "IndexedStep",
@@ -30,12 +30,14 @@ class Step:
         The transform of the last step should be `None`.
     """
 
-    def __init__(self, frame: str | CoordinateFrame, transform: Mdl = None):
+    def __init__(self, frame: CoordinateFrame, transform: Mdl = None):
         # Allow for a string to be passed in for the frame but be turned into a
         # frame object
-        self.frame = (
-            frame if isinstance(frame, CoordinateFrame) else EmptyFrame(name=frame)
-        )
+        if not isinstance(frame, CoordinateFrame):
+            msg = "`frame` should be an instance of CoordinateFrame"
+            raise TypeError(msg)
+
+        self.frame = frame
         self.transform = transform
 
     @property

--- a/gwcs/wcs/_step.py
+++ b/gwcs/wcs/_step.py
@@ -1,5 +1,5 @@
 import warnings
-from typing import NamedTuple, TypeAlias, Union
+from typing import NamedTuple, Self, TypeAlias, Union
 
 from astropy.modeling.core import Model
 
@@ -53,21 +53,29 @@ class Step:
         self._frame = val
 
     @property
-    def transform(self):
+    def transform(self) -> Mdl:
         return self._transform
 
     @transform.setter
-    def transform(self, val):
-        if val is not None and not isinstance(val, (Model)):
+    def transform(self, val: Mdl):
+        if val is not None and not isinstance(val, Model):
             msg = '"transform" should be an instance of astropy.modeling.Model.'
             raise TypeError(msg)
         self._transform = val
 
     @property
-    def frame_name(self):
-        if isinstance(self.frame, str):
-            return self.frame
+    def frame_name(self) -> str:
         return self.frame.name
+
+    @property
+    def inverse_transform(self) -> Mdl:
+        if self.transform is None:
+            return None
+
+        try:
+            return self.transform.inverse
+        except NotImplementedError:
+            return None
 
     def __getitem__(self, ind):
         warnings.warn(
@@ -95,8 +103,8 @@ class Step:
             f"transform={getattr(self.transform, 'name', 'None') or type(self.transform).__name__})"  # noqa: E501
         )
 
-    def copy(self):
-        return Step(self.frame, self.transform)
+    def copy(self) -> Self:
+        return type(self)(self.frame, self.transform)
 
 
 class IndexedStep(NamedTuple):

--- a/gwcs/wcstools.py
+++ b/gwcs/wcstools.py
@@ -9,7 +9,14 @@ from astropy.modeling import fitting, models, projections
 from astropy.modeling.bounding_box import CompoundBoundingBox, ModelBoundingBox
 from astropy.modeling.core import Model
 
-from .coordinate_frames import CelestialFrame, CompositeFrame, Frame2D, SpectralFrame
+from .coordinate_frames import (
+    AxisType,
+    CelestialFrame,
+    CompositeFrame,
+    CoordinateFrame,
+    Frame2D,
+    SpectralFrame,
+)
 from .utils import (
     UnsupportedProjectionError,
     UnsupportedTransformError,
@@ -112,8 +119,16 @@ def wcs_from_fiducial(
             )
             raise ValueError(msg)
         forward_transform.bounding_box = bounding_box[::-1]
+
     if input_frame is None:
-        input_frame = "detector"
+        input_frame = CoordinateFrame(
+            naxes=forward_transform.n_inputs,
+            axes_type=(AxisType.SPATIAL,) * forward_transform.n_inputs,
+            axes_order=tuple(range(forward_transform.n_inputs)),
+            name="detector",
+            unit=(None,) * forward_transform.n_inputs,
+        )
+
     return WCS(
         output_frame=coordinate_frame,
         input_frame=input_frame,


### PR DESCRIPTION
<!-- describe the changes comprising this PR here -->

This PR removes the ability for users to use strings as coordinate frames in the GWCS. This ensures that the necessary meta data for the GWCS is present. The only uses of strings for coordinate frames was for creating partial GWCS for the purposes of unit testing. This is  a marginal case which can be resolved by the testers simply filling in the proper information for the GWCS

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->

## Tasks

- [ ] Update or add relevant `gwcs` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [ ] Does this PR need a changelog entry? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).

<details><summary>News fragment change types:</summary>

- `changes/<PR#>.feature.rst`: new feature
- `changes/<PR#>.breaking.rst`: any change or deprecation of the public API
- `changes/<PR#>.bugfix.rst`: fixes an issue
- `changes/<PR#>.doc.rst`: documentation change
- `changes/<PR#>.misc.rst`: infrastructure or miscellaneous change
</details
