### PR TITLE
Add support for frame aliases

### DIFF
--- a/changes/721.feature.rst
+++ b/changes/721.feature.rst
@@ -1,0 +1,1 @@
+Add ability to alias frames to additional names in the pipeline.

--- a/gwcs/converters/tests/test_wcs.py
+++ b/gwcs/converters/tests/test_wcs.py
@@ -27,6 +27,7 @@ def _assert_frame_equal(a, b):
         return a == b
 
     assert a.name == b.name  # nosec
+    assert a.aliases == b.aliases  # nosec
     if not isinstance(a, cf.EmptyFrame):
         assert a.axes_order == b.axes_order  # nosec
         assert a.axes_names == b.axes_names  # nosec
@@ -70,8 +71,10 @@ def assert_wcs_roundtrip(wcs, tmp_path, version=None):
 
 def _wcs_factory():
     m1 = models.Shift(12.4) & models.Shift(-2)
-    icrs = cf.CelestialFrame(name="icrs", reference_frame=coord.ICRS())
-    det = cf.Frame2D(name="detector", axes_order=(0, 1))
+    icrs = cf.CelestialFrame(
+        name="icrs", reference_frame=coord.ICRS(), aliases=("output_frame",)
+    )
+    det = cf.Frame2D(name="detector", axes_order=(0, 1), aliases=("det",))
 
     with pytest.warns(DeprecationWarning, match=r"The use of strings.*"):
         gw1 = wcs.WCS(output_frame="icrs", input_frame="detector", forward_transform=m1)

--- a/gwcs/converters/wcs.py
+++ b/gwcs/converters/wcs.py
@@ -103,6 +103,9 @@ class FrameConverter(Converter):
         if "axis_physical_types" in node:
             kwargs["axis_physical_types"] = tuple(node["axis_physical_types"])
 
+        if "aliases" in node:
+            kwargs["aliases"] = tuple(node["aliases"])
+
         return kwargs
 
     def _to_yaml_tree(self, frame: CoordinateFrame, tag, ctx):
@@ -133,6 +136,9 @@ class FrameConverter(Converter):
 
         if frame.raw_properties.axis_physical_types is not None:
             node["axis_physical_types"] = list(frame.raw_properties.axis_physical_types)
+
+        if frame.aliases:
+            node["aliases"] = list(frame.aliases)
 
         return node
 

--- a/gwcs/coordinate_frames/_base.py
+++ b/gwcs/coordinate_frames/_base.py
@@ -155,6 +155,13 @@ class CoordinateFrameProtocol(Protocol):
 
     @property
     @abstractmethod
+    def aliases(self) -> tuple[str, ...]:
+        """
+        Alternative names for the coordinate frame.
+        """
+
+    @property
+    @abstractmethod
     def unit(self) -> tuple[u.Unit, ...]:
         """
         The units of the axes in this frame.

--- a/gwcs/coordinate_frames/_celestial.py
+++ b/gwcs/coordinate_frames/_celestial.py
@@ -31,6 +31,8 @@ class CelestialFrame(CoordinateFrame):
         Names of the axes in this frame.
     name : str
         Name of this frame.
+    aliases : iterable of str
+        Alternative names for this frame.
     axis_physical_types : list
         The UCD 1+ physical types for the axes, in frame order (lon, lat).
     """
@@ -42,6 +44,7 @@ class CelestialFrame(CoordinateFrame):
         unit: tuple[u.Unit, ...] | None = None,
         axes_names: tuple[str, ...] | None = None,
         name: str | None = None,
+        aliases: list[str] | None = None,
         axis_physical_types: tuple[str | None, ...] | None = None,
     ) -> None:
         if (
@@ -80,6 +83,7 @@ class CelestialFrame(CoordinateFrame):
             unit=unit,
             axes_names=axes_names,
             name=name,
+            aliases=aliases,
             axis_physical_types=pht,
         )
 

--- a/gwcs/coordinate_frames/_composite.py
+++ b/gwcs/coordinate_frames/_composite.py
@@ -25,9 +25,16 @@ class CompositeFrame(CoordinateFrame):
         List of constituient frames.
     name : str
         Name for this frame.
+    aliases : iterable of str
+        Alternative names for this frame.
     """
 
-    def __init__(self, frames: list[CoordinateFrame], name: str | None = None) -> None:
+    def __init__(
+        self,
+        frames: list[CoordinateFrame],
+        name: str | None = None,
+        aliases: list[str] | None = None,
+    ) -> None:
         self._frames = frames[:]
         naxes = sum([frame._naxes for frame in self._frames])
 
@@ -63,6 +70,7 @@ class CompositeFrame(CoordinateFrame):
             axes_names=tuple(axes_names),
             axis_physical_types=tuple(ph_type),
             name=name,
+            aliases=aliases,
         )
         # Reset after the super init which may have messed this up
         self._axis_physical_types = tuple(ph_type)

--- a/gwcs/coordinate_frames/_core.py
+++ b/gwcs/coordinate_frames/_core.py
@@ -39,6 +39,8 @@ class CoordinateFrame(CoordinateFrameProtocol):
         Names of the axes in this frame.
     name : str
         Name of this frame.
+    aliases : iterable of str
+        Alternative names for this frame.
     """
 
     def __init__(
@@ -50,6 +52,7 @@ class CoordinateFrame(CoordinateFrameProtocol):
         unit: tuple[u.Unit, ...] | None = None,
         axes_names: tuple[str, ...] | None = None,
         name: str | None = None,
+        aliases: list[str] | None = None,
         axis_physical_types: tuple[str | None, ...] | None = None,
     ) -> None:
         self._naxes = naxes
@@ -57,6 +60,7 @@ class CoordinateFrame(CoordinateFrameProtocol):
         self._reference_frame = reference_frame
 
         self._name = type(self).__name__ if name is None else name
+        self._aliases = () if aliases is None else tuple(aliases)
 
         if len(self._axes_order) != naxes:
             msg = "Length of axes_order does not match number of axes."
@@ -114,6 +118,11 @@ class CoordinateFrame(CoordinateFrameProtocol):
     def name(self, val: str) -> None:
         """A custom name of this frame."""
         self._name = val
+
+    @property
+    def aliases(self):
+        """Alternative names for this frame."""
+        return self._aliases
 
     @property
     def naxes(self) -> int:

--- a/gwcs/coordinate_frames/_empty.py
+++ b/gwcs/coordinate_frames/_empty.py
@@ -15,8 +15,9 @@ class EmptyFrame(CoordinateFrame):
     for input frame by the WCS object.
     """
 
-    def __init__(self, name=None):
+    def __init__(self, name=None, aliases=None):
         self._name = "detector" if name is None else name
+        self._aliases = () if aliases is None else tuple(aliases)
         msg = (
             "The use of strings in place of a proper CoordinateFrame has been "
             "deprecated."

--- a/gwcs/coordinate_frames/_frame.py
+++ b/gwcs/coordinate_frames/_frame.py
@@ -23,6 +23,8 @@ class Frame2D(CoordinateFrame):
         Names of the axes in this frame.
     name : str
         Name of this frame.
+    aliases : iterable of str
+        Alternative names for this frame.
     """
 
     def __init__(
@@ -31,6 +33,7 @@ class Frame2D(CoordinateFrame):
         unit: tuple[u.Unit, u.Unit] = (u.pix, u.pix),
         axes_names: tuple[str, str] = ("x", "y"),
         name: str | None = None,
+        aliases: list[str] | None = None,
         axes_type: tuple[AxisType | str, AxisType | str] | None = None,
         axis_physical_types: tuple[str | None, str | None] | None = None,
     ) -> None:
@@ -44,6 +47,7 @@ class Frame2D(CoordinateFrame):
             name=name,
             axes_names=axes_names,
             unit=unit,
+            aliases=aliases,
             axis_physical_types=axis_physical_types
             or (
                 axes_names

--- a/gwcs/coordinate_frames/_spectral.py
+++ b/gwcs/coordinate_frames/_spectral.py
@@ -28,6 +28,8 @@ class SpectralFrame(CoordinateFrame):
         Spectral axis name.
     name : str
         Name for this frame.
+    aliases : iterable of str
+        Alternative names for this frame.
 
     """
 
@@ -38,6 +40,7 @@ class SpectralFrame(CoordinateFrame):
         unit: tuple[u.Unit] | None = None,
         axes_names: tuple[str] | None = None,
         name: str | None = None,
+        aliases: list[str] | None = None,
         axis_physical_types: tuple[str | None] | None = None,
     ) -> None:
         if unit is None or not np.iterable(unit):
@@ -53,6 +56,7 @@ class SpectralFrame(CoordinateFrame):
             reference_frame=reference_frame,
             unit=unit,
             name=name,
+            aliases=aliases,
             axis_physical_types=pht,
         )
 

--- a/gwcs/coordinate_frames/_stokes.py
+++ b/gwcs/coordinate_frames/_stokes.py
@@ -18,6 +18,8 @@ class StokesFrame(CoordinateFrame):
         Name of this frame.
     axes_order : tuple
         A dimension in the data that corresponds to this axis.
+    aliases : iterable of str
+        Alternative names for this frame.
     """
 
     def __init__(
@@ -25,6 +27,7 @@ class StokesFrame(CoordinateFrame):
         axes_order: tuple[int] = (0,),
         axes_names: tuple[str] = ("stokes",),
         name: str | None = None,
+        aliases: list[str] | None = None,
         axis_physical_types: tuple[str | None] | None = None,
     ) -> None:
         super().__init__(
@@ -32,6 +35,7 @@ class StokesFrame(CoordinateFrame):
             axes_type=(AxisType.STOKES,),
             axes_order=axes_order,
             name=name,
+            aliases=aliases,
             axes_names=axes_names,
             unit=(u.one,),
             axis_physical_types=axis_physical_types,

--- a/gwcs/coordinate_frames/_temporal.py
+++ b/gwcs/coordinate_frames/_temporal.py
@@ -30,6 +30,8 @@ class TemporalFrame(CoordinateFrame):
         A dimension in the data that corresponds to this axis.
     name : str
         Name for this frame.
+    aliases : iterable of str
+        Alternative names for this frame.
     """
 
     def __init__(
@@ -39,6 +41,7 @@ class TemporalFrame(CoordinateFrame):
         axes_order: tuple[int] = (0,),
         axes_names: tuple[str] | None = None,
         name: str | None = None,
+        aliases: list[str] | None = None,
         axis_physical_types: tuple[str | None] | None = None,
     ):
         axes_names = (
@@ -58,6 +61,7 @@ class TemporalFrame(CoordinateFrame):
             reference_frame=reference_frame,
             unit=unit,
             name=name,
+            aliases=aliases,
             axis_physical_types=axis_physical_types,
         )
         self._attrs = {}

--- a/gwcs/tests/test_coordinate_systems.py
+++ b/gwcs/tests/test_coordinate_systems.py
@@ -31,9 +31,13 @@ with contextlib.suppress(ValueError):
     coord_frames.remove("SkyOffsetFrame")
 
 
-icrs = cf.CelestialFrame(reference_frame=coord.ICRS(), axes_order=(0, 1))
-detector = cf.Frame2D(name="detector", axes_order=(0, 1))
-focal = cf.Frame2D(name="focal", axes_order=(0, 1), unit=(u.m, u.m))
+icrs = cf.CelestialFrame(
+    reference_frame=coord.ICRS(), axes_order=(0, 1), aliases=("test_alias",)
+)
+detector = cf.Frame2D(name="detector", axes_order=(0, 1), aliases=("test_alias",))
+focal = cf.Frame2D(
+    name="focal", axes_order=(0, 1), unit=(u.m, u.m), aliases=("test_alias",)
+)
 
 spec1 = cf.SpectralFrame(
     name="freq",
@@ -41,6 +45,7 @@ spec1 = cf.SpectralFrame(
         u.Hz,
     ],
     axes_order=(2,),
+    aliases=("test_alias",),
 )
 spec2 = cf.SpectralFrame(
     name="wave",
@@ -49,6 +54,7 @@ spec2 = cf.SpectralFrame(
     ],
     axes_order=(2,),
     axes_names=("lambda",),
+    aliases=("test_alias",),
 )
 spec3 = cf.SpectralFrame(
     name="energy",
@@ -56,6 +62,7 @@ spec3 = cf.SpectralFrame(
         u.J,
     ],
     axes_order=(2,),
+    aliases=("test_alias",),
 )
 spec4 = cf.SpectralFrame(
     name="pixel",
@@ -63,6 +70,7 @@ spec4 = cf.SpectralFrame(
         u.pix,
     ],
     axes_order=(2,),
+    aliases=("test_alias",),
 )
 with pytest.warns(UserWarning, match=r"Physical type may be ambiguous.*"):
     spec5 = cf.SpectralFrame(
@@ -71,14 +79,17 @@ with pytest.warns(UserWarning, match=r"Physical type may be ambiguous.*"):
             u.m / u.s,
         ],
         axes_order=(2,),
+        aliases=("test_alias",),
     )
 
-comp1 = cf.CompositeFrame([icrs, spec1])
-comp2 = cf.CompositeFrame([focal, spec2])
-comp3 = cf.CompositeFrame([icrs, spec3])
-comp4 = cf.CompositeFrame([icrs, spec4])
-comp5 = cf.CompositeFrame([icrs, spec5])
-comp = cf.CompositeFrame([comp1, cf.SpectralFrame(axes_order=(3,), unit=(u.m,))])
+comp1 = cf.CompositeFrame([icrs, spec1], aliases=("test_alias",))
+comp2 = cf.CompositeFrame([focal, spec2], aliases=("test_alias",))
+comp3 = cf.CompositeFrame([icrs, spec3], aliases=("test_alias",))
+comp4 = cf.CompositeFrame([icrs, spec4], aliases=("test_alias",))
+comp5 = cf.CompositeFrame([icrs, spec5], aliases=("test_alias",))
+comp = cf.CompositeFrame(
+    [comp1, cf.SpectralFrame(axes_order=(3,), unit=(u.m,))], aliases=("test_alias",)
+)
 
 _FRAMES = (
     icrs,
@@ -631,6 +642,7 @@ def test_CoordinateFrameProtocol():
     class MyFrame:
         naxes = 1
         name = "myframe"
+        aliases = ("test_alias",)
         unit = (u.m,)
         axes_names = ("x",)
         axes_order = (0,)
@@ -666,3 +678,26 @@ def test_BaseCoordinateFrame():
 
         class MyFrame(cf.BaseCoordinateFrame):
             pass
+
+
+@pytest.mark.parametrize(
+    "frame",
+    [
+        icrs,
+        detector,
+        focal,
+        spec1,
+        spec2,
+        spec3,
+        spec4,
+        spec5,
+        comp1,
+        comp2,
+        comp3,
+        comp4,
+        comp5,
+        comp,
+    ],
+)
+def test_frame_alias(frame):
+    assert frame.aliases == ("test_alias",)

--- a/gwcs/wcs/_pipeline.py
+++ b/gwcs/wcs/_pipeline.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import warnings
+from collections import ChainMap
 from functools import reduce
 from typing import TypeAlias, Union, overload
 
@@ -171,6 +172,14 @@ class Pipeline:
         """
         return [step.frame.name for step in self._pipeline]
 
+    @property
+    def alias_map(self) -> dict[str, str]:
+        """
+        A dictionary mapping aliaes to their corresponding frame names for all
+        frames in the pipeline.
+        """
+        return dict(ChainMap(*[step.alias_map for step in self._pipeline]))
+
     def get_frame(
         self, frame: str | CoordinateFrameProtocol
     ) -> CoordinateFrameProtocol:
@@ -210,15 +219,30 @@ class Pipeline:
         # the control of the pipeline
         value = step.copy() if isinstance(step, Step) else Step(*step)
 
-        frames = list(self.available_frames)
+        frames = self.available_frames
+        alias_map = self.alias_map
 
         # If we are replacing a step, remove it from the list of frames as we will
         # not be duplicating it in that case
         if replace_index is not None:
-            frames.pop(replace_index)
+            current_frame = frames.pop(replace_index)
+            alias_map = {
+                alias: frame_name
+                for alias, frame_name in alias_map.items()
+                if frame_name != current_frame
+            }
 
         if value.frame.name in frames:
             msg = f"Frame {value.frame.name} is already in the pipeline."
+            raise GwcsFrameExistsError(msg)
+
+        if any(alias in alias_map for alias in value.alias_map) or any(
+            alias in frames for alias in value.alias_map
+        ):
+            msg = (
+                f"One of the aliases {tuple(value.alias_map.keys())} for frame "
+                f"{value.frame.name} is already in use in the pipeline."
+            )
             raise GwcsFrameExistsError(msg)
 
         # Add the frame as an attribute of the pipeline
@@ -281,8 +305,7 @@ class Pipeline:
 
         return reduce(lambda x, y: x | y, transforms)
 
-    @staticmethod
-    def _frame_name(frame: str | CoordinateFrameProtocol) -> str:
+    def _frame_name(self, frame: str | CoordinateFrameProtocol) -> str:
         """
         Return the name of the frame.
 
@@ -295,7 +318,11 @@ class Pipeline:
         -------
         Name of the frame.
         """
-        return frame.name if isinstance(frame, CoordinateFrameProtocol) else frame
+        return (
+            frame.name
+            if isinstance(frame, CoordinateFrameProtocol)
+            else self.alias_map.get(frame, frame)
+        )
 
     def _frame_index(self, frame: str | CoordinateFrameProtocol) -> int:
         """

--- a/gwcs/wcs/_step.py
+++ b/gwcs/wcs/_step.py
@@ -87,6 +87,14 @@ class Step:
         return self.frame.name
 
     @property
+    def alias_map(self) -> dict[str, str]:
+        """
+        A dictionary mapping aliaes to their corresponding frame names for this step's
+        frame.
+        """
+        return dict.fromkeys(self.frame.aliases, self.frame.name)
+
+    @property
     def inverse(self) -> Mdl:
         if self.transform is None:
             return None


### PR DESCRIPTION
<!-- describe the changes comprising this PR here -->

This PR adds support for setting aliases for frame names. This allows alternate strings to be used to reference a given frame in the WCS.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->

## Tasks

- [ ] Update or add relevant `gwcs` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [ ] Does this PR need a changelog entry? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).

<details><summary>News fragment change types:</summary>

- `changes/<PR#>.feature.rst`: new feature
- `changes/<PR#>.breaking.rst`: any change or deprecation of the public API
- `changes/<PR#>.bugfix.rst`: fixes an issue
- `changes/<PR#>.doc.rst`: documentation change
- `changes/<PR#>.misc.rst`: infrastructure or miscellaneous change
</details
