### PR TITLE
Bugfix for `uses_quantity` lies

### DIFF
--- a/changes/709.bugfix.rst
+++ b/changes/709.bugfix.rst
@@ -1,0 +1,3 @@
+Bugfix for circumstances that occur when the number of parameters for a model
+is 0, which can lead to `~astropy.modeling.Model.uses_quantity` giving
+erroneous results by defaulting to `True`.

--- a/gwcs/tests/test_wcs.py
+++ b/gwcs/tests/test_wcs.py
@@ -1961,3 +1961,45 @@ def test_non_coordinate_input():
     )
     assert gw(1, 2, 3) == (1, 2, 3)
     assert gw(1 * u.deg, 2 * u.deg, 3) == (1 * u.deg, 2 * u.deg, 3 * u.micron)
+
+
+def test_tabular_quantity_issues():
+    """
+    This checks that the uses_quantity lie of astropy models for Tabular1D and Tabular2D
+    is caught and handled correctly by the WCS machinery. This is a regression test for
+    #686
+    """
+
+    in_frame = cf.CoordinateFrame(
+        naxes=1,
+        axes_type=["SPATIAL"],
+        name="pixels",
+        axes_names=("x",),
+        axes_order=(0,),
+        unit=(u.pix,),
+    )
+    out_frame = cf.SpectralFrame(name="wavelength", unit=(u.nm,))
+
+    m = models.Tabular1D(points=np.arange(10), lookup_table=np.arange(10) * 2)
+    gw = wcs.WCS([(in_frame, m), (out_frame, None)])
+
+    assert gw(2) == 4
+    assert gw(2 * u.pix) == 4 * u.nm
+
+
+def test_identity_quantity_issues():
+    in_frame = cf.CoordinateFrame(
+        naxes=1,
+        axes_type=["SPATIAL"],
+        name="pixels",
+        axes_names=("x",),
+        axes_order=(0,),
+        unit=(u.pix,),
+    )
+    out_frame = cf.SpectralFrame(name="wavelength", unit=(u.nm,))
+    m = models.Identity(1)
+
+    gw = wcs.WCS([(in_frame, m), (out_frame, None)])
+
+    assert gw(2) == 2
+    assert gw(2 * u.pix) == 2 * u.nm

--- a/gwcs/wcs/_wcs.py
+++ b/gwcs/wcs/_wcs.py
@@ -18,6 +18,8 @@ from astropy.modeling.models import (
     RotateCelestial2Native,
     Shift,
     Sky2Pix_TAN,
+    Tabular1D,
+    Tabular2D,
 )
 from astropy.modeling.parameters import _tofloat
 from astropy.wcs.utils import celestial_frame_to_wcs, proj_plane_pixel_scales
@@ -237,7 +239,14 @@ class WCS(Pipeline, WCSAPIMixin):
         """
         # Validate that the input type matches what the transform expects
         input_is_quantity = any(isinstance(a, u.Quantity) for a in args)
-        transform_uses_quantity = not (transform is None or not transform.uses_quantity)
+        if isinstance(transform, (Tabular1D, Tabular2D)):
+            transform_uses_quantity = isinstance(transform.lookup_table, u.Quantity)
+        elif transform is not None and len(transform.parameters) == 0:
+            transform_uses_quantity = False
+        else:
+            transform_uses_quantity = not (
+                transform is None or not transform.uses_quantity
+            )
         return input_is_quantity, transform_uses_quantity
 
     def _make_input_units_consistent(


### PR DESCRIPTION
<!-- describe the changes comprising this PR here -->

This PR attempts to address some of the issues with `uses_quantity` lies, such as those detailed in #686 and #558. Hopefully, this has more robust handling for the common case.

Fixes #686

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->

## Tasks

- [ ] Update or add relevant `gwcs` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [ ] Does this PR need a changelog entry? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).

<details><summary>News fragment change types:</summary>

- `changes/<PR#>.feature.rst`: new feature
- `changes/<PR#>.breaking.rst`: any change or deprecation of the public API
- `changes/<PR#>.bugfix.rst`: fixes an issue
- `changes/<PR#>.doc.rst`: documentation change
- `changes/<PR#>.misc.rst`: infrastructure or miscellaneous change
</details
