### PR TITLE
Unignore chararray DeprecationWarning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,8 +81,6 @@ filterwarnings = [
   "error",
   "ignore:Models in math_functions:astropy.utils.exceptions.AstropyUserWarning",
   "ignore:numpy.ndarray size changed:RuntimeWarning",
-  # Remove when https://github.com/astropy/astropy/issues/19216 is resolved
-  "ignore:The chararray class is deprecated and will be removed in a future release:DeprecationWarning",
 ]
 
 [tool.coverage.run]


### PR DESCRIPTION
<!-- describe the changes comprising this PR here -->

This PR reverts some of https://github.com/spacetelescope/gwcs/pull/691 . This does not need a change log.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->

## Tasks

- [ ] Update or add relevant `gwcs` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [ ] Does this PR need a changelog entry? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).

<details><summary>News fragment change types:</summary>

- `changes/<PR#>.feature.rst`: new feature
- `changes/<PR#>.breaking.rst`: any change or deprecation of the public API
- `changes/<PR#>.bugfix.rst`: fixes an issue
- `changes/<PR#>.doc.rst`: documentation change
- `changes/<PR#>.misc.rst`: infrastructure or miscellaneous change
</details
