### PR TITLE
Fix docs for numpy 2.5

### DIFF
--- a/gwcs/coordinate_frames/_base.py
+++ b/gwcs/coordinate_frames/_base.py
@@ -5,7 +5,15 @@ from abc import abstractmethod
 from collections.abc import Callable
 from itertools import zip_longest
 from numbers import Number
-from typing import Any, NamedTuple, Protocol, Self, TypeAlias, runtime_checkable
+from typing import (
+    Any,
+    NamedTuple,
+    Protocol,
+    Self,
+    TypeAlias,
+    TypeVar,
+    runtime_checkable,
+)
 
 import numpy as np
 from astropy import units as u
@@ -15,7 +23,6 @@ from astropy.wcs.wcsapi.high_level_api import (
     high_level_objects_to_values,
     values_to_high_level_objects,
 )
-from numpy import typing as npt
 
 from ._axis import AxesType
 
@@ -29,9 +36,10 @@ __all__ = [
     "WorldAxisObjectClassConverter",
     "WorldAxisObjectComponent",
 ]
+_DtypeGeneric = TypeVar("_DtypeGeneric", bound=np.generic)
 
 AstropyBuiltInFrame: TypeAlias = Time | _AstropyBaseCoordinateFrame
-LowLevelArray: TypeAlias = npt.NDArray[np.generic]
+LowLevelArray: TypeAlias = np.ndarray[tuple[int, ...], np.dtype[_DtypeGeneric]]
 LowLevelInput: TypeAlias = LowLevelArray | u.Quantity
 
 

--- a/gwcs/wcs/_wcs.py
+++ b/gwcs/wcs/_wcs.py
@@ -307,7 +307,7 @@ class WCS(Pipeline, WCSAPIMixin):
         with_bounding_box: bool = True,
         fill_value: float | np.number = np.nan,
         **kwargs,
-    ) -> bool | npt.NDArray[np.bool_]:
+    ) -> bool | np.ndarray[tuple[int, ...], np.dtype[np.bool_]]:
         """
         This method tests if one or more of the input world coordinates are
         contained within forward transformation's image and that it maps to


### PR DESCRIPTION
<!-- describe the changes comprising this PR here -->

Numpy 2.5 release's typing changes broke the docs in GWCS slightly. This PR fixes that.

## Tasks

- [ ] Update or add relevant `gwcs` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [ ] Does this PR need a changelog entry? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).

<details><summary>News fragment change types:</summary>

- `changes/<PR#>.feature.rst`: new feature
- `changes/<PR#>.breaking.rst`: any change or deprecation of the public API
- `changes/<PR#>.bugfix.rst`: fixes an issue
- `changes/<PR#>.doc.rst`: documentation change
- `changes/<PR#>.misc.rst`: infrastructure or miscellaneous change
</details
