### PR TITLE
Better `EmptyFrame`

### DIFF
--- a/changes/724.feature.rst
+++ b/changes/724.feature.rst
@@ -1,0 +1,4 @@
+Improve the implementation of the ``EmptyFrame`` so that it can be used within GWCS
+and other code without special handling. Note that in this case we will have an error
+raised whenever the user tries to use ``EmptyFrame`` with units as this violates the
+expectations of the normal GWCS API.

--- a/changes/724.feature.rst
+++ b/changes/724.feature.rst
@@ -1,4 +1,3 @@
 Improve the implementation of the ``EmptyFrame`` so that it can be used within GWCS
-and other code without special handling. Note that in this case we will have an error
-raised whenever the user tries to use ``EmptyFrame`` with units as this violates the
+and other code without special handling. Note that now the code will raise an error whenever the user tries to use ``EmptyFrame`` with units as this violates the
 expectations of the normal GWCS API.

--- a/gwcs/api.py
+++ b/gwcs/api.py
@@ -187,7 +187,10 @@ class WCSAPIMixin(BaseLowLevelWCS, HighLevelWCSMixin, NativeAPIMixin):
         """
         if isinstance(self.output_frame, EmptyFrame):
             return ()
-        return tuple(unit.to_string(format="vounit") for unit in self.output_frame.unit)
+        return tuple(
+            "None" if unit is None else unit.to_string(format="vounit")
+            for unit in self.output_frame.unit
+        )
 
     @staticmethod
     def _remove_quantity_frame(

--- a/gwcs/api.py
+++ b/gwcs/api.py
@@ -16,7 +16,7 @@ from astropy.modeling import separable
 from astropy.wcs.wcsapi import BaseLowLevelWCS, HighLevelWCSMixin
 
 from gwcs import utils
-from gwcs.coordinate_frames import EmptyFrame, LowLevelArray, LowLevelInput
+from gwcs.coordinate_frames import LowLevelArray, LowLevelInput
 
 if TYPE_CHECKING:
     from astropy.modeling import Model
@@ -148,9 +148,6 @@ class WCSAPIMixin(BaseLowLevelWCS, HighLevelWCSMixin, NativeAPIMixin):
         """
         The number of axes in the pixel coordinate system.
         """
-        if isinstance(self.input_frame, EmptyFrame):
-            # This is because astropy.modeling.Model does not type hint n_inputs
-            return self.forward_transform.n_inputs  # type: ignore[no-any-return]
         return self.input_frame.naxes
 
     @property
@@ -158,9 +155,6 @@ class WCSAPIMixin(BaseLowLevelWCS, HighLevelWCSMixin, NativeAPIMixin):
         """
         The number of axes in the world coordinate system.
         """
-        if isinstance(self.output_frame, EmptyFrame):
-            # This is because astropy.modeling.Model does not type hint n_inputs
-            return self.forward_transform.n_outputs  # type: ignore[no-any-return]
         return self.output_frame.naxes
 
     @property
@@ -185,8 +179,6 @@ class WCSAPIMixin(BaseLowLevelWCS, HighLevelWCSMixin, NativeAPIMixin):
         specification document, units that do not follow this standard are still
         allowed, but just not recommended).
         """
-        if isinstance(self.output_frame, EmptyFrame):
-            return ()
         return tuple(
             "None" if unit is None else unit.to_string(format="vounit")
             for unit in self.output_frame.unit
@@ -197,9 +189,6 @@ class WCSAPIMixin(BaseLowLevelWCS, HighLevelWCSMixin, NativeAPIMixin):
         result: tuple[LowLevelInput, ...] | LowLevelInput,
         frame: CoordinateFrameProtocol,
     ) -> tuple[LowLevelArray, ...] | LowLevelArray:
-        if isinstance(frame, EmptyFrame):
-            return result
-
         if frame.naxes == 1:
             result = (result,)
 
@@ -375,17 +364,11 @@ class WCSAPIMixin(BaseLowLevelWCS, HighLevelWCSMixin, NativeAPIMixin):
         return False
 
     @property
-    def world_axis_object_classes(self) -> WorldAxisObjectClasses | None:
-        if isinstance(self.output_frame, EmptyFrame):
-            return None
-
+    def world_axis_object_classes(self) -> WorldAxisObjectClasses:
         return self.output_frame.world_axis_object_classes
 
     @property
-    def world_axis_object_components(self) -> list[WorldAxisObjectComponent] | None:
-        if isinstance(self.output_frame, EmptyFrame):
-            return None
-
+    def world_axis_object_components(self) -> list[WorldAxisObjectComponent]:
         return self.output_frame.world_axis_object_components
 
     @property
@@ -393,9 +376,6 @@ class WCSAPIMixin(BaseLowLevelWCS, HighLevelWCSMixin, NativeAPIMixin):
         """
         An iterable of strings describing the name for each pixel axis.
         """
-        if isinstance(self.input_frame, EmptyFrame):
-            return tuple([""] * self.pixel_n_dim)
-
         return self.input_frame.axes_names
 
     @property
@@ -403,7 +383,4 @@ class WCSAPIMixin(BaseLowLevelWCS, HighLevelWCSMixin, NativeAPIMixin):
         """
         An iterable of strings describing the name for each world axis.
         """
-        if isinstance(self.output_frame, EmptyFrame):
-            return tuple([""] * self.world_n_dim)
-
         return self.output_frame.axes_names

--- a/gwcs/converters/tests/test_wcs.py
+++ b/gwcs/converters/tests/test_wcs.py
@@ -27,7 +27,9 @@ def _assert_frame_equal(a, b):
         return a == b
 
     assert a.name == b.name  # nosec
-    if not isinstance(a, cf.EmptyFrame):
+    if not isinstance(a, cf.EmptyFrame) or (
+        isinstance(a, cf.EmptyFrame) and a._naxes is not None
+    ):
         assert a.axes_order == b.axes_order  # nosec
         assert a.axes_names == b.axes_names  # nosec
         assert a.unit == b.unit  # nosec

--- a/gwcs/coordinate_frames/__init__.py
+++ b/gwcs/coordinate_frames/__init__.py
@@ -222,7 +222,7 @@ from ._base import (
 from ._celestial import CelestialFrame
 from ._composite import CompositeFrame
 from ._core import CoordinateFrame
-from ._empty import EmptyFrame, EmptyFrameDeprecationWarning
+from ._empty import EmptyFrame, EmptyFrameDeprecationWarning, EmptyFrameUnitsWarning
 from ._frame import Frame2D
 from ._spectral import SpectralFrame
 from ._stokes import StokesFrame
@@ -238,6 +238,7 @@ __all__ = [
     "CoordinateFrameProtocol",
     "EmptyFrame",
     "EmptyFrameDeprecationWarning",
+    "EmptyFrameUnitsWarning",
     "Frame2D",
     "LowLevelArray",
     "LowLevelInput",

--- a/gwcs/coordinate_frames/_axis.py
+++ b/gwcs/coordinate_frames/_axis.py
@@ -16,6 +16,7 @@ class AxisType(StrEnum):
     TIME = "TIME"
     STOKES = "STOKES"
     PIXEL = "PIXEL"
+    UNKNOWN = "UNKNOWN"
 
     def __str__(self) -> str:
         return self.value

--- a/gwcs/coordinate_frames/_axis.py
+++ b/gwcs/coordinate_frames/_axis.py
@@ -16,7 +16,7 @@ class AxisType(StrEnum):
     TIME = "TIME"
     STOKES = "STOKES"
     PIXEL = "PIXEL"
-    UNKNOWN = "UNKNOWN"
+    UNDEFINED = "UNDEFINED"
 
     def __str__(self) -> str:
         return self.value

--- a/gwcs/coordinate_frames/_base.py
+++ b/gwcs/coordinate_frames/_base.py
@@ -155,7 +155,7 @@ class CoordinateFrameProtocol(Protocol):
 
     @property
     @abstractmethod
-    def unit(self) -> tuple[u.Unit, ...]:
+    def unit(self) -> tuple[u.Unit | None, ...]:
         """
         The units of the axes in this frame.
         """

--- a/gwcs/coordinate_frames/_empty.py
+++ b/gwcs/coordinate_frames/_empty.py
@@ -1,6 +1,12 @@
 import warnings
 
-from ._core import CoordinateFrame
+from ._axis import AxesType, AxisType
+from ._base import (
+    CoordinateFrameProtocol,
+    WorldAxisObjectClass,
+    WorldAxisObjectClasses,
+    WorldAxisObjectComponent,
+)
 
 __all__ = ["EmptyFrame"]
 
@@ -9,35 +15,36 @@ class EmptyFrameDeprecationWarning(DeprecationWarning):
     pass
 
 
-class EmptyFrame(CoordinateFrame):
+class EmptyFrame(CoordinateFrameProtocol):
     """
     Represents a "default" detector frame. This is for use as the default value
     for input frame by the WCS object.
     """
 
-    def __init__(self, name=None):
+    def __init__(self, name: str | None = None, naxes: int | None = None) -> None:
         self._name = "detector" if name is None else name
+        self._naxes = naxes
         msg = (
             "The use of strings in place of a proper CoordinateFrame has been "
             "deprecated."
         )
         warnings.warn(msg, EmptyFrameDeprecationWarning, stacklevel=2)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f'<{type(self).__name__}(name="{self.name}")>'
 
-    def __str__(self):
+    def __str__(self) -> str:
         if self._name is not None:
             return self._name
         return type(self).__name__
 
     @property
-    def name(self):
+    def name(self) -> str:
         """A custom name of this frame."""
         return self._name
 
     @name.setter
-    def name(self, val):
+    def name(self, val: str) -> None:
         """A custom name of this frame."""
         self._name = val
 
@@ -46,40 +53,52 @@ class EmptyFrame(CoordinateFrame):
         raise NotImplementedError(msg)
 
     @property
-    def naxes(self):
-        self._raise_error()
+    def naxes(self) -> int:
+        if self._naxes is None:
+            msg = "The number of axes for this EmptyFrame has not  been set."
+            raise NotImplementedError(msg)
+
+        return self._naxes
 
     @property
-    def unit(self):
+    def unit(self) -> tuple[None, ...]:
+        return (None,) * self.naxes
+
+    @property
+    def axes_names(self) -> tuple[str, ...]:
+        return ("None",) * self.naxes
+
+    @property
+    def axes_order(self) -> tuple[int, ...]:
+        return tuple(range(self.naxes))
+
+    @property
+    def reference_frame(self) -> None:
         return None
 
     @property
-    def axes_names(self):
-        self._raise_error()
-
-    @property
-    def axes_order(self):
-        self._raise_error()
-
-    @property
-    def reference_frame(self):
-        self._raise_error()
-
-    @property
-    def axes_type(self):
-        self._raise_error()
+    def axes_type(self) -> AxesType:
+        return (AxisType.UNKNOWN,) * self.naxes
 
     @property
     def axis_physical_types(self):
-        self._raise_error()
+        return tuple(f"custom:{t}" for t in self.axes_type)
 
     @property
-    def world_axis_object_classes(self):
-        self._raise_error()
+    def world_axis_object_classes(self) -> WorldAxisObjectClasses:
+        return {
+            f"{at}{i}" if i != 0 else at: WorldAxisObjectClass(
+                "None", (), {"unit": unit}
+            )
+            for i, (at, unit) in enumerate(zip(self.axes_type, self.unit, strict=False))
+        }
 
     @property
-    def _native_world_axis_object_components(self):
-        self._raise_error()
+    def world_axis_object_components(self) -> list[WorldAxisObjectComponent]:
+        return [
+            WorldAxisObjectComponent(f"{at}{i}" if i != 0 else at, 0, "value")
+            for i, at in enumerate(self.axes_type)
+        ]
 
     def to_high_level_coordinates(self, *values):
         self._raise_error()

--- a/gwcs/coordinate_frames/_empty.py
+++ b/gwcs/coordinate_frames/_empty.py
@@ -3,22 +3,28 @@ from __future__ import annotations
 import warnings
 from typing import Self, TypeAlias, Union
 
+from astropy import units as u
 from astropy.modeling import Model
 
 from ._axis import AxesType, AxisType
 from ._base import (
     CoordinateFrameProtocol,
+    LowLevelInput,
     WorldAxisObjectClass,
     WorldAxisObjectClasses,
     WorldAxisObjectComponent,
 )
 
-__all__ = ["EmptyFrame"]
+__all__ = ["EmptyFrame", "EmptyFrameDeprecationWarning", "EmptyFrameUnitsWarning"]
 
 _Mdl: TypeAlias = Union[Model, None]  # noqa: UP007
 
 
 class EmptyFrameDeprecationWarning(DeprecationWarning):
+    pass
+
+
+class EmptyFrameUnitsWarning(UserWarning):
     pass
 
 
@@ -143,3 +149,33 @@ class EmptyFrame(CoordinateFrameProtocol):
 
     def from_high_level_coordinates(self, *high_level_coords):
         self._raise_error()
+
+    def add_units(
+        self, arrays: tuple[LowLevelInput, ...] | LowLevelInput
+    ) -> tuple[LowLevelInput, ...]:
+        msg = (
+            "EmptyFrame (string frame) does not have any unit information. "
+            "Therefore, GWCS cannot ensure that units are being properly handled. "
+            "If an error occurs due to units, please provide a proper CoordinateFrame "
+            "and/or ensure that the input values you are providing have the correct "
+            "units attached (or removed) in order to be compatible with the transform."
+        )
+        warnings.warn(msg, EmptyFrameUnitsWarning, stacklevel=2)
+
+        return super().add_units(arrays)
+
+    def remove_units(
+        self, arrays: tuple[LowLevelInput, ...] | LowLevelInput
+    ) -> tuple[LowLevelInput, ...]:
+        with warnings.catch_warnings():
+            # Filter unit warning if there is no unit information to remove. This
+            #   is because there is nothing for GWCS to be concerned about in this
+            #   case and the only reason it is being triggered is that we attempt
+            #   to add the unit information in order to force a unit conversion if
+            #   needed.
+            if (self.naxes == 1 and not isinstance(arrays, u.Quantity)) or not any(
+                isinstance(arr, u.Quantity) for arr in arrays
+            ):
+                warnings.filterwarnings("ignore", category=EmptyFrameUnitsWarning)
+
+            return super().remove_units(arrays)

--- a/gwcs/coordinate_frames/_empty.py
+++ b/gwcs/coordinate_frames/_empty.py
@@ -122,7 +122,7 @@ class EmptyFrame(CoordinateFrameProtocol):
 
     @property
     def axes_type(self) -> AxesType:
-        return (AxisType.UNKNOWN,) * self.naxes
+        return (AxisType.UNDEFINED,) * self.naxes
 
     @property
     def axis_physical_types(self):

--- a/gwcs/coordinate_frames/_empty.py
+++ b/gwcs/coordinate_frames/_empty.py
@@ -1,4 +1,9 @@
+from __future__ import annotations
+
 import warnings
+from typing import Self, TypeAlias, Union
+
+from astropy.modeling import Model
 
 from ._axis import AxesType, AxisType
 from ._base import (
@@ -9,6 +14,8 @@ from ._base import (
 )
 
 __all__ = ["EmptyFrame"]
+
+_Mdl: TypeAlias = Union[Model, None]  # noqa: UP007
 
 
 class EmptyFrameDeprecationWarning(DeprecationWarning):
@@ -29,6 +36,33 @@ class EmptyFrame(CoordinateFrameProtocol):
             "deprecated."
         )
         warnings.warn(msg, EmptyFrameDeprecationWarning, stacklevel=2)
+
+    @classmethod
+    def from_transform(cls, name: str | None = None, transform: _Mdl = None) -> Self:
+        """
+        Class method constructor to allow for an EmptyFrame to be created using data
+        from a transform.
+
+        Notes
+        -----
+        - This assumes that the number of inputs to the transform corresponds to the
+            number of axes in the frame. Therefore, this assumes that there are NO
+            non-coordinate inputs present.
+
+        Parameters
+        ----------
+        name : str or None
+            Name of the frame. If None, defaults to "detector".
+        transform : astropy.modeling.Model or None
+            A transform from this step's frame to next step's frame. The transform of
+            the last step should be None.
+
+        Returns
+        -------
+        EmptyFrame
+            An EmptyFrame object with the number of axes set based on the transform.
+        """
+        return cls(name=name, naxes=None if transform is None else transform.n_inputs)
 
     def __repr__(self) -> str:
         return f'<{type(self).__name__}(name="{self.name}")>'
@@ -60,13 +94,17 @@ class EmptyFrame(CoordinateFrameProtocol):
 
         return self._naxes
 
+    @naxes.setter
+    def naxes(self, val: int | None) -> None:
+        self._naxes = val
+
     @property
     def unit(self) -> tuple[None, ...]:
         return (None,) * self.naxes
 
     @property
     def axes_names(self) -> tuple[str, ...]:
-        return ("None",) * self.naxes
+        return ("",) * self.naxes
 
     @property
     def axes_order(self) -> tuple[int, ...]:

--- a/gwcs/examples.py
+++ b/gwcs/examples.py
@@ -35,8 +35,8 @@ def gwcs_simple_2d():
 def gwcs_empty_output_2d():
     return wcs.WCS(
         MODEL_2D_SHIFT,
-        input_frame=cf.EmptyFrame(name="detector"),
-        output_frame=cf.EmptyFrame(name="world"),
+        input_frame="detector",
+        output_frame="world",
     )
 
 

--- a/gwcs/tests/test_api.py
+++ b/gwcs/tests/test_api.py
@@ -308,7 +308,7 @@ def test_high_level_wrapper(wcsobj, request):
     # uses the mixin class and __call__ calls values_to_high_level_objects
     wc1 = hlvl.pixel_to_world(*pixel_input)
     wc2 = wcsobj(*pixel_input)
-    results = wcsobj._remove_units_input(wc2, wcsobj.output_frame)
+    results = wcsobj.output_frame.remove_units(wc2)
 
     wc2 = values_to_high_level_objects(*results, low_level_wcs=wcsobj)
     if len(wc2) == 1:

--- a/gwcs/tests/test_api.py
+++ b/gwcs/tests/test_api.py
@@ -646,10 +646,35 @@ def test_no_input_frame(gwcs_simple_2d):
 
 def test_empty_output_frame(gwcs_empty_output_2d):
     """Test running the API on the WCS with an empty output frame."""
-    assert (np.array([3]), np.array([1])) == gwcs_empty_output_2d.pixel_to_world_values(
-        np.array([2]), np.array([-1])
-    )
+    assert (
+        np.array([3]),
+        np.array([1]),
+    ) == gwcs_empty_output_2d.pixel_to_world_values(np.array([2]), np.array([-1]))
     assert (
         np.array([2]),
         np.array([-1]),
     ) == gwcs_empty_output_2d.world_to_pixel_values(np.array([3]), np.array([1]))
+
+
+def test_empty_frame_units_warning(gwcs_empty_output_2d):
+    """
+    Test that a warning is raised when a unit conversion is attempted on an empty frame.
+    """
+    # > 1d case
+    with pytest.warns(
+        cf.EmptyFrameUnitsWarning, match=r"EmptyFrame.*does not have any unit.*"
+    ):
+        assert (
+            np.array([3]),
+            np.array([4]),
+        ) == gwcs_empty_output_2d.pixel_to_world_values(2 * u.m, 2 * u.m)
+
+    # 1d case
+    with pytest.warns(cf.EmptyFrameDeprecationWarning, match=r"The use of strings.*"):
+        wcs = gwcs.WCS(
+            forward_transform=m.Shift(7), input_frame="detector", output_frame="world"
+        )
+    with pytest.warns(
+        cf.EmptyFrameUnitsWarning, match=r"EmptyFrame.*does not have any unit.*"
+    ):
+        assert np.array([8]) == wcs(1 * u.pix)

--- a/gwcs/tests/test_api_consistent.py
+++ b/gwcs/tests/test_api_consistent.py
@@ -200,20 +200,17 @@ def test_transform_with_units(wcsobj):
 @wcs_no_unit_1d
 def test_add_units(wcsobj):
     if wcsobj.input_frame.naxes == 1:
-        assert (
-            wcsobj._add_units_input((1,), wcsobj.input_frame)
-            == 1 * wcsobj.input_frame.unit[0]
-        )
+        assert wcsobj.input_frame.add_units((1,)) == 1 * wcsobj.input_frame.unit[0]
         assert_allclose(
-            wcsobj._add_units_input(([1, 1],), wcsobj.input_frame),
+            wcsobj.input_frame.add_units(([1, 1],)),
             ([1, 1] * wcsobj.input_frame.unit[0],),
         )
     elif wcsobj.input_frame.naxes == 2:
         assert_quantity_allclose(
-            wcsobj._add_units_input((1, 1), wcsobj.input_frame), (1 * u.pix, 1 * u.pix)
+            wcsobj.input_frame.add_units((1, 1)), (1 * u.pix, 1 * u.pix)
         )
         assert_quantity_allclose(
-            wcsobj._add_units_input(([1, 1], [1, 1]), wcsobj.input_frame),
+            wcsobj.input_frame.add_units(([1, 1], [1, 1])),
             ([1, 1] * u.pix, [1, 1] * u.pix),
         )
 
@@ -222,19 +219,14 @@ def test_add_units(wcsobj):
 def test_remove_units(wcsobj):
     if wcsobj.input_frame.naxes == 1:
         unit = wcsobj.input_frame.unit[0]
-        assert wcsobj._remove_units_input(1 * unit, wcsobj.input_frame) == (1,)
-        assert_allclose(
-            wcsobj._remove_units_input(([1, 1] * unit,), wcsobj.input_frame), ([1, 1],)
-        )
+        assert wcsobj.input_frame.remove_units(1 * unit) == (1,)
+        assert_allclose(wcsobj.input_frame.remove_units(([1, 1] * unit,)), ([1, 1],))
     elif wcsobj.input_frame.naxes == 2:
         assert_quantity_allclose(
-            wcsobj._remove_units_input((1 * u.pix, 1 * u.pix), wcsobj.input_frame),
-            (1, 1),
+            wcsobj.input_frame.remove_units((1 * u.pix, 1 * u.pix)), (1, 1)
         )
         assert_quantity_allclose(
-            wcsobj._remove_units_input(
-                ([1, 1] * u.pix, [1, 1] * u.pix), wcsobj.input_frame
-            ),
+            wcsobj.input_frame.remove_units(([1, 1] * u.pix, [1, 1] * u.pix)),
             ([1, 1], [1, 1]),
         )
 

--- a/gwcs/tests/test_wcs.py
+++ b/gwcs/tests/test_wcs.py
@@ -1442,7 +1442,7 @@ def test_initialize_wcs_with_list():
 
     # make pipeline consisting of tuples and Steps
     shift1 = models.Shift(10 * u.pix) & models.Shift(2 * u.pix)
-    shift2 = models.Shift(3 * u.pix)
+    shift2 = models.Shift(3 * u.pix) & models.Shift(27 * u.pix)
 
     with pytest.warns(DeprecationWarning, match=r"The use of strings.*"):
         pipeline = [("detector", shift1), wcs.Step("extra_step", shift2)]

--- a/gwcs/tests/test_wcs.py
+++ b/gwcs/tests/test_wcs.py
@@ -299,7 +299,11 @@ def test_bounding_box_units():
         w = wcs.WCS(pipeline)
 
     w.bounding_box = bb
-    world = w(-1 * u.pix, -1 * u.pix)
+    with pytest.warns(
+        cf.EmptyFrameUnitsWarning, match=r"EmptyFrame.*does not have any unit.*"
+    ):
+        world = w(-1 * u.pix, -1 * u.pix)
+
     assert_allclose(world, (np.nan, np.nan))
 
 
@@ -349,8 +353,11 @@ def test_compound_bounding_box():
     assert w.bounding_box == cbb
     assert w.bounding_box is trans.bounding_box
 
-    assert_allclose(w(-1 * u.pix, 1 * u.pix), (np.nan, np.nan))
-    assert_allclose(w(7 * u.pix, 2 * u.pix), (np.nan, np.nan))
+    with pytest.warns(UserWarning, match=r"EmptyFrame.*does not have any unit.*"):
+        assert_allclose(w(-1 * u.pix, 1 * u.pix), (np.nan, np.nan))
+
+    with pytest.warns(UserWarning, match=r"EmptyFrame.*does not have any unit.*"):
+        assert_allclose(w(7 * u.pix, 2 * u.pix), (np.nan, np.nan))
 
 
 def test_grid_from_bounding_box():

--- a/gwcs/wcs/_pipeline.py
+++ b/gwcs/wcs/_pipeline.py
@@ -8,7 +8,7 @@ from astropy.modeling import Model
 from astropy.modeling.bounding_box import CompoundBoundingBox, ModelBoundingBox
 from astropy.units import Unit
 
-from gwcs.coordinate_frames import CoordinateFrameProtocol
+from gwcs.coordinate_frames import CoordinateFrameProtocol, EmptyFrame
 from gwcs.utils import CoordinateFrameError
 
 from ._exception import GwcsBoundingBoxWarning, GwcsFrameExistsError
@@ -151,6 +151,13 @@ class Pipeline:
                 "with a transform between them."
             )
             raise ValueError(msg)
+
+        # Fix the naxes of the last frame if it is an EmptyFrame as it must
+        #   guess the number of axes based on the number of outputs of the
+        #   forward transform. This means that non-coordinate inputs are not
+        #   supported if the last frame is an EmptyFrame.
+        if isinstance(self._pipeline[-1].frame, EmptyFrame):
+            self._pipeline[-1].frame.naxes = self.forward_transform.n_outputs
 
     @property
     def pipeline(self) -> list[Step]:

--- a/gwcs/wcs/_step.py
+++ b/gwcs/wcs/_step.py
@@ -56,7 +56,11 @@ class Step:
         # Allow for a string to be passed in for the frame but be turned into a
         # frame object
         # This is correct type-wise, but the Python 3.11 bugfix causes a MyPy error
-        self.frame = frame if _is_coordinate_frame(frame) else EmptyFrame(frame)  # type: ignore[assignment, arg-type]
+        self.frame = (
+            frame
+            if _is_coordinate_frame(frame)
+            else EmptyFrame.from_transform(frame, transform)  # type: ignore[assignment, arg-type]
+        )
         self.transform = transform
 
     @property

--- a/gwcs/wcs/_step.py
+++ b/gwcs/wcs/_step.py
@@ -34,7 +34,7 @@ if sys.version_info >= (3, 12):
 else:
 
     def _is_coordinate_frame(frame: str | CoordinateFrameProtocol) -> bool:
-        return isinstance(frame, BaseCoordinateFrame | CoordinateFrame)
+        return isinstance(frame, BaseCoordinateFrame | CoordinateFrame | EmptyFrame)
 
 
 class Step:
@@ -56,7 +56,7 @@ class Step:
         # Allow for a string to be passed in for the frame but be turned into a
         # frame object
         # This is correct type-wise, but the Python 3.11 bugfix causes a MyPy error
-        self.frame = frame if _is_coordinate_frame(frame) else EmptyFrame(frame)  # type: ignore[assignment]
+        self.frame = frame if _is_coordinate_frame(frame) else EmptyFrame(frame)  # type: ignore[assignment, arg-type]
         self.transform = transform
 
     @property

--- a/gwcs/wcs/_wcs.py
+++ b/gwcs/wcs/_wcs.py
@@ -1268,7 +1268,7 @@ class WCS(Pipeline, WCSAPIMixin):
     def __str__(self) -> str:
         from astropy.table import Table
 
-        col1 = [step.frame for step in self._pipeline]
+        col1 = [str(step.frame) for step in self._pipeline]
         col2: list[str | None] = []
         for item in self._pipeline[:-1]:
             model = item.transform


### PR DESCRIPTION
<!-- describe the changes comprising this PR here -->

This PR adds implementation for several of the properties of the `EmptyFrame` in order to make it more functional within GWCS without special handling.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->

## Tasks

- [ ] Update or add relevant `gwcs` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [ ] Does this PR need a changelog entry? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).

<details><summary>News fragment change types:</summary>

- `changes/<PR#>.feature.rst`: new feature
- `changes/<PR#>.breaking.rst`: any change or deprecation of the public API
- `changes/<PR#>.bugfix.rst`: fixes an issue
- `changes/<PR#>.doc.rst`: documentation change
- `changes/<PR#>.misc.rst`: infrastructure or miscellaneous change
</details
