### PR TITLE
Bugfixes for LabelMapper converters

### DIFF
--- a/changes/701.bugfix.rst
+++ b/changes/701.bugfix.rst
@@ -1,0 +1,12 @@
+Fix two bugs in the ``LabelMapperConverter``:
+
+   1. When roundtripping a ``LabelMapperArray``, with a non-default number
+      of ``inputs``, deserialization fails because the init of the
+      ``LabelMapperArray`` will set the number of inputs in the model to the
+      default value of 2, which is then attempted to be overridden by later
+      deseriaization methods.
+
+   2. The converter fails when ``lazy_load`` is set to false and the
+      ``mapper`` is an array.
+
+Both of these issues have been resolved.

--- a/gwcs/converters/selector.py
+++ b/gwcs/converters/selector.py
@@ -44,7 +44,9 @@ class LabelMapperConverter(TransformConverterBase):
             if mapper.ndim != 2:
                 msg = "GWCS currently only supports 2D masks."
                 raise NotImplementedError(msg)
-            return LabelMapperArray(mapper, inputs_mapping)
+            if (inputs := node.get("inputs")) is None:
+                return LabelMapperArray(mapper, inputs_mapping)
+            return LabelMapperArray(mapper, inputs_mapping, inputs=tuple(inputs))
         if isinstance(mapper, Model):
             inputs = node.get("inputs")
             return LabelMapper(

--- a/gwcs/converters/selector.py
+++ b/gwcs/converters/selector.py
@@ -40,7 +40,7 @@ class LabelMapperConverter(TransformConverterBase):
         atol = node.get("atol", 1e-8)
         no_label = node.get("no_label", np.nan)
 
-        if isinstance(mapper, NDArrayType):
+        if isinstance(mapper, (NDArrayType, np.ndarray)):
             if mapper.ndim != 2:
                 msg = "GWCS currently only supports 2D masks."
                 raise NotImplementedError(msg)

--- a/gwcs/converters/tests/test_selector.py
+++ b/gwcs/converters/tests/test_selector.py
@@ -94,6 +94,14 @@ def test_labelMapperArray_int(tmp_path):
     assert_selector_roundtrip(mask, tmp_path)
 
 
+def test_labelMapperArray_non_default_inputs(tmp_path):
+    a = np.array([[1, 0, 2], [1, 0, 0], [1, 2, 2]])
+    mask = selector.LabelMapperArray(
+        a, inputs_mapping=Mapping((0, 1), n_inputs=3), inputs=("x", "y", "order")
+    )
+    assert_selector_roundtrip(mask, tmp_path)
+
+
 def test_LabelMapperDict(tmp_path):
     dmapper = create_scalar_mapper()
     sel = selector.LabelMapperDict(

--- a/gwcs/converters/tests/test_selector.py
+++ b/gwcs/converters/tests/test_selector.py
@@ -1,6 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import asdf
 import numpy as np
+import pytest
 from astropy.modeling.models import Mapping, Polynomial2D, Scale, Shift
 from numpy.testing import assert_array_equal
 
@@ -45,7 +46,7 @@ def _assert_selector_equal(a, b):
         assert_array_equal(a.undefined_transform_value, b.undefined_transform_value)
 
 
-def assert_selector_roundtrip(s, tmp_path, version=None):
+def assert_selector_roundtrip(s, tmp_path, lazy_load=True, version=None):
     """
     Assert that a selector can be written to an ASDF file and read back
     in without losing any of its essential properties.
@@ -55,7 +56,7 @@ def assert_selector_roundtrip(s, tmp_path, version=None):
     with asdf.AsdfFile({"selector": s}, version=version) as af:
         af.write_to(path)
 
-    with asdf.open(path) as af:
+    with asdf.open(path, lazy_load=lazy_load) as af:
         rs = af["selector"]
         if isinstance(s, selector.RegionsSelector):
             _assert_selector_equal(s, rs)
@@ -66,72 +67,76 @@ def assert_selector_roundtrip(s, tmp_path, version=None):
             raise TypeError(msg)
 
 
-def test_regions_selector(tmp_path):
-    m1 = Mapping([0, 1, 1]) | Shift(1) & Shift(2) & Shift(3)
-    m2 = Mapping([0, 1, 1]) | Scale(2) & Scale(3) & Scale(3)
-    sel = {1: m1, 2: m2}
-    a = np.zeros((5, 6), dtype=np.int32)
-    a[:, 1:3] = 1
-    a[:, 4:5] = 2
-    mask = selector.LabelMapperArray(a)
-    rs = selector.RegionsSelector(
-        inputs=("x", "y"), outputs=("ra", "dec", "lam"), selector=sel, label_mapper=mask
-    )
-    assert_selector_roundtrip(rs, tmp_path)
+@pytest.mark.parametrize("lazy_load", [True, False])
+class TestSelectorConverter:
+    def test_regions_selector(self, tmp_path, lazy_load):
+        m1 = Mapping([0, 1, 1]) | Shift(1) & Shift(2) & Shift(3)
+        m2 = Mapping([0, 1, 1]) | Scale(2) & Scale(3) & Scale(3)
+        sel = {1: m1, 2: m2}
+        a = np.zeros((5, 6), dtype=np.int32)
+        a[:, 1:3] = 1
+        a[:, 4:5] = 2
+        mask = selector.LabelMapperArray(a)
+        rs = selector.RegionsSelector(
+            inputs=("x", "y"),
+            outputs=("ra", "dec", "lam"),
+            selector=sel,
+            label_mapper=mask,
+        )
+        assert_selector_roundtrip(rs, tmp_path, lazy_load=lazy_load)
 
+    def test_LabelMapperArray_str(self, tmp_path, lazy_load):
+        a = np.array(
+            [
+                ["label1", "", "label2"],
+                ["label1", "", ""],
+                ["label1", "label2", "label2"],
+            ]
+        )
+        mask = selector.LabelMapperArray(a)
+        assert_selector_roundtrip(mask, tmp_path, lazy_load=lazy_load)
 
-def test_LabelMapperArray_str(tmp_path):
-    a = np.array(
-        [["label1", "", "label2"], ["label1", "", ""], ["label1", "label2", "label2"]]
-    )
-    mask = selector.LabelMapperArray(a)
-    assert_selector_roundtrip(mask, tmp_path)
+    def test_labelMapperArray_int(self, tmp_path, lazy_load):
+        a = np.array([[1, 0, 2], [1, 0, 0], [1, 2, 2]])
+        mask = selector.LabelMapperArray(a)
+        assert_selector_roundtrip(mask, tmp_path, lazy_load=lazy_load)
 
+    def test_labelMapperArray_non_default_inputs(self, tmp_path, lazy_load):
+        a = np.array([[1, 0, 2], [1, 0, 0], [1, 2, 2]])
+        mask = selector.LabelMapperArray(
+            a, inputs_mapping=Mapping((0, 1), n_inputs=3), inputs=("x", "y", "order")
+        )
+        assert_selector_roundtrip(mask, tmp_path, lazy_load=lazy_load)
 
-def test_labelMapperArray_int(tmp_path):
-    a = np.array([[1, 0, 2], [1, 0, 0], [1, 2, 2]])
-    mask = selector.LabelMapperArray(a)
-    assert_selector_roundtrip(mask, tmp_path)
+    def test_LabelMapperDict(self, tmp_path, lazy_load):
+        dmapper = create_scalar_mapper()
+        sel = selector.LabelMapperDict(
+            ("x", "y"), dmapper, inputs_mapping=Mapping((0,), n_inputs=2), atol=1e-3
+        )
+        assert_selector_roundtrip(sel, tmp_path, lazy_load=lazy_load)
 
-
-def test_labelMapperArray_non_default_inputs(tmp_path):
-    a = np.array([[1, 0, 2], [1, 0, 0], [1, 2, 2]])
-    mask = selector.LabelMapperArray(
-        a, inputs_mapping=Mapping((0, 1), n_inputs=3), inputs=("x", "y", "order")
-    )
-    assert_selector_roundtrip(mask, tmp_path)
-
-
-def test_LabelMapperDict(tmp_path):
-    dmapper = create_scalar_mapper()
-    sel = selector.LabelMapperDict(
-        ("x", "y"), dmapper, inputs_mapping=Mapping((0,), n_inputs=2), atol=1e-3
-    )
-    assert_selector_roundtrip(sel, tmp_path)
-
-
-def test_LabelMapperRange(tmp_path):
-    m = []
-    for i in np.arange(9) * 0.1:
-        c0_0, c1_0, c0_1, c1_1 = np.ones((4,)) * i
-        m.append(Polynomial2D(2, c0_0=c0_0, c1_0=c1_0, c0_1=c0_1, c1_1=c1_1))
-    keys = np.array(
-        [
-            [4.88, 5.64],
-            [5.75, 6.5],
-            [6.67, 7.47],
-            [7.7, 8.63],
-            [8.83, 9.96],
-            [10.19, 11.49],
-            [11.77, 13.28],
-            [13.33, 15.34],
-            [15.56, 18.09],
-        ]
-    )
-    rmapper = {}
-    for k, v in zip(keys, m, strict=False):
-        rmapper[tuple(k)] = v
-    sel = selector.LabelMapperRange(
-        ("x", "y"), rmapper, inputs_mapping=Mapping((0,), n_inputs=2)
-    )
-    assert_selector_roundtrip(sel, tmp_path)
+    def test_LabelMapperRange(self, tmp_path, lazy_load):
+        m = []
+        for i in np.arange(9) * 0.1:
+            c0_0, c1_0, c0_1, c1_1 = np.ones((4,)) * i
+            m.append(Polynomial2D(2, c0_0=c0_0, c1_0=c1_0, c0_1=c0_1, c1_1=c1_1))
+        keys = np.array(
+            [
+                [4.88, 5.64],
+                [5.75, 6.5],
+                [6.67, 7.47],
+                [7.7, 8.63],
+                [8.83, 9.96],
+                [10.19, 11.49],
+                [11.77, 13.28],
+                [13.33, 15.34],
+                [15.56, 18.09],
+            ]
+        )
+        rmapper = {}
+        for k, v in zip(keys, m, strict=False):
+            rmapper[tuple(k)] = v
+        sel = selector.LabelMapperRange(
+            ("x", "y"), rmapper, inputs_mapping=Mapping((0,), n_inputs=2)
+        )
+        assert_selector_roundtrip(sel, tmp_path, lazy_load=lazy_load)


### PR DESCRIPTION
<!-- describe the changes comprising this PR here -->

This PR addresses two bugs found in the label mapper converter:

1. It cannot handle non-default numbers of inputs for the `LabelMapperArray` when round tripping. fixes #700
2. It cannot handle when `lazy_load` is set to false. fixes #699

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->

## Tasks

- [ ] Update or add relevant `gwcs` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [ ] Does this PR need a changelog entry? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).

<details><summary>News fragment change types:</summary>

- `changes/<PR#>.feature.rst`: new feature
- `changes/<PR#>.breaking.rst`: any change or deprecation of the public API
- `changes/<PR#>.bugfix.rst`: fixes an issue
- `changes/<PR#>.doc.rst`: documentation change
- `changes/<PR#>.misc.rst`: infrastructure or miscellaneous change
</details
