### PR TITLE
solves #726: bug in default inverse mapping

### DIFF
--- a/gwcs/wcs/_wcs.py
+++ b/gwcs/wcs/_wcs.py
@@ -2787,14 +2787,14 @@ class WCS(Pipeline, WCSAPIMixin):
             if isinstance(transform, projections.Projection):
                 sky2pix_proj = transform
                 break
-        if sky2pix_proj.__name__.startswith("Pix2Sky"):
+        if type(sky2pix_proj).__name__.startswith("Pix2Sky"):
             sky2pix_proj = sky2pix_proj.inverse
         lon_pole = _compute_lon_pole((crval1, crval2), sky2pix_proj)
         ntransform = (
             (Shift(crpix[0]) & Shift(crpix[1]))
             | self.forward_transform
             | RotateCelestial2Native(crval1, crval2, lon_pole)
-            | sky2pix_proj()
+            | sky2pix_proj
         )
 
         # standard sampling:


### PR DESCRIPTION
```python
# =============================================
# Following the same example described in the issue #726  
# after bug fix
# =============================================

In [23]: wa
Out[23]:
<SkyCoord (ICRS): (ra, dec) in deg
    (5.46165002, -72.12183946)>


In [29]: wcsobj.backward_transform
---------------------------------------------------------------------------
NotImplementedError                       Traceback (most recent call last)
File ~/Softwares/gwcs/gwcs/wcs/_pipeline.py:639, in Pipeline.backward_transform(self)
    638 try:
--> 639     backward = self.forward_transform.inverse
    640 except NotImplementedError as err:

File ~/anaconda3/envs/rdm_env_latest/lib/python3.14/site-packages/astropy/modeling/core.py:1383, in Model.inverse(self)
   1382 elif self._inverse is not None:
-> 1383     result = self._inverse()
   1384     if result is not NotImplemented:
.
.
.
.
NotImplementedError: No analytical or user-supplied inverse transform has been implemented for this model.

# Even when backward transform is not implemented in the original definition of the `wcsobj`, it should default successfully to `numerical_inverse` as shown below:
In [24]: wcsobj.world_to_pixel(wa)
Out[24]: (np.float64(3.999999999638021), np.float64(3.999999999540023))

In [25]: wcsobj.numerical_inverse(wa.ra.deg, wa.dec.deg)
Out[25]: (3.999999999638021, 3.999999999540023)

```

<!-- describe the changes comprising this PR here -->

This PR addresses a bug that triggered when a `backward_transform` is not defined and default `numerical_inverse` needs to be used.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->

## Tasks

- `no-changelog-entry-needed`

<details><summary>News fragment change types:</summary>

- `changes/727.bugfix.rst`: fixes an issue
