### PR TITLE
Deprecate `BaseCoordinateFrame` and create a coordinate frame protocol.

### DIFF
--- a/changes/722.feature.rst
+++ b/changes/722.feature.rst
@@ -1,0 +1,1 @@
+Deprecate the ``BaseCoordinateFrame`` and replace it with the ``CoordinateFrameProtocol`` protocol.

--- a/gwcs/api.py
+++ b/gwcs/api.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
     from astropy.modeling import Model
     from astropy.modeling.bounding_box import CompoundBoundingBox, ModelBoundingBox
 
-    from gwcs.coordinate_frames import BaseCoordinateFrame
+    from gwcs.coordinate_frames import CoordinateFrameProtocol
 
 __all__ = ["NativeAPIMixin", "WCSAPIMixin"]
 
@@ -34,12 +34,12 @@ class NativeAPIMixin(abc.ABC):
 
     @property
     @abc.abstractmethod
-    def input_frame(self) -> BaseCoordinateFrame:
+    def input_frame(self) -> CoordinateFrameProtocol:
         """The input coordinate frame."""
 
     @property
     @abc.abstractmethod
-    def output_frame(self) -> BaseCoordinateFrame:
+    def output_frame(self) -> CoordinateFrameProtocol:
         """The output coordinate frame."""
 
     @property
@@ -108,7 +108,7 @@ class WCSAPIMixin(BaseLowLevelWCS, HighLevelWCSMixin, NativeAPIMixin):
             return ()
         return tuple(unit.to_string(format="vounit") for unit in self.output_frame.unit)
 
-    def _remove_quantity_output(self, result, frame: BaseCoordinateFrame):
+    def _remove_quantity_output(self, result, frame: CoordinateFrameProtocol):
         if not isinstance(frame, EmptyFrame):
             if frame.naxes == 1:
                 result = [result]

--- a/gwcs/api.py
+++ b/gwcs/api.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
     from astropy.modeling import Model
     from astropy.modeling.bounding_box import CompoundBoundingBox, ModelBoundingBox
 
-    from gwcs.coordinate_frames import CoordinateFrame
+    from gwcs.coordinate_frames import BaseCoordinateFrame
 
 __all__ = ["NativeAPIMixin", "WCSAPIMixin"]
 
@@ -34,12 +34,12 @@ class NativeAPIMixin(abc.ABC):
 
     @property
     @abc.abstractmethod
-    def input_frame(self) -> CoordinateFrame:
+    def input_frame(self) -> BaseCoordinateFrame:
         """The input coordinate frame."""
 
     @property
     @abc.abstractmethod
-    def output_frame(self) -> CoordinateFrame:
+    def output_frame(self) -> BaseCoordinateFrame:
         """The output coordinate frame."""
 
     @property
@@ -108,7 +108,7 @@ class WCSAPIMixin(BaseLowLevelWCS, HighLevelWCSMixin, NativeAPIMixin):
             return ()
         return tuple(unit.to_string(format="vounit") for unit in self.output_frame.unit)
 
-    def _remove_quantity_output(self, result, frame: CoordinateFrame):
+    def _remove_quantity_output(self, result, frame: BaseCoordinateFrame):
         if not isinstance(frame, EmptyFrame):
             if frame.naxes == 1:
                 result = [result]

--- a/gwcs/converters/tests/test_wcs.py
+++ b/gwcs/converters/tests/test_wcs.py
@@ -12,6 +12,7 @@ from astropy.modeling import models
 
 from gwcs import coordinate_frames as cf
 from gwcs import wcs
+from gwcs.wcs._step import _is_coordinate_frame
 
 
 def _assert_frame_equal(a, b):
@@ -22,7 +23,7 @@ def _assert_frame_equal(a, b):
     if a is None:
         return None
 
-    if not isinstance(a, cf.CoordinateFrameProtocol):
+    if not _is_coordinate_frame(a):
         return a == b
 
     assert a.name == b.name  # nosec

--- a/gwcs/converters/tests/test_wcs.py
+++ b/gwcs/converters/tests/test_wcs.py
@@ -22,7 +22,7 @@ def _assert_frame_equal(a, b):
     if a is None:
         return None
 
-    if not isinstance(a, cf.CoordinateFrame):
+    if not isinstance(a, cf.BaseCoordinateFrame):
         return a == b
 
     assert a.name == b.name  # nosec

--- a/gwcs/converters/tests/test_wcs.py
+++ b/gwcs/converters/tests/test_wcs.py
@@ -22,7 +22,7 @@ def _assert_frame_equal(a, b):
     if a is None:
         return None
 
-    if not isinstance(a, cf.BaseCoordinateFrame):
+    if not isinstance(a, cf.CoordinateFrameProtocol):
         return a == b
 
     assert a.name == b.name  # nosec

--- a/gwcs/converters/wcs.py
+++ b/gwcs/converters/wcs.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import warnings
 from contextlib import suppress
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from asdf.extension import Converter
 from asdf_astropy.converters.transform.core import (
@@ -108,7 +108,7 @@ class FrameConverter(Converter):
     def _to_yaml_tree(self, frame: CoordinateFrame, tag, ctx):
         from gwcs.coordinate_frames import CoordinateFrame
 
-        node = {}
+        node: dict[str, Any] = {}
 
         node["name"] = frame.name
 

--- a/gwcs/coordinate_frames/__init__.py
+++ b/gwcs/coordinate_frames/__init__.py
@@ -211,7 +211,7 @@ in the coordinate frames before the transform is called:
 """  # noqa: E501
 
 from ._axis import AxisType
-from ._base import CoordinateFrameProtocol
+from ._base import BaseCoordinateFrame, CoordinateFrameProtocol
 from ._celestial import CelestialFrame
 from ._composite import CompositeFrame
 from ._core import CoordinateFrame
@@ -224,6 +224,7 @@ from ._utils import get_ctype_from_ucd
 
 __all__ = [
     "AxisType",
+    "BaseCoordinateFrame",
     "CelestialFrame",
     "CompositeFrame",
     "CoordinateFrame",

--- a/gwcs/coordinate_frames/__init__.py
+++ b/gwcs/coordinate_frames/__init__.py
@@ -211,7 +211,7 @@ in the coordinate frames before the transform is called:
 """  # noqa: E501
 
 from ._axis import AxisType
-from ._base import BaseCoordinateFrame
+from ._base import CoordinateFrameProtocol
 from ._celestial import CelestialFrame
 from ._composite import CompositeFrame
 from ._core import CoordinateFrame
@@ -224,10 +224,10 @@ from ._utils import get_ctype_from_ucd
 
 __all__ = [
     "AxisType",
-    "BaseCoordinateFrame",
     "CelestialFrame",
     "CompositeFrame",
     "CoordinateFrame",
+    "CoordinateFrameProtocol",
     "EmptyFrame",
     "EmptyFrameDeprecationWarning",
     "Frame2D",

--- a/gwcs/coordinate_frames/_base.py
+++ b/gwcs/coordinate_frames/_base.py
@@ -1,62 +1,53 @@
-import abc
+from __future__ import annotations
+
 from itertools import zip_longest
+from typing import Protocol, runtime_checkable
 
 import numpy as np
 from astropy import units as u
 
 from ._axis import AxesType
-from ._properties import FrameProperties
 
 __all__ = ["BaseCoordinateFrame"]
 
 
-class BaseCoordinateFrame(abc.ABC):
+@runtime_checkable
+class BaseCoordinateFrame(Protocol):
     """
     API Definition for a Coordinate frame
     """
 
-    _prop: FrameProperties
-    """
-    The FrameProperties object holding properties in native frame order.
-    """
-
     @property
-    @abc.abstractmethod
     def naxes(self) -> int:
         """
         The number of axes described by this frame.
         """
 
     @property
-    @abc.abstractmethod
     def name(self) -> str:
         """
         The name of the coordinate frame.
         """
 
     @property
-    @abc.abstractmethod
     def unit(self) -> tuple[u.Unit, ...]:
         """
         The units of the axes in this frame.
         """
 
     @property
-    @abc.abstractmethod
     def axes_names(self) -> tuple[str, ...]:
         """
         Names describing the axes of the frame.
         """
 
     @property
-    @abc.abstractmethod
     def axes_order(self) -> tuple[int, ...]:
         """
         The position of the axes in the frame in the transform.
         """
 
     @property
-    @abc.abstractmethod
     def reference_frame(self):
         """
         The reference frame of the coordinates described by this frame.
@@ -65,7 +56,6 @@ class BaseCoordinateFrame(abc.ABC):
         """
 
     @property
-    @abc.abstractmethod
     def axes_type(self) -> AxesType:
         """
         An upcase string (or tuple of strings) describing the type of the axis.
@@ -75,14 +65,12 @@ class BaseCoordinateFrame(abc.ABC):
         """
 
     @property
-    @abc.abstractmethod
     def axis_physical_types(self):
         """
         The UCD 1+ physical types for the axes, in frame order.
         """
 
     @property
-    @abc.abstractmethod
     def world_axis_object_classes(self):
         """
         The APE 14 object classes for this frame.
@@ -100,31 +88,6 @@ class BaseCoordinateFrame(abc.ABC):
         See Also
         --------
         astropy.wcs.wcsapi.BaseLowLevelWCS.world_axis_object_components
-        """
-        if self.naxes == 1:
-            return self._native_world_axis_object_components
-
-        # If we have more than one axis then we should sort the native
-        # components by the axes_order.
-        ordered = np.array(self._native_world_axis_object_components, dtype=object)[
-            np.argsort(self.axes_order)
-        ]
-        return list(map(tuple, ordered))
-
-    @property
-    @abc.abstractmethod
-    def _native_world_axis_object_components(self):
-        """
-        This property holds the "native" frame order of the components.
-
-        The native order of the components is the order the frame assumes the
-        axes are in when creating the high level objects, for example
-        ``CelestialFrame`` creates ``SkyCoord`` objects which are in lon, lat
-        order (in their positional args).
-
-        This property is used both to construct the ordered
-        ``world_axis_object_components`` property as well as by `CompositeFrame`
-        to be able to get the components in their native order.
         """
 
     def add_units(

--- a/gwcs/coordinate_frames/_base.py
+++ b/gwcs/coordinate_frames/_base.py
@@ -8,7 +8,7 @@ from typing import Any, NamedTuple, Protocol, Self, TypeAlias, runtime_checkable
 
 import numpy as np
 from astropy import units as u
-from astropy.coordinates import builtin_frames
+from astropy.coordinates import BaseCoordinateFrame as _AstropyBaseCoordinateFrame
 from astropy.time import Time
 
 from ._axis import AxesType
@@ -22,40 +22,7 @@ __all__ = [
     "WorldAxisObjectComponent",
 ]
 
-AstropyBuiltInFrame: TypeAlias = (
-    Time
-    | builtin_frames.ICRS
-    | builtin_frames.FK5
-    | builtin_frames.FK4
-    | builtin_frames.FK4NoETerms
-    | builtin_frames.Galactic
-    | builtin_frames.Galactocentric
-    | builtin_frames.Supergalactic
-    | builtin_frames.AltAz
-    | builtin_frames.HADec
-    | builtin_frames.GCRS
-    | builtin_frames.CIRS
-    | builtin_frames.ITRS
-    | builtin_frames.HCRS
-    | builtin_frames.TEME
-    | builtin_frames.TETE
-    | builtin_frames.PrecessedGeocentric
-    | builtin_frames.GeocentricMeanEcliptic
-    | builtin_frames.BarycentricMeanEcliptic
-    | builtin_frames.HeliocentricMeanEcliptic
-    | builtin_frames.GeocentricTrueEcliptic
-    | builtin_frames.BarycentricTrueEcliptic
-    | builtin_frames.HeliocentricTrueEcliptic
-    | builtin_frames.HeliocentricEclipticIAU76
-    | builtin_frames.CustomBarycentricEcliptic
-    | builtin_frames.LSR
-    | builtin_frames.LSRK
-    | builtin_frames.LSRD
-    | builtin_frames.GalacticLSR
-    | builtin_frames.SkyOffsetFrame
-    | builtin_frames.BaseEclipticFrame
-    | builtin_frames.BaseRADecFrame
-)
+AstropyBuiltInFrame: TypeAlias = Time | _AstropyBaseCoordinateFrame
 
 
 class WorldAxisObjectClass(NamedTuple):

--- a/gwcs/coordinate_frames/_base.py
+++ b/gwcs/coordinate_frames/_base.py
@@ -2,15 +2,158 @@ from __future__ import annotations
 
 import warnings
 from abc import abstractmethod
+from collections.abc import Callable
 from itertools import zip_longest
-from typing import Protocol, runtime_checkable
+from typing import Any, NamedTuple, Protocol, Self, TypeAlias, runtime_checkable
 
 import numpy as np
 from astropy import units as u
+from astropy.coordinates import builtin_frames
+from astropy.time import Time
 
 from ._axis import AxesType
 
-__all__ = ["CoordinateFrameProtocol"]
+__all__ = [
+    "AstropyBuiltInFrame",
+    "BaseCoordinateFrame",
+    "CoordinateFrameProtocol",
+    "WorldAxisObjectClass",
+    "WorldAxisObjectClassConverter",
+    "WorldAxisObjectComponent",
+]
+
+AstropyBuiltInFrame: TypeAlias = (
+    Time
+    | builtin_frames.ICRS
+    | builtin_frames.FK5
+    | builtin_frames.FK4
+    | builtin_frames.FK4NoETerms
+    | builtin_frames.Galactic
+    | builtin_frames.Galactocentric
+    | builtin_frames.Supergalactic
+    | builtin_frames.AltAz
+    | builtin_frames.HADec
+    | builtin_frames.GCRS
+    | builtin_frames.CIRS
+    | builtin_frames.ITRS
+    | builtin_frames.HCRS
+    | builtin_frames.TEME
+    | builtin_frames.TETE
+    | builtin_frames.PrecessedGeocentric
+    | builtin_frames.GeocentricMeanEcliptic
+    | builtin_frames.BarycentricMeanEcliptic
+    | builtin_frames.HeliocentricMeanEcliptic
+    | builtin_frames.GeocentricTrueEcliptic
+    | builtin_frames.BarycentricTrueEcliptic
+    | builtin_frames.HeliocentricTrueEcliptic
+    | builtin_frames.HeliocentricEclipticIAU76
+    | builtin_frames.CustomBarycentricEcliptic
+    | builtin_frames.LSR
+    | builtin_frames.LSRK
+    | builtin_frames.LSRD
+    | builtin_frames.GalacticLSR
+    | builtin_frames.SkyOffsetFrame
+    | builtin_frames.BaseEclipticFrame
+    | builtin_frames.BaseRADecFrame
+)
+
+
+class WorldAxisObjectClass(NamedTuple):
+    """
+    A tuple to document the individual elements of the ``world_axis_object_classes``
+    of the WCS API.
+
+    Notes
+    -----
+    - ``world_axis_object_classes`` will return a dictionary with the key being
+        the name from ``world_axis_object_components`` and the value being an
+        instance of this class.
+
+    - To stay consistent with the APE 14 API, users should not access the elements
+        of this tuple via their names, but instead should access them via their
+        position in the tuple.
+
+    Attributes
+    ----------
+    class_object : type | str
+        The High-Level Object class for the axis or a string that is the fully
+        qualified name of the class.
+    arguments : tuple
+        The positional arguments to be passed to the class when instantiating an
+        object of this class. Note if ``world_axis_object_components`` specifies that
+        the world coordinates should be passed as a positional argument, then this
+        tuple will include `None` as a place holder for each of the world coordinates.
+    keyword_arguments : dict
+        The keyword arguments to be passed to the class when instantiating an object of
+        this class.
+    """
+
+    class_object: type | str
+    arguments: tuple[Any, ...]
+    keyword_arguments: dict[str, Any]
+
+
+class WorldAxisObjectClassConverter(NamedTuple):
+    """
+    Same as the `WorldAxisObjectClass` but with an additional converter field.
+
+    Attributes
+    ----------
+    converter : Callable[..., Any]
+        A callable that will convert the input values into the desired output
+    """
+
+    class_object: type | str
+    arguments: tuple[Any, ...]
+    keyword_arguments: dict[str, Any]
+    converter: Callable[..., Any]
+
+
+WorldAxisObjectClasses: TypeAlias = (
+    dict[str, WorldAxisObjectClass]
+    | dict[str, WorldAxisObjectClassConverter]
+    | dict[str, WorldAxisObjectClass | WorldAxisObjectClassConverter]
+)
+
+
+class WorldAxisObjectComponent(NamedTuple):
+    """
+    A tuple to document the individual elements of the ``world_axis_object_components``
+    of the WCS API.
+
+    Notes
+    -----
+    - ``world_axis_object_components`` will return a list of tuples with each tuple
+        being an instance of this class.
+
+    - To stay consistent with the APE 14 API, users should not access the elements
+        of this tuple via their names, but instead should access them via their
+        position in the tuple.
+
+    Attributes
+    ----------
+    name : str
+        Name for the world object this world array corresponds to, which *must*
+        match the string names used in ``world_axis_object_classes``.  Note that
+        names might appear twice because two world arrays might correspond to a
+        single world object (e.g. a celestial coordinate might have both “ra”
+        and “dec” arrays, which correspond to a single sky coordinate object.
+    position : str | int
+        This is either a string keyword argument name or a positional index for
+        the corresponding class from ``world_axis_object_classes``.
+    property: str | Callable[[Any], str]
+        This is a string giving the name of the property to access on the
+        corresponding class from ``world_axis_object_classes`` in order to get
+        numerical values.
+    """
+
+    name: str
+    position: str | int
+    property: str | Callable[[Any], str]
+
+    @classmethod
+    def from_tuple(cls, tup: tuple[str, str | int, str]) -> Self:
+        return cls(*tup)
 
 
 @runtime_checkable
@@ -56,7 +199,7 @@ class CoordinateFrameProtocol(Protocol):
 
     @property
     @abstractmethod
-    def reference_frame(self):
+    def reference_frame(self) -> AstropyBuiltInFrame | None:
         """
         The reference frame of the coordinates described by this frame.
 
@@ -75,14 +218,14 @@ class CoordinateFrameProtocol(Protocol):
 
     @property
     @abstractmethod
-    def axis_physical_types(self):
+    def axis_physical_types(self) -> tuple[str | None, ...]:
         """
         The UCD 1+ physical types for the axes, in frame order.
         """
 
     @property
     @abstractmethod
-    def world_axis_object_classes(self):
+    def world_axis_object_classes(self) -> WorldAxisObjectClasses:
         """
         The APE 14 object classes for this frame.
 
@@ -93,7 +236,7 @@ class CoordinateFrameProtocol(Protocol):
 
     @property
     @abstractmethod
-    def world_axis_object_components(self):
+    def world_axis_object_components(self) -> list[WorldAxisObjectComponent]:
         """
         The APE 14 object components for this frame.
 

--- a/gwcs/coordinate_frames/_base.py
+++ b/gwcs/coordinate_frames/_base.py
@@ -8,11 +8,11 @@ from astropy import units as u
 
 from ._axis import AxesType
 
-__all__ = ["BaseCoordinateFrame"]
+__all__ = ["CoordinateFrameProtocol"]
 
 
 @runtime_checkable
-class BaseCoordinateFrame(Protocol):
+class CoordinateFrameProtocol(Protocol):
     """
     API Definition for a Coordinate frame
     """

--- a/gwcs/coordinate_frames/_base.py
+++ b/gwcs/coordinate_frames/_base.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import warnings
+from abc import abstractmethod
 from itertools import zip_longest
 from typing import Protocol, runtime_checkable
 
@@ -18,36 +20,42 @@ class CoordinateFrameProtocol(Protocol):
     """
 
     @property
+    @abstractmethod
     def naxes(self) -> int:
         """
         The number of axes described by this frame.
         """
 
     @property
+    @abstractmethod
     def name(self) -> str:
         """
         The name of the coordinate frame.
         """
 
     @property
+    @abstractmethod
     def unit(self) -> tuple[u.Unit, ...]:
         """
         The units of the axes in this frame.
         """
 
     @property
+    @abstractmethod
     def axes_names(self) -> tuple[str, ...]:
         """
         Names describing the axes of the frame.
         """
 
     @property
+    @abstractmethod
     def axes_order(self) -> tuple[int, ...]:
         """
         The position of the axes in the frame in the transform.
         """
 
     @property
+    @abstractmethod
     def reference_frame(self):
         """
         The reference frame of the coordinates described by this frame.
@@ -56,6 +64,7 @@ class CoordinateFrameProtocol(Protocol):
         """
 
     @property
+    @abstractmethod
     def axes_type(self) -> AxesType:
         """
         An upcase string (or tuple of strings) describing the type of the axis.
@@ -65,12 +74,14 @@ class CoordinateFrameProtocol(Protocol):
         """
 
     @property
+    @abstractmethod
     def axis_physical_types(self):
         """
         The UCD 1+ physical types for the axes, in frame order.
         """
 
     @property
+    @abstractmethod
     def world_axis_object_classes(self):
         """
         The APE 14 object classes for this frame.
@@ -81,6 +92,7 @@ class CoordinateFrameProtocol(Protocol):
         """
 
     @property
+    @abstractmethod
     def world_axis_object_components(self):
         """
         The APE 14 object components for this frame.
@@ -123,3 +135,49 @@ class CoordinateFrameProtocol(Protocol):
             #   are tacked onto the end of the tuple of "coordinate" inputs/outputs.
             for array, unit in zip_longest(arrays, self.unit)
         )
+
+
+class BaseCoordinateFrame(CoordinateFrameProtocol):
+    """
+    Legacy base class for coordinate frames.
+    """
+
+    def __init_subclass__(cls, *args, **kwargs):
+        msg = (
+            "BaseCoordinateFrame has been deprecated and will be removed in a"
+            "future release. Please implement or inherit from CoordinateFrameProtocol "
+            "instead."
+        )
+        warnings.warn(msg, DeprecationWarning, stacklevel=2)
+
+        super().__init_subclass__(*args, **kwargs)
+
+    @property
+    def world_axis_object_components(self):
+        """
+        The APE 14 object components for this frame.
+
+        See Also
+        --------
+        astropy.wcs.wcsapi.BaseLowLevelWCS.world_axis_object_components
+        """
+        if self.naxes == 1:
+            return self._native_world_axis_object_components
+
+        # If we have more than one axis then we should sort the native
+        # components by the axes_order.
+        ordered = np.array(self._native_world_axis_object_components, dtype=object)[
+            np.argsort(self.axes_order)
+        ]
+        return list(map(tuple, ordered))
+
+    @property
+    @abstractmethod
+    def _native_world_axis_object_components(self):
+        """
+        This property holds the "native" frame order of the components.
+
+        The native order of the components is the order the frame assumes the
+        input arrays are in. This is not necessarily the same as the order of
+        the axes in the frame, which is given by axes_order.
+        """

--- a/gwcs/coordinate_frames/_celestial.py
+++ b/gwcs/coordinate_frames/_celestial.py
@@ -2,6 +2,7 @@ from astropy import coordinates as coord
 from astropy import units as u
 
 from ._axis import AxisType
+from ._base import AstropyBuiltInFrame, WorldAxisObjectClass, WorldAxisObjectComponent
 from ._core import CoordinateFrame
 
 __all__ = ["CelestialFrame"]
@@ -36,34 +37,39 @@ class CelestialFrame(CoordinateFrame):
 
     def __init__(
         self,
-        axes_order=None,
-        reference_frame=None,
-        unit=None,
-        axes_names=None,
-        name=None,
-        axis_physical_types=None,
-    ):
+        axes_order: tuple[int, ...] | None = None,
+        reference_frame: AstropyBuiltInFrame | None = None,
+        unit: tuple[u.Unit, ...] | None = None,
+        axes_names: tuple[str, ...] | None = None,
+        name: str | None = None,
+        axis_physical_types: tuple[str | None, ...] | None = None,
+    ) -> None:
         if (
             reference_frame is not None
             and not isinstance(reference_frame, str)
             and reference_frame.name.upper() in STANDARD_REFERENCE_FRAMES
+            and axes_names is None
         ):
-            _axes_names = list(reference_frame.representation_component_names.values())
+            _axes_names: list[str] = list(
+                reference_frame.representation_component_names.values()
+            )
             if "distance" in _axes_names:
                 _axes_names.remove("distance")
-            if axes_names is None:
-                axes_names = _axes_names
+
+            axes_names = tuple(_axes_names)
 
         naxes = len(axes_names) if axes_names is not None else 2
 
         self.native_axes_order = tuple(range(naxes))
         if axes_order is None:
             axes_order = self.native_axes_order
+
         if unit is None:
             unit = tuple([u.degree] * naxes)
+
         axes_type = (AxisType.SPATIAL,) * naxes
 
-        pht = axis_physical_types or self._default_axis_physical_types(
+        pht = axis_physical_types or self._default_axis_physical_types_reference_frame(
             reference_frame, axes_names
         )
         super().__init__(
@@ -77,24 +83,32 @@ class CelestialFrame(CoordinateFrame):
             axis_physical_types=pht,
         )
 
-    def _default_axis_physical_types(self, reference_frame, axes_names):
+    def _default_axis_physical_types_reference_frame(
+        self,
+        reference_frame: AstropyBuiltInFrame | None,
+        axes_names: tuple[str, ...] | None,
+    ) -> tuple[str, ...] | None:
         if isinstance(reference_frame, coord.Galactic):
             return "pos.galactic.lon", "pos.galactic.lat"
+
         if isinstance(
             reference_frame,
             coord.GeocentricTrueEcliptic | coord.GCRS | coord.PrecessedGeocentric,
         ):
             return "pos.bodyrc.lon", "pos.bodyrc.lat"
+
         if isinstance(reference_frame, coord.builtin_frames.BaseRADecFrame):
             return "pos.eq.ra", "pos.eq.dec"
+
         if isinstance(reference_frame, coord.builtin_frames.BaseEclipticFrame):
             return "pos.ecliptic.lon", "pos.ecliptic.lat"
-        return tuple(f"custom:{t}" for t in axes_names)
+
+        return axes_names
 
     @property
-    def world_axis_object_classes(self):
+    def world_axis_object_classes(self) -> dict[str, WorldAxisObjectClass]:
         return {
-            "celestial": (
+            "celestial": WorldAxisObjectClass(
                 coord.SkyCoord,
                 (),
                 {"frame": self.reference_frame, "unit": self._prop.unit},
@@ -102,8 +116,12 @@ class CelestialFrame(CoordinateFrame):
         }
 
     @property
-    def _native_world_axis_object_components(self):
+    def _native_world_axis_object_components(self) -> list[WorldAxisObjectComponent]:
         return [
-            ("celestial", 0, lambda sc: sc.spherical.lon.to_value(self._prop.unit[0])),
-            ("celestial", 1, lambda sc: sc.spherical.lat.to_value(self._prop.unit[1])),
+            WorldAxisObjectComponent(
+                "celestial", 0, lambda sc: sc.spherical.lon.to_value(self._prop.unit[0])
+            ),
+            WorldAxisObjectComponent(
+                "celestial", 1, lambda sc: sc.spherical.lat.to_value(self._prop.unit[1])
+            ),
         ]

--- a/gwcs/coordinate_frames/_core.py
+++ b/gwcs/coordinate_frames/_core.py
@@ -158,7 +158,38 @@ class CoordinateFrame(BaseCoordinateFrame):
         }
 
     @property
+    def world_axis_object_components(self):
+        """
+        The APE 14 object components for this frame.
+
+        See Also
+        --------
+        astropy.wcs.wcsapi.BaseLowLevelWCS.world_axis_object_components
+        """
+        if self.naxes == 1:
+            return self._native_world_axis_object_components
+
+        # If we have more than one axis then we should sort the native
+        # components by the axes_order.
+        ordered = np.array(self._native_world_axis_object_components, dtype=object)[
+            np.argsort(self.axes_order)
+        ]
+        return list(map(tuple, ordered))
+
+    @property
     def _native_world_axis_object_components(self):
+        """
+        This property holds the "native" frame order of the components.
+
+        The native order of the components is the order the frame assumes the
+        axes are in when creating the high level objects, for example
+        ``CelestialFrame`` creates ``SkyCoord`` objects which are in lon, lat
+        order (in their positional args).
+
+        This property is used both to construct the ordered
+        ``world_axis_object_components`` property as well as by `CompositeFrame`
+        to be able to get the components in their native order.
+        """
         return [
             (f"{at}{i}" if i != 0 else at, 0, "value")
             for i, at in enumerate(self._prop.axes_type)

--- a/gwcs/coordinate_frames/_core.py
+++ b/gwcs/coordinate_frames/_core.py
@@ -7,13 +7,13 @@ from astropy.wcs.wcsapi.high_level_api import (
     values_to_high_level_objects,
 )
 
-from ._base import BaseCoordinateFrame
+from ._base import CoordinateFrameProtocol
 from ._properties import FrameProperties
 
 __all__ = ["CoordinateFrame"]
 
 
-class CoordinateFrame(BaseCoordinateFrame):
+class CoordinateFrame(CoordinateFrameProtocol):
     """
     Base class for Coordinate Frames.
 

--- a/gwcs/coordinate_frames/_core.py
+++ b/gwcs/coordinate_frames/_core.py
@@ -1,4 +1,5 @@
 import numbers
+from typing import TypeVar
 
 import numpy as np
 from astropy import units as u
@@ -7,10 +8,19 @@ from astropy.wcs.wcsapi.high_level_api import (
     values_to_high_level_objects,
 )
 
-from ._base import CoordinateFrameProtocol
+from ._axis import AxesType, AxisType
+from ._base import (
+    AstropyBuiltInFrame,
+    CoordinateFrameProtocol,
+    WorldAxisObjectClass,
+    WorldAxisObjectClasses,
+    WorldAxisObjectComponent,
+)
 from ._properties import FrameProperties
 
 __all__ = ["CoordinateFrame"]
+
+_PropertyItem = TypeVar("_PropertyItem")
 
 
 class CoordinateFrame(CoordinateFrameProtocol):
@@ -39,22 +49,19 @@ class CoordinateFrame(CoordinateFrameProtocol):
     def __init__(
         self,
         naxes: int,
-        axes_type,
-        axes_order,
-        reference_frame=None,
-        unit=None,
-        axes_names=None,
-        name=None,
-        axis_physical_types=None,
-    ):
+        axes_type: AxesType,
+        axes_order: tuple[int, ...],
+        reference_frame: AstropyBuiltInFrame | None = None,
+        unit: tuple[u.Unit, ...] | None = None,
+        axes_names: tuple[str, ...] | None = None,
+        name: str | None = None,
+        axis_physical_types: tuple[str | None, ...] | None = None,
+    ) -> None:
         self._naxes = naxes
         self._axes_order = tuple(axes_order)
         self._reference_frame = reference_frame
 
-        if name is None:
-            self._name = self.__class__.__name__
-        else:
-            self._name = name
+        self._name = type(self).__name__ if name is None else name
 
         if len(self._axes_order) != naxes:
             msg = "Length of axes_order does not match number of axes."
@@ -63,7 +70,7 @@ class CoordinateFrame(CoordinateFrameProtocol):
         if isinstance(axes_type, str):
             axes_type = (axes_type,)
 
-        self._prop = FrameProperties(
+        self._prop = FrameProperties.from_frame(
             naxes,
             axes_type,
             unit,
@@ -73,14 +80,16 @@ class CoordinateFrame(CoordinateFrameProtocol):
 
         super().__init__()
 
-    def _default_axis_physical_types(self, axes_type):
+    def _default_axis_physical_types(
+        self, axes_type: tuple[AxisType | str, ...]
+    ) -> tuple[str, ...]:
         """
         The default physical types to use for this frame if none are specified
         by the user.
         """
         return tuple(f"custom:{t}" for t in axes_type)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         fmt = (
             f'<{self.__class__.__name__}(name="{self.name}", unit={self.unit}, '
             f"axes_names={self.axes_names}, axes_order={self.axes_order}"
@@ -90,24 +99,24 @@ class CoordinateFrame(CoordinateFrameProtocol):
         fmt += ")>"
         return fmt
 
-    def __str__(self):
-        if self._name is not None:
-            return self._name
-        return self.__class__.__name__
+    def __str__(self) -> str:
+        return self.name
 
-    def _sort_property(self, prop):
+    def _sort_property(
+        self, prop: tuple[_PropertyItem, ...]
+    ) -> tuple[_PropertyItem, ...]:
         sorted_prop = sorted(
             zip(prop, self.axes_order, strict=False), key=lambda x: x[1]
         )
         return tuple([t[0] for t in sorted_prop])
 
     @property
-    def name(self):
+    def name(self) -> str:
         """A custom name of this frame."""
         return self._name
 
     @name.setter
-    def name(self, val):
+    def name(self, val: str) -> None:
         """A custom name of this frame."""
         self._name = val
 
@@ -117,32 +126,32 @@ class CoordinateFrame(CoordinateFrameProtocol):
         return self._naxes
 
     @property
-    def unit(self):
+    def unit(self) -> tuple[u.Unit, ...]:
         """The unit of this frame."""
         return self._sort_property(self._prop.unit)
 
     @property
-    def axes_names(self):
+    def axes_names(self) -> tuple[str, ...]:
         """Names of axes in the frame."""
         return self._sort_property(self._prop.axes_names)
 
     @property
-    def axes_order(self):
+    def axes_order(self) -> tuple[int, ...]:
         """A tuple of indices which map inputs to axes."""
         return self._axes_order
 
     @property
-    def reference_frame(self):
+    def reference_frame(self) -> AstropyBuiltInFrame | None:
         """Reference frame, used to convert to world coordinate objects."""
         return self._reference_frame
 
     @property
-    def axes_type(self):
+    def axes_type(self) -> tuple[AxisType | str, ...]:
         """Type of this frame : 'SPATIAL', 'SPECTRAL', 'TIME'."""
         return self._sort_property(self._prop.axes_type)
 
     @property
-    def axis_physical_types(self):
+    def axis_physical_types(self) -> tuple[str | None, ...]:
         """
         The axis physical types for this frame.
 
@@ -151,14 +160,16 @@ class CoordinateFrame(CoordinateFrameProtocol):
         return self._sort_property(self._prop.axis_physical_types)
 
     @property
-    def world_axis_object_classes(self):
+    def world_axis_object_classes(self) -> WorldAxisObjectClasses:
         return {
-            f"{at}{i}" if i != 0 else at: (u.Quantity, (), {"unit": unit})
+            f"{at}{i}" if i != 0 else at: WorldAxisObjectClass(
+                u.Quantity, (), {"unit": unit}
+            )
             for i, (at, unit) in enumerate(zip(self.axes_type, self.unit, strict=False))
         }
 
     @property
-    def world_axis_object_components(self):
+    def world_axis_object_components(self) -> list[WorldAxisObjectComponent]:
         """
         The APE 14 object components for this frame.
 
@@ -174,10 +185,10 @@ class CoordinateFrame(CoordinateFrameProtocol):
         ordered = np.array(self._native_world_axis_object_components, dtype=object)[
             np.argsort(self.axes_order)
         ]
-        return list(map(tuple, ordered))
+        return list(map(WorldAxisObjectComponent.from_tuple, ordered))
 
     @property
-    def _native_world_axis_object_components(self):
+    def _native_world_axis_object_components(self) -> list[WorldAxisObjectComponent]:
         """
         This property holds the "native" frame order of the components.
 
@@ -191,12 +202,12 @@ class CoordinateFrame(CoordinateFrameProtocol):
         to be able to get the components in their native order.
         """
         return [
-            (f"{at}{i}" if i != 0 else at, 0, "value")
+            WorldAxisObjectComponent(f"{at}{i}" if i != 0 else at, 0, "value")
             for i, at in enumerate(self._prop.axes_type)
         ]
 
     @property
-    def serialized_classes(self):
+    def serialized_classes(self) -> bool:
         """
         This property is used by the low level WCS API in Astropy.
 
@@ -220,7 +231,7 @@ class CoordinateFrame(CoordinateFrameProtocol):
         Parameters
         ----------
         values : `numbers.Number`, `numpy.ndarray`, or `~astropy.units.Quantity`
-           ``naxis`` number of coordinates as scalars or arrays.
+            ``naxis`` number of coordinates as scalars or arrays.
 
         Returns
         -------

--- a/gwcs/coordinate_frames/_frame.py
+++ b/gwcs/coordinate_frames/_frame.py
@@ -27,18 +27,15 @@ class Frame2D(CoordinateFrame):
 
     def __init__(
         self,
-        axes_order=(0, 1),
-        unit=(u.pix, u.pix),
-        axes_names=("x", "y"),
-        name=None,
-        axes_type=None,
-        axis_physical_types=None,
-    ):
+        axes_order: tuple[int, int] = (0, 1),
+        unit: tuple[u.Unit, u.Unit] = (u.pix, u.pix),
+        axes_names: tuple[str, str] = ("x", "y"),
+        name: str | None = None,
+        axes_type: tuple[AxisType | str, AxisType | str] | None = None,
+        axis_physical_types: tuple[str | None, str | None] | None = None,
+    ) -> None:
         if axes_type is None:
             axes_type = (AxisType.SPATIAL, AxisType.SPATIAL)
-        pht = axis_physical_types or self._default_axis_physical_types(
-            axes_names, axes_type
-        )
 
         super().__init__(
             naxes=2,
@@ -47,13 +44,10 @@ class Frame2D(CoordinateFrame):
             name=name,
             axes_names=axes_names,
             unit=unit,
-            axis_physical_types=pht,
+            axis_physical_types=axis_physical_types
+            or (
+                axes_names
+                if (axes_names is not None and all(axes_names))
+                else axes_type
+            ),
         )
-
-    def _default_axis_physical_types(self, axes_names, axes_type):
-        if axes_names is not None and all(axes_names):
-            ph_type = axes_names
-        else:
-            ph_type = axes_type
-
-        return tuple(f"custom:{t}" for t in ph_type)

--- a/gwcs/coordinate_frames/_stokes.py
+++ b/gwcs/coordinate_frames/_stokes.py
@@ -1,6 +1,8 @@
 from astropy import units as u
 from astropy.coordinates import StokesCoord
 
+from ._axis import AxisType
+from ._base import WorldAxisObjectClass, WorldAxisObjectComponent
 from ._core import CoordinateFrame
 
 __all__ = ["StokesFrame"]
@@ -20,30 +22,30 @@ class StokesFrame(CoordinateFrame):
 
     def __init__(
         self,
-        axes_order=(0,),
-        axes_names=("stokes",),
-        name=None,
-        axis_physical_types=None,
-    ):
-        pht = axis_physical_types or self._default_axis_physical_types()
-
+        axes_order: tuple[int] = (0,),
+        axes_names: tuple[str] = ("stokes",),
+        name: str | None = None,
+        axis_physical_types: tuple[str | None] | None = None,
+    ) -> None:
         super().__init__(
-            1,
-            ["STOKES"],
-            axes_order,
+            naxes=1,
+            axes_type=(AxisType.STOKES,),
+            axes_order=axes_order,
             name=name,
             axes_names=axes_names,
-            unit=u.one,
-            axis_physical_types=pht,
+            unit=(u.one,),
+            axis_physical_types=axis_physical_types,
         )
 
-    def _default_axis_physical_types(self):
+    def _default_axis_physical_types(
+        self, axes_type: tuple[AxisType | str, ...]
+    ) -> tuple[str, ...]:
         return ("phys.polarization.stokes",)
 
     @property
-    def world_axis_object_classes(self):
+    def world_axis_object_classes(self) -> dict[str, WorldAxisObjectClass]:
         return {
-            "stokes": (
+            "stokes": WorldAxisObjectClass(
                 StokesCoord,
                 (),
                 {},
@@ -51,5 +53,5 @@ class StokesFrame(CoordinateFrame):
         }
 
     @property
-    def _native_world_axis_object_components(self):
-        return [("stokes", 0, "value")]
+    def _native_world_axis_object_components(self) -> list[WorldAxisObjectComponent]:
+        return [WorldAxisObjectComponent("stokes", 0, "value")]

--- a/gwcs/region.py
+++ b/gwcs/region.py
@@ -26,7 +26,7 @@ class Region:
     ----------
     rid : int or str
         region ID
-    coordinate_frame : `~gwcs.coordinate_frames.BaseCoordinateFrame`
+    coordinate_frame : `~gwcs.coordinate_frames.CoordinateFrameProtocol`
         Coordinate frame in which the region is defined.
     """
 
@@ -84,7 +84,7 @@ class Polygon(Region):
          counterclockwise direction, the enclosed area is the polygon.
          The last vertex must coincide with the first vertex, minimum
          4 vertices are needed to define a triangle
-    coord_frame : str or `~gwcs.coordinate_frames.BaseCoordinateFrame`
+    coord_frame : str or `~gwcs.coordinate_frames.CoordinateFrameProtocol`
         Coordinate frame in which the polygon is defined.
 
     """

--- a/gwcs/region.py
+++ b/gwcs/region.py
@@ -26,7 +26,7 @@ class Region:
     ----------
     rid : int or str
         region ID
-    coordinate_frame : `~gwcs.coordinate_frames.CoordinateFrame`
+    coordinate_frame : `~gwcs.coordinate_frames.BaseCoordinateFrame`
         Coordinate frame in which the region is defined.
     """
 
@@ -84,7 +84,7 @@ class Polygon(Region):
          counterclockwise direction, the enclosed area is the polygon.
          The last vertex must coincide with the first vertex, minimum
          4 vertices are needed to define a triangle
-    coord_frame : str or `~gwcs.coordinate_frames.CoordinateFrame`
+    coord_frame : str or `~gwcs.coordinate_frames.BaseCoordinateFrame`
         Coordinate frame in which the polygon is defined.
 
     """

--- a/gwcs/tests/test_api_slicing.py
+++ b/gwcs/tests/test_api_slicing.py
@@ -4,6 +4,8 @@ from astropy.wcs.wcsapi import wcs_info_str
 from astropy.wcs.wcsapi.wrappers import SlicedLowLevelWCS
 from numpy.testing import assert_allclose, assert_equal
 
+from gwcs.coordinate_frames._properties import FrameProperties
+
 EXPECTED_ELLIPSIS_REPR = """
 SlicedLowLevelWCS Transformation
 
@@ -483,7 +485,12 @@ def test_ellipsis_none_types(gwcs_3d_galactic_spectral):
     pht = list(gwcs_3d_galactic_spectral.output_frame._axis_physical_types)
     # This index is in "axes_order" ordering
     pht[2] = None
-    gwcs_3d_galactic_spectral.output_frame._prop.axis_physical_types = tuple(pht)
+    gwcs_3d_galactic_spectral.output_frame._prop = FrameProperties(
+        axes_type=gwcs_3d_galactic_spectral.output_frame._prop.axes_type,
+        unit=gwcs_3d_galactic_spectral.output_frame._prop.unit,
+        axes_names=gwcs_3d_galactic_spectral.output_frame._prop.axes_names,
+        axis_physical_types=tuple(pht),
+    )
 
     wcs = SlicedLowLevelWCS(gwcs_3d_galactic_spectral, Ellipsis)
 

--- a/gwcs/tests/test_coordinate_systems.py
+++ b/gwcs/tests/test_coordinate_systems.py
@@ -131,7 +131,7 @@ def coordinate_to_quantity(*inputs, frame):
 
 @pytest.mark.parametrize("frame", _FRAMES)
 def test_frame_protocol(frame):
-    assert isinstance(frame, cf.BaseCoordinateFrame)
+    assert isinstance(frame, cf.CoordinateFrameProtocol)
 
 
 @pytest.mark.parametrize("inputs", inputs2)
@@ -627,7 +627,7 @@ def test_composite_ordering():
     assert comp.axes_order == (1, 0, 2)
 
 
-def test_BaseCoordinateFrame_protocol():
+def test_CoordinateFrameProtocol():
     class MyFrame:
         naxes = 1
         name = "myframe"
@@ -647,4 +647,4 @@ def test_BaseCoordinateFrame_protocol():
             return arrays
 
     frame = MyFrame()
-    assert isinstance(frame, cf.BaseCoordinateFrame)
+    assert isinstance(frame, cf.CoordinateFrameProtocol)

--- a/gwcs/tests/test_coordinate_systems.py
+++ b/gwcs/tests/test_coordinate_systems.py
@@ -648,3 +648,15 @@ def test_CoordinateFrameProtocol():
 
     frame = MyFrame()
     assert isinstance(frame, cf.CoordinateFrameProtocol)
+
+
+def test_BaseCoordinateFrame():
+    with pytest.raises(TypeError, match=r"Can't instantiate abstract class.*"):
+        cf.BaseCoordinateFrame()
+
+    with pytest.warns(
+        DeprecationWarning, match=r"BaseCoordinateFrame has been deprecated.*"
+    ):
+
+        class MyFrame(cf.BaseCoordinateFrame):
+            pass

--- a/gwcs/tests/test_coordinate_systems.py
+++ b/gwcs/tests/test_coordinate_systems.py
@@ -80,6 +80,23 @@ comp4 = cf.CompositeFrame([icrs, spec4])
 comp5 = cf.CompositeFrame([icrs, spec5])
 comp = cf.CompositeFrame([comp1, cf.SpectralFrame(axes_order=(3,), unit=(u.m,))])
 
+_FRAMES = (
+    icrs,
+    detector,
+    focal,
+    spec1,
+    spec2,
+    spec3,
+    spec4,
+    spec5,
+    comp1,
+    comp2,
+    comp3,
+    comp4,
+    comp5,
+    comp,
+)
+
 xscalar = 1
 yscalar = 2
 xarr = np.arange(5)
@@ -110,6 +127,11 @@ def coordinate_to_quantity(*inputs, frame):
     if not isinstance(results, list):
         results = [results]
     return [r << unit for r, unit in zip(results, frame.unit, strict=False)]
+
+
+@pytest.mark.parametrize("frame", _FRAMES)
+def test_frame_protocol(frame):
+    assert isinstance(frame, cf.BaseCoordinateFrame)
 
 
 @pytest.mark.parametrize("inputs", inputs2)
@@ -603,3 +625,26 @@ def test_composite_ordering():
     assert comp.axis_physical_types == ("custom:lat", "custom:lon", "em.wl")
     assert comp.unit == (u.arcsec, u.deg, u.AA)
     assert comp.axes_order == (1, 0, 2)
+
+
+def test_BaseCoordinateFrame_protocol():
+    class MyFrame:
+        naxes = 1
+        name = "myframe"
+        unit = (u.m,)
+        axes_names = ("x",)
+        axes_order = (0,)
+        reference_frame = None
+        axes_type = ("SPATIAL",)
+        axis_physical_types = ("custom:x",)
+        world_axis_object_classes = (u.Quantity,)
+        world_axis_object_components = ("custom:x",)
+
+        def add_units(self, arrays):
+            return arrays
+
+        def remove_units(self, arrays):
+            return arrays
+
+    frame = MyFrame()
+    assert isinstance(frame, cf.BaseCoordinateFrame)

--- a/gwcs/wcs/_pipeline.py
+++ b/gwcs/wcs/_pipeline.py
@@ -8,7 +8,7 @@ from astropy.modeling import Model
 from astropy.modeling.bounding_box import CompoundBoundingBox, ModelBoundingBox
 from astropy.units import Unit
 
-from gwcs.coordinate_frames import BaseCoordinateFrame
+from gwcs.coordinate_frames import CoordinateFrameProtocol
 from gwcs.utils import CoordinateFrameError
 
 from ._exception import GwcsBoundingBoxWarning, GwcsFrameExistsError
@@ -34,8 +34,8 @@ class Pipeline:
         self,
         forward_transform: Model,
         *,
-        input_frame: str | BaseCoordinateFrame,
-        output_frame: str | BaseCoordinateFrame,
+        input_frame: str | CoordinateFrameProtocol,
+        output_frame: str | CoordinateFrameProtocol,
     ) -> None: ...
 
     @overload
@@ -51,8 +51,8 @@ class Pipeline:
         self,
         forward_transform: ForwardTransform,
         *,
-        input_frame: str | BaseCoordinateFrame | None = None,
-        output_frame: str | BaseCoordinateFrame | None = None,
+        input_frame: str | CoordinateFrameProtocol | None = None,
+        output_frame: str | CoordinateFrameProtocol | None = None,
     ) -> None:
         self._pipeline: list[Step] = []
         self._initialize_pipeline(forward_transform, input_frame, output_frame)
@@ -60,8 +60,8 @@ class Pipeline:
     def _initialize_pipeline(
         self,
         forward_transform: ForwardTransform,
-        input_frame: str | BaseCoordinateFrame | None,
-        output_frame: str | BaseCoordinateFrame | None,
+        input_frame: str | CoordinateFrameProtocol | None,
+        output_frame: str | CoordinateFrameProtocol | None,
     ) -> None:
         """
         Initialize a pipeline from a forward transform specification.
@@ -72,11 +72,11 @@ class Pipeline:
             The forward transform to initialize the pipeline with.
             - Can be a single model which acts as the entire transform.
             - List of steps for the pipeline
-            - List of tuples[BaseCoordinateFrame, Model] for the pipeline
+            - List of tuples[CoordinateFrameProtocol, Model] for the pipeline
             - None for an empty pipeline
-        input_frame : `~gwcs.coordinate_frames.BaseCoordinateFrame` or None
+        input_frame : `~gwcs.coordinate_frames.CoordinateFrameProtocol` or None
             The input frame of the pipeline.
-        output_frame : `~gwcs.coordinate_frames.BaseCoordinateFrame` or None
+        output_frame : `~gwcs.coordinate_frames.CoordinateFrameProtocol` or None
             The output frame of the pipeline. This must be specified if
             forward_transform is not a list of steps.
 
@@ -171,18 +171,20 @@ class Pipeline:
         """
         return [step.frame.name for step in self._pipeline]
 
-    def get_frame(self, frame: str | BaseCoordinateFrame) -> BaseCoordinateFrame:
+    def get_frame(
+        self, frame: str | CoordinateFrameProtocol
+    ) -> CoordinateFrameProtocol:
         """
         Return the frame object corresponding to the given frame name.
 
         Parameters
         ----------
-        frame : str or `~gwcs.coordinate_frames.BaseCoordinateFrame`
+        frame : str or `~gwcs.coordinate_frames.CoordinateFrameProtocol`
             Name of the frame or the frame object.
 
         Returns
         -------
-        frame : `~gwcs.coordinate_frames.BaseCoordinateFrame`
+        frame : `~gwcs.coordinate_frames.CoordinateFrameProtocol`
             The frame object corresponding to the given name.
         """
         return self._pipeline[self._frame_index(frame)].frame
@@ -250,14 +252,14 @@ class Pipeline:
         self._check_last_step()
 
     @property
-    def input_frame(self) -> BaseCoordinateFrame:
+    def input_frame(self) -> CoordinateFrameProtocol:
         """
         Return the input frame name of the pipeline.
         """
         return self._pipeline[0].frame
 
     @property
-    def output_frame(self) -> BaseCoordinateFrame:
+    def output_frame(self) -> CoordinateFrameProtocol:
         """
         Return the output frame name of the pipeline.
         """
@@ -276,28 +278,28 @@ class Pipeline:
         return reduce(lambda x, y: x | y, transforms)
 
     @staticmethod
-    def _frame_name(frame: str | BaseCoordinateFrame) -> str:
+    def _frame_name(frame: str | CoordinateFrameProtocol) -> str:
         """
         Return the name of the frame.
 
         Parameters
         ----------
-        frame : str or `~gwcs.coordinate_frames.BaseCoordinateFrame`
+        frame : str or `~gwcs.coordinate_frames.CoordinateFrameProtocol`
             Name of the frame or the frame object.
 
         Returns
         -------
         Name of the frame.
         """
-        return frame.name if isinstance(frame, BaseCoordinateFrame) else frame
+        return frame.name if isinstance(frame, CoordinateFrameProtocol) else frame
 
-    def _frame_index(self, frame: str | BaseCoordinateFrame) -> int:
+    def _frame_index(self, frame: str | CoordinateFrameProtocol) -> int:
         """
         Return the index of the given frame in the pipeline.
 
         Parameters
         ----------
-        frame : str or `~gwcs.coordinate_frames.BaseCoordinateFrame`
+        frame : str or `~gwcs.coordinate_frames.CoordinateFrameProtocol`
             Name of the frame or the frame object.
 
         Returns
@@ -310,7 +312,7 @@ class Pipeline:
             msg = f"Frame {self._frame_name(frame)} is not in the available frames"
             raise CoordinateFrameError(msg) from err
 
-    def _get_step(self, frame: str | BaseCoordinateFrame) -> IndexedStep:
+    def _get_step(self, frame: str | CoordinateFrameProtocol) -> IndexedStep:
         """
         Get the index and step corresponding to the given frame.
         """
@@ -319,16 +321,18 @@ class Pipeline:
         return IndexedStep(index, self._pipeline[index])
 
     def get_transform(
-        self, from_frame: str | BaseCoordinateFrame, to_frame: str | BaseCoordinateFrame
+        self,
+        from_frame: str | CoordinateFrameProtocol,
+        to_frame: str | CoordinateFrameProtocol,
     ) -> Mdl:
         """
         Return a transform between two coordinate frames.
 
         Parameters
         ----------
-        from_frame : str or `~gwcs.coordinate_frames.BaseCoordinateFrame`
+        from_frame : str or `~gwcs.coordinate_frames.CoordinateFrameProtocol`
             Initial coordinate frame name of object.
-        to_frame : str or `~gwcs.coordinate_frames.BaseCoordinateFrame`
+        to_frame : str or `~gwcs.coordinate_frames.CoordinateFrameProtocol`
             End coordinate frame name or object.
 
         Returns
@@ -360,8 +364,8 @@ class Pipeline:
 
     def set_transform(
         self,
-        from_frame: str | BaseCoordinateFrame,
-        to_frame: str | BaseCoordinateFrame,
+        from_frame: str | CoordinateFrameProtocol,
+        to_frame: str | CoordinateFrameProtocol,
         transform: Model,
     ) -> None:
         """
@@ -369,9 +373,9 @@ class Pipeline:
 
         Parameters
         ----------
-        from_frame : str or `~gwcs.coordinate_frames.BaseCoordinateFrame`
+        from_frame : str or `~gwcs.coordinate_frames.CoordinateFrameProtocol`
             Initial coordinate frame.
-        to_frame : str, or instance of `~gwcs.coordinate_frames.BaseCoordinateFrame`
+        to_frame : str, or instance of `~gwcs.coordinate_frames.CoordinateFrameProtocol`
             End coordinate frame.
         transform : `~astropy.modeling.Model`
             Transform between ``from_frame`` and ``to_frame``.
@@ -390,7 +394,10 @@ class Pipeline:
         self._pipeline[from_index].transform = transform
 
     def insert_transform(
-        self, frame: str | BaseCoordinateFrame, transform: Model, after: bool = False
+        self,
+        frame: str | CoordinateFrameProtocol,
+        transform: Model,
+        after: bool = False,
     ) -> None:
         """
         Insert a transform before (default) or after a coordinate frame.
@@ -399,7 +406,7 @@ class Pipeline:
 
         Parameters
         ----------
-        frame : str or `~gwcs.coordinate_frames.BaseCoordinateFrame`
+        frame : str or `~gwcs.coordinate_frames.CoordinateFrameProtocol`
             Coordinate frame which sets the point of insertion.
         transform : `~astropy.modeling.Model`
             New transform to be inserted in the pipeline
@@ -431,34 +438,34 @@ class Pipeline:
 
     def insert_frame(
         self,
-        input_frame: str | BaseCoordinateFrame,
+        input_frame: str | CoordinateFrameProtocol,
         transform: Model,
-        output_frame: str | BaseCoordinateFrame,
+        output_frame: str | CoordinateFrameProtocol,
     ) -> None:
         """
         Insert a new frame into an existing pipeline. This frame must be
         anchored to a frame already in the pipeline by a transform. This
         existing frame is identified solely by its name, although an entire
-        `~gwcs.coordinate_frames.BaseCoordinateFrame` can be passed (e.g., the
+        `~gwcs.coordinate_frames.CoordinateFrameProtocol` can be passed (e.g., the
         `input_frame` or `output_frame` attribute). This frame is never
         modified.
 
         Parameters
         ----------
-        input_frame : str or `~gwcs.coordinate_frames.BaseCoordinateFrame`
+        input_frame : str or `~gwcs.coordinate_frames.CoordinateFrameProtocol`
             Coordinate frame at start of new transform
         transform : `~astropy.modeling.Model`
             New transform to be inserted in the pipeline
-        output_frame: str or `~gwcs.coordinate_frames.BaseCoordinateFrame`
+        output_frame: str or `~gwcs.coordinate_frames.CoordinateFrameProtocol`
             Coordinate frame at end of new transform
         """
 
-        def get_index(frame: str | BaseCoordinateFrame) -> int | None:
+        def get_index(frame: str | CoordinateFrameProtocol) -> int | None:
             try:
                 index = self._frame_index(frame)
             except CoordinateFrameError as err:
                 index = None
-                if not isinstance(frame, BaseCoordinateFrame):
+                if not isinstance(frame, CoordinateFrameProtocol):
                     msg = (
                         f"New coordinate frame {self._frame_name(frame)} "
                         "must be defined"
@@ -542,7 +549,7 @@ class Pipeline:
         Set the range of acceptable values for each input axis.
 
         The order of the axes is
-        `~gwcs.coordinate_frames.BaseCoordinateFrame.axes_order`.
+        `~gwcs.coordinate_frames.CoordinateFrameProtocol.axes_order`.
         For two inputs and axes_order(0, 1) the bounding box is
         ((xlow, xhigh), (ylow, yhigh)).
 

--- a/gwcs/wcs/_step.py
+++ b/gwcs/wcs/_step.py
@@ -3,7 +3,7 @@ from typing import NamedTuple, TypeAlias, Union
 
 from astropy.modeling.core import Model
 
-from gwcs.coordinate_frames import CoordinateFrame, EmptyFrame
+from gwcs.coordinate_frames import BaseCoordinateFrame, EmptyFrame
 
 __all__ = [
     "IndexedStep",
@@ -14,7 +14,7 @@ __all__ = [
 
 
 Mdl: TypeAlias = Union[Model, None]  # noqa: UP007
-StepTuple: TypeAlias = tuple[CoordinateFrame, Union[Model, None]]  # noqa: UP007
+StepTuple: TypeAlias = tuple[BaseCoordinateFrame, Union[Model, None]]  # noqa: UP007
 
 
 class Step:
@@ -23,29 +23,29 @@ class Step:
 
     Parameters
     ----------
-    frame : `~gwcs.coordinate_frames.CoordinateFrame`
+    frame : `~gwcs.coordinate_frames.BaseCoordinateFrame`
         A gwcs coordinate frame object.
     transform : `~astropy.modeling.Model` or None
         A transform from this step's frame to next step's frame.
         The transform of the last step should be `None`.
     """
 
-    def __init__(self, frame: str | CoordinateFrame, transform: Mdl = None):
+    def __init__(self, frame: str | BaseCoordinateFrame, transform: Mdl = None):
         # Allow for a string to be passed in for the frame but be turned into a
         # frame object
         self.frame = (
-            frame if isinstance(frame, CoordinateFrame) else EmptyFrame(name=frame)
+            frame if isinstance(frame, BaseCoordinateFrame) else EmptyFrame(name=frame)
         )
         self.transform = transform
 
     @property
-    def frame(self) -> CoordinateFrame:
+    def frame(self) -> BaseCoordinateFrame:
         return self._frame
 
     @frame.setter
-    def frame(self, val: CoordinateFrame):
-        if not isinstance(val, CoordinateFrame):
-            msg = '"frame" should be an instance of CoordinateFrame.'
+    def frame(self, val: BaseCoordinateFrame):
+        if not isinstance(val, BaseCoordinateFrame):
+            msg = '"frame" should be an instance of BaseCoordinateFrame.'
             raise TypeError(msg)
 
         self._frame = val

--- a/gwcs/wcs/_step.py
+++ b/gwcs/wcs/_step.py
@@ -3,7 +3,7 @@ from typing import NamedTuple, TypeAlias, Union
 
 from astropy.modeling.core import Model
 
-from gwcs.coordinate_frames import BaseCoordinateFrame, EmptyFrame
+from gwcs.coordinate_frames import CoordinateFrameProtocol, EmptyFrame
 
 __all__ = [
     "IndexedStep",
@@ -14,7 +14,7 @@ __all__ = [
 
 
 Mdl: TypeAlias = Union[Model, None]  # noqa: UP007
-StepTuple: TypeAlias = tuple[BaseCoordinateFrame, Union[Model, None]]  # noqa: UP007
+StepTuple: TypeAlias = tuple[CoordinateFrameProtocol, Union[Model, None]]  # noqa: UP007
 
 
 class Step:
@@ -23,29 +23,31 @@ class Step:
 
     Parameters
     ----------
-    frame : `~gwcs.coordinate_frames.BaseCoordinateFrame`
+    frame : `~gwcs.coordinate_frames.CoordinateFrameProtocol` or str
         A gwcs coordinate frame object.
     transform : `~astropy.modeling.Model` or None
         A transform from this step's frame to next step's frame.
         The transform of the last step should be `None`.
     """
 
-    def __init__(self, frame: str | BaseCoordinateFrame, transform: Mdl = None):
+    def __init__(self, frame: str | CoordinateFrameProtocol, transform: Mdl = None):
         # Allow for a string to be passed in for the frame but be turned into a
         # frame object
         self.frame = (
-            frame if isinstance(frame, BaseCoordinateFrame) else EmptyFrame(name=frame)
+            frame
+            if isinstance(frame, CoordinateFrameProtocol)
+            else EmptyFrame(name=frame)
         )
         self.transform = transform
 
     @property
-    def frame(self) -> BaseCoordinateFrame:
+    def frame(self) -> CoordinateFrameProtocol:
         return self._frame
 
     @frame.setter
-    def frame(self, val: BaseCoordinateFrame):
-        if not isinstance(val, BaseCoordinateFrame):
-            msg = '"frame" should be an instance of BaseCoordinateFrame.'
+    def frame(self, val: CoordinateFrameProtocol):
+        if not isinstance(val, CoordinateFrameProtocol):
+            msg = '"frame" should be an instance of CoordinateFrameProtocol.'
             raise TypeError(msg)
 
         self._frame = val

--- a/gwcs/wcs/_wcs.py
+++ b/gwcs/wcs/_wcs.py
@@ -32,9 +32,9 @@ from scipy import optimize
 from gwcs.api import WCSAPIMixin
 from gwcs.coordinate_frames import (
     AxisType,
-    BaseCoordinateFrame,
     CelestialFrame,
     CompositeFrame,
+    CoordinateFrameProtocol,
     EmptyFrame,
     get_ctype_from_ucd,
 )
@@ -66,7 +66,7 @@ class _WorldAxisInfo:
         axis : int
             Output axis number [in the forward transformation].
 
-        frame : cf.BaseCoordinateFrame
+        frame : cf.CoordinateFrameProtocol
             Coordinate frame to which this axis belongs.
 
         world_axis_order : int
@@ -115,8 +115,8 @@ class WCS(Pipeline, WCSAPIMixin):
     def __init__(
         self,
         forward_transform: Model,
-        input_frame: str | BaseCoordinateFrame,
-        output_frame: str | BaseCoordinateFrame,
+        input_frame: str | CoordinateFrameProtocol,
+        output_frame: str | CoordinateFrameProtocol,
         name: str | None = None,
     ) -> None: ...
 
@@ -132,8 +132,8 @@ class WCS(Pipeline, WCSAPIMixin):
     def __init__(
         self,
         forward_transform: ForwardTransform,
-        input_frame: str | BaseCoordinateFrame | None = None,
-        output_frame: str | BaseCoordinateFrame | None = None,
+        input_frame: str | CoordinateFrameProtocol | None = None,
+        output_frame: str | CoordinateFrameProtocol | None = None,
         name: str | None = None,
     ) -> None:
         super().__init__(
@@ -148,7 +148,7 @@ class WCS(Pipeline, WCSAPIMixin):
         self._pixel_shape = None
 
     def _add_units_input(
-        self, arrays: np.ndarray | tuple[float, ...], frame: BaseCoordinateFrame
+        self, arrays: np.ndarray | tuple[float, ...], frame: CoordinateFrameProtocol
     ) -> tuple[u.Quantity, ...]:
         if not isinstance(frame, EmptyFrame):
             return frame.add_units(arrays)
@@ -157,7 +157,7 @@ class WCS(Pipeline, WCSAPIMixin):
         return arrays  # type: ignore[return-value]
 
     def _remove_units_input(
-        self, arrays: tuple[u.Quantity, ...], frame: BaseCoordinateFrame
+        self, arrays: tuple[u.Quantity, ...], frame: CoordinateFrameProtocol
     ) -> tuple[np.ndarray, ...]:
         if not isinstance(frame, EmptyFrame):
             return frame.remove_units(arrays)
@@ -256,7 +256,7 @@ class WCS(Pipeline, WCSAPIMixin):
         self,
         transform,
         *args,
-        frame: BaseCoordinateFrame,
+        frame: CoordinateFrameProtocol,
         input_is_quantity=False,
         transform_uses_quantity=False,
         **kwargs,
@@ -282,7 +282,7 @@ class WCS(Pipeline, WCSAPIMixin):
         self,
         transform,
         *args,
-        frame: BaseCoordinateFrame,
+        frame: CoordinateFrameProtocol,
         input_is_quantity=False,
         transform_uses_quantity=False,
         **kwargs,
@@ -1163,8 +1163,8 @@ class WCS(Pipeline, WCSAPIMixin):
 
     def transform(
         self,
-        from_frame: str | BaseCoordinateFrame,
-        to_frame: str | BaseCoordinateFrame,
+        from_frame: str | CoordinateFrameProtocol,
+        to_frame: str | CoordinateFrameProtocol,
         *args,
         with_bounding_box: bool = True,
         fill_value: float | np.number = np.nan,

--- a/gwcs/wcs/_wcs.py
+++ b/gwcs/wcs/_wcs.py
@@ -32,9 +32,9 @@ from scipy import optimize
 from gwcs.api import WCSAPIMixin
 from gwcs.coordinate_frames import (
     AxisType,
+    BaseCoordinateFrame,
     CelestialFrame,
     CompositeFrame,
-    CoordinateFrame,
     EmptyFrame,
     get_ctype_from_ucd,
 )
@@ -66,7 +66,7 @@ class _WorldAxisInfo:
         axis : int
             Output axis number [in the forward transformation].
 
-        frame : cf.CoordinateFrame
+        frame : cf.BaseCoordinateFrame
             Coordinate frame to which this axis belongs.
 
         world_axis_order : int
@@ -115,8 +115,8 @@ class WCS(Pipeline, WCSAPIMixin):
     def __init__(
         self,
         forward_transform: Model,
-        input_frame: str | CoordinateFrame,
-        output_frame: str | CoordinateFrame,
+        input_frame: str | BaseCoordinateFrame,
+        output_frame: str | BaseCoordinateFrame,
         name: str | None = None,
     ) -> None: ...
 
@@ -132,8 +132,8 @@ class WCS(Pipeline, WCSAPIMixin):
     def __init__(
         self,
         forward_transform: ForwardTransform,
-        input_frame: str | CoordinateFrame | None = None,
-        output_frame: str | CoordinateFrame | None = None,
+        input_frame: str | BaseCoordinateFrame | None = None,
+        output_frame: str | BaseCoordinateFrame | None = None,
         name: str | None = None,
     ) -> None:
         super().__init__(
@@ -148,7 +148,7 @@ class WCS(Pipeline, WCSAPIMixin):
         self._pixel_shape = None
 
     def _add_units_input(
-        self, arrays: np.ndarray | tuple[float, ...], frame: CoordinateFrame
+        self, arrays: np.ndarray | tuple[float, ...], frame: BaseCoordinateFrame
     ) -> tuple[u.Quantity, ...]:
         if not isinstance(frame, EmptyFrame):
             return frame.add_units(arrays)
@@ -157,7 +157,7 @@ class WCS(Pipeline, WCSAPIMixin):
         return arrays  # type: ignore[return-value]
 
     def _remove_units_input(
-        self, arrays: tuple[u.Quantity, ...], frame: CoordinateFrame
+        self, arrays: tuple[u.Quantity, ...], frame: BaseCoordinateFrame
     ) -> tuple[np.ndarray, ...]:
         if not isinstance(frame, EmptyFrame):
             return frame.remove_units(arrays)
@@ -256,7 +256,7 @@ class WCS(Pipeline, WCSAPIMixin):
         self,
         transform,
         *args,
-        frame: CoordinateFrame,
+        frame: BaseCoordinateFrame,
         input_is_quantity=False,
         transform_uses_quantity=False,
         **kwargs,
@@ -282,7 +282,7 @@ class WCS(Pipeline, WCSAPIMixin):
         self,
         transform,
         *args,
-        frame: CoordinateFrame,
+        frame: BaseCoordinateFrame,
         input_is_quantity=False,
         transform_uses_quantity=False,
         **kwargs,
@@ -1163,8 +1163,8 @@ class WCS(Pipeline, WCSAPIMixin):
 
     def transform(
         self,
-        from_frame: str | CoordinateFrame,
-        to_frame: str | CoordinateFrame,
+        from_frame: str | BaseCoordinateFrame,
+        to_frame: str | BaseCoordinateFrame,
         *args,
         with_bounding_box: bool = True,
         fill_value: float | np.number = np.nan,

--- a/gwcs/wcstools.py
+++ b/gwcs/wcstools.py
@@ -47,7 +47,7 @@ def wcs_from_fiducial(
             A location on the sky in some standard coordinate system.
             A Quantity with spectral units.
             A list of the above.
-    coordinate_frame : ~gwcs.coordinate_frames.BaseCoordinateFrame`
+    coordinate_frame : ~gwcs.coordinate_frames.CoordinateFrameProtocol`
         The output coordinate frame.
         If fiducial is not an instance of `~astropy.coordinates.SkyCoord`,
         ``coordinate_frame`` is required.
@@ -64,10 +64,10 @@ def wcs_from_fiducial(
         The bounding box over which the WCS is valid.
         It is a tuple of tuples of size 2 where each tuple
         represents a range of (low, high) values. The ``bounding_box`` is in the
-        order of the axes, `~gwcs.coordinate_frames.BaseCoordinateFrame.axes_order`.
+        order of the axes, `~gwcs.coordinate_frames.CoordinateFrameProtocol.axes_order`.
         For two inputs and axes_order(0, 1) the bounding box is
         ((xlow, xhigh), (ylow, yhigh)).
-    input_frame : ~gwcs.coordinate_frames.BaseCoordinateFrame`
+    input_frame : ~gwcs.coordinate_frames.CoordinateFrameProtocol`
         The input coordinate frame.
     """
     from .wcs import WCS

--- a/gwcs/wcstools.py
+++ b/gwcs/wcstools.py
@@ -47,7 +47,7 @@ def wcs_from_fiducial(
             A location on the sky in some standard coordinate system.
             A Quantity with spectral units.
             A list of the above.
-    coordinate_frame : ~gwcs.coordinate_frames.CoordinateFrame`
+    coordinate_frame : ~gwcs.coordinate_frames.BaseCoordinateFrame`
         The output coordinate frame.
         If fiducial is not an instance of `~astropy.coordinates.SkyCoord`,
         ``coordinate_frame`` is required.
@@ -64,10 +64,10 @@ def wcs_from_fiducial(
         The bounding box over which the WCS is valid.
         It is a tuple of tuples of size 2 where each tuple
         represents a range of (low, high) values. The ``bounding_box`` is in the
-        order of the axes, `~gwcs.coordinate_frames.CoordinateFrame.axes_order`.
+        order of the axes, `~gwcs.coordinate_frames.BaseCoordinateFrame.axes_order`.
         For two inputs and axes_order(0, 1) the bounding box is
         ((xlow, xhigh), (ylow, yhigh)).
-    input_frame : ~gwcs.coordinate_frames.CoordinateFrame`
+    input_frame : ~gwcs.coordinate_frames.BaseCoordinateFrame`
         The input coordinate frame.
     """
     from .wcs import WCS


### PR DESCRIPTION
<!-- describe the changes comprising this PR here -->

This PR deprecates the `BaseCoordinateFrame` and changes things to use the `CoordinateFrameProtocol` so that externally defined frames are properly handled

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->

## Tasks

- [ ] Update or add relevant `gwcs` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [ ] Does this PR need a changelog entry? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).

<details><summary>News fragment change types:</summary>

- `changes/<PR#>.feature.rst`: new feature
- `changes/<PR#>.breaking.rst`: any change or deprecation of the public API
- `changes/<PR#>.bugfix.rst`: fixes an issue
- `changes/<PR#>.doc.rst`: documentation change
- `changes/<PR#>.misc.rst`: infrastructure or miscellaneous change
</details
