### PR TITLE
lu_factor needs explicit complex128/float64 casting (SciPy 1.18.0)

### DIFF
--- a/gwcs/wcs/_utils.py
+++ b/gwcs/wcs/_utils.py
@@ -96,7 +96,7 @@ def _poly_fit_lu(xin, yin, xout, yout, degree, coord_pow=None):
     with warnings.catch_warnings(record=True):
         warnings.simplefilter("error", category=linalg.LinAlgWarning)
         try:
-            lu_piv = linalg.lu_factor(a.astype(np.complex128))
+            lu_piv = linalg.lu_factor(a.astype(np.float128))
             poly_coeff_x = linalg.lu_solve(lu_piv, bx).astype(float)
             poly_coeff_y = linalg.lu_solve(lu_piv, by).astype(float)
         except (ValueError, linalg.LinAlgWarning, np.linalg.LinAlgError) as e:

--- a/gwcs/wcs/_utils.py
+++ b/gwcs/wcs/_utils.py
@@ -45,7 +45,8 @@ def _poly_fit_lu(xin, yin, xout, yout, degree, coord_pow=None):
 
     nterms = len(powers)
 
-    flt_type = np.longdouble
+    # lu_factor and _lu_solve deprecated float128 support in scipy 1.18.0
+    flt_type = np.float64
 
     # allocate array for the coefficients of the system of equations (a*x=b):
     a = np.empty((nterms, nterms), dtype=flt_type)
@@ -96,7 +97,7 @@ def _poly_fit_lu(xin, yin, xout, yout, degree, coord_pow=None):
     with warnings.catch_warnings(record=True):
         warnings.simplefilter("error", category=linalg.LinAlgWarning)
         try:
-            lu_piv = linalg.lu_factor(a.astype(np.float64))
+            lu_piv = linalg.lu_factor(a)
             poly_coeff_x = linalg.lu_solve(lu_piv, bx).astype(float)
             poly_coeff_y = linalg.lu_solve(lu_piv, by).astype(float)
         except (ValueError, linalg.LinAlgWarning, np.linalg.LinAlgError) as e:

--- a/gwcs/wcs/_utils.py
+++ b/gwcs/wcs/_utils.py
@@ -96,7 +96,7 @@ def _poly_fit_lu(xin, yin, xout, yout, degree, coord_pow=None):
     with warnings.catch_warnings(record=True):
         warnings.simplefilter("error", category=linalg.LinAlgWarning)
         try:
-            lu_piv = linalg.lu_factor(a.astype(np.float128))
+            lu_piv = linalg.lu_factor(a.astype(np.float64))
             poly_coeff_x = linalg.lu_solve(lu_piv, bx).astype(float)
             poly_coeff_y = linalg.lu_solve(lu_piv, by).astype(float)
         except (ValueError, linalg.LinAlgWarning, np.linalg.LinAlgError) as e:

--- a/gwcs/wcs/_utils.py
+++ b/gwcs/wcs/_utils.py
@@ -96,7 +96,7 @@ def _poly_fit_lu(xin, yin, xout, yout, degree, coord_pow=None):
     with warnings.catch_warnings(record=True):
         warnings.simplefilter("error", category=linalg.LinAlgWarning)
         try:
-            lu_piv = linalg.lu_factor(a)
+            lu_piv = linalg.lu_factor(a.astype(np.complex128))
             poly_coeff_x = linalg.lu_solve(lu_piv, bx).astype(float)
             poly_coeff_y = linalg.lu_solve(lu_piv, by).astype(float)
         except (ValueError, linalg.LinAlgWarning, np.linalg.LinAlgError) as e:


### PR DESCRIPTION
<!-- describe the changes comprising this PR here -->

This PR fixes #738 . Probably no need for change log?

Note to self: `gwcs@git+https://github.com/pllim/gwcs.git@ghost-in-a-call-standalone-complex`

Regression tests:

* jwst: https://github.com/spacetelescope/RegressionTests/actions/runs/25937742387, https://github.com/spacetelescope/RegressionTests/actions/runs/25940866810
* romancal: https://github.com/spacetelescope/RegressionTests/actions/runs/25937798895

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->

## Tasks

- [ ] Update or add relevant `gwcs` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [x] Does this PR need a changelog entry? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).

<details><summary>News fragment change types:</summary>

- `changes/<PR#>.feature.rst`: new feature
- `changes/<PR#>.breaking.rst`: any change or deprecation of the public API
- `changes/<PR#>.bugfix.rst`: fixes an issue
- `changes/<PR#>.doc.rst`: documentation change
- `changes/<PR#>.misc.rst`: infrastructure or miscellaneous change
</details
