### PR TITLE
Drop python 3.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,7 @@ jobs:
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@8c8bb6c6c962542921f993d47d26df38dccd50b1 # v3.0.2
     with:
       envs: |
-        - linux: py311-oldestdeps
-        - linux: py311
+        - linux: py312-oldestdeps
         - linux: py312
         - linux: py314
         # `tox` does not currently respect `requires-python` versions when creating testing environments;

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,6 +9,7 @@ repos:
       - id: check-added-large-files
         args: ["--enforce-all", "--maxkb=300"]
       - id: check-ast
+        language_version: python3.12
       - id: check-case-conflict
       - id: check-json
       - id: check-yaml
@@ -18,6 +19,7 @@ repos:
       - id: check-merge-conflict
       - id: check-symlinks
       - id: debug-statements
+        language_version: python3.12
       - id: detect-private-key
       - id: end-of-file-fixer
         exclude: ".*(data.*)$"
@@ -44,6 +46,7 @@ repos:
     rev: v2.3.1
     hooks:
       - id: mypy
+        language_version: python3.12
   # spell-checking
   - repo: https://github.com/codespell-project/codespell
     rev: v2.4.3

--- a/changes/760.breaking.rst
+++ b/changes/760.breaking.rst
@@ -1,0 +1,1 @@
+Drop support for Python 3.11. The minimum supported Python version is now 3.12.

--- a/docs/_templates/autosummary/module.rst
+++ b/docs/_templates/autosummary/module.rst
@@ -2,6 +2,14 @@
 
 .. automodule:: {{ fullname }}
 
+   {% if fullname == "gwcs.typing" %}
+   .. rubric:: Type aliases
+
+   {% for item in typing_type_aliases | sort %}
+   .. autotype:: {{ item }}
+   {% endfor %}
+   {% endif %}
+
    {% block classes %}
    {% if all_classes %}
    .. rubric:: Classes

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -180,6 +180,10 @@ typing_type_aliases = frozenset(
     )
 )
 
+# PEP 695 type parameters are local to their generic declarations and do not
+# have Python-domain documentation targets. Preserve their rendered text.
+local_type_parameters = frozenset({"Wcs"})
+
 # Type hints report the defining private submodule, e.g.
 # ``gwcs.coordinate_frames._base.WorldAxisObjectClass``.
 private_module = re.compile(r"\._\w+(?=\.)")
@@ -195,6 +199,11 @@ def resolve_missing_reference(app, env, node, contnode):
     """
     # Sphinx provides the unresolved target on the reference node.
     target = node.get("reftarget", "")
+
+    # Generic type parameters are not importable objects, so they cannot link
+    # to an API page; preserve their type-hint text without a cross-reference.
+    if target in local_type_parameters:
+        return contnode.deepcopy()
 
     # Private implementation details have no public documentation target.
     if target.rsplit(".", 1)[-1].startswith("_"):

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -166,21 +166,60 @@ unqualified_type_names = {
     "CompoundBoundingBox": "astropy.modeling.bounding_box.CompoundBoundingBox",
 }
 
+typing_type_aliases = frozenset(
+    f"gwcs.typing.{name}"
+    for name in (
+        "AstropyBuiltInFrame",
+        "AxesType",
+        "ForwardTransform",
+        "LowLevelArray",
+        "LowLevelInput",
+        "Mdl",
+        "StepTuple",
+        "WorldAxisObjectClasses",
+    )
+)
+
 # Type hints report the defining private submodule, e.g.
 # ``gwcs.coordinate_frames._base.WorldAxisObjectClass``.
 private_module = re.compile(r"\._\w+(?=\.)")
 
 
 def resolve_missing_reference(app, env, node, contnode):
+    """Resolve type references that Sphinx cannot find through its normal lookup.
+
+    Private names are rendered as plain text. Unqualified external types are
+    retried through intersphinx, PEP 695 aliases emitted as classes are retried
+    as Python ``type`` objects, and GWCS private-module paths are rewritten to
+    their public import paths before resolving them in the Python domain.
+    """
+    # Sphinx provides the unresolved target on the reference node.
     target = node.get("reftarget", "")
 
+    # Private implementation details have no public documentation target.
     if target.rsplit(".", 1)[-1].startswith("_"):
         return contnode.deepcopy()
 
+    # Resolve postponed, unqualified third-party annotations with intersphinx.
     if external := unqualified_type_names.get(target):
         node["reftarget"] = external
         return intersphinx_missing_reference(app, env, node, contnode)
 
+    # sphinx_autodoc_typehints labels PEP 695 aliases as classes; use their
+    # documented Python-domain type targets instead.
+    if target in typing_type_aliases and node["reftype"] == "class":
+        return env.get_domain("py").resolve_xref(
+            env,
+            node.get("refdoc"),
+            app.builder,
+            "type",
+            target,
+            node,
+            contnode,
+        )
+
+    # Replace a defining private GWCS module with its public re-export before
+    # retrying Python-domain resolution.
     public = private_module.sub("", target)
     if target.startswith("gwcs.") and public != target:
         node["reftarget"] = public
@@ -198,9 +237,19 @@ def resolve_missing_reference(app, env, node, contnode):
 
 
 def skip_excluded_inherited_members(*event_args):
+    """Exclude inherited ``str`` and Astropy ``Model`` members from autodoc.
+
+    The ``autodoc-skip-member`` event passes the candidate object as its fourth
+    positional argument. Its owner and wrapped implementation identify members
+    inherited from the two noisy base classes; returning ``True`` omits them,
+    while ``None`` leaves Sphinx's default decision unchanged.
+    """
+    # Extract the candidate object and normalize bound methods to functions.
     obj = event_args[3]
     owner = getattr(obj, "__objclass__", None)
     wrapped = getattr(obj, "__func__", obj)
+    # Suppress inherited string methods and Astropy Model members that do not
+    # describe the GWCS subclass's API.
     if (
         getattr(wrapped, "__qualname__", "").startswith("str.")
         or owner is str
@@ -212,34 +261,56 @@ def skip_excluded_inherited_members(*event_args):
     ):
         return True
 
+    # Defer all other members to Sphinx's standard inclusion rules.
     return None
 
 
 def setup(app):
+    """Register the custom autodoc and missing-reference event handlers."""
+    # Filter inherited implementation details while autodoc gathers members.
     app.connect("autodoc-skip-member", skip_excluded_inherited_members)
+    # Repair type-hint cross-references after normal resolution fails.
     app.connect("missing-reference", resolve_missing_reference)
 
 
 def is_property(modname, qualname, attr):
-    """Used by the autosummary class template to pick autoproperty vs autoattribute."""
+    """Return whether an autosummary class member is a property descriptor.
+
+    The class template uses this to choose ``autoproperty`` rather than
+    ``autoattribute``. Static lookup avoids triggering descriptors while the
+    class and requested member are inspected.
+    """
+    # Walk from the module to the nested class requested by the template.
     obj = importlib.import_module(modname)
     for part in qualname.split("."):
         obj = getattr(obj, part)
+    # Missing members are attributes rather than properties for template use.
     try:
         member = inspect.getattr_static(obj, attr)
     except AttributeError:
         return False
+    # Only descriptor instances declared as properties need autoproperty.
     return isinstance(member, property)
 
 
 def is_inherited_model_name(modname, qualname, attr):
+    """Return whether ``name`` is inherited from an Astropy modeling base class.
+
+    The autosummary template uses this to avoid documenting an inherited model
+    name as though it were declared by the current GWCS class. Members other
+    than ``name`` cannot match this special case.
+    """
+    # This workaround applies only to the inherited Model ``name`` attribute.
     if attr != "name":
         return False
 
+    # Walk from the module to the nested class requested by the template.
     obj = importlib.import_module(modname)
     for part in qualname.split("."):
         obj = getattr(obj, part)
 
+    # Report a match only when this class lacks ``name`` and an Astropy modeling
+    # base class supplies it.
     return "name" not in obj.__dict__ and any(
         "name" in base.__dict__ and base.__module__.startswith("astropy.modeling")
         for base in obj.__mro__[1:]
@@ -252,4 +323,5 @@ autosummary_ignore_module_all = False
 autosummary_context = {
     "is_inherited_model_name": is_inherited_model_name,
     "is_property": is_property,
+    "typing_type_aliases": typing_type_aliases,
 }

--- a/gwcs/converters/tests/test_wcs.py
+++ b/gwcs/converters/tests/test_wcs.py
@@ -12,7 +12,6 @@ from astropy.modeling import models
 
 from gwcs import coordinate_frames as cf
 from gwcs import wcs
-from gwcs.wcs._step import _is_coordinate_frame
 
 
 def _assert_frame_equal(a, b):
@@ -23,7 +22,7 @@ def _assert_frame_equal(a, b):
     if a is None:
         return None
 
-    if not _is_coordinate_frame(a):
+    if not isinstance(a, cf.CoordinateFrameProtocol):
         return a == b
 
     assert a.name == b.name  # nosec

--- a/gwcs/tests/test_wcs.py
+++ b/gwcs/tests/test_wcs.py
@@ -2273,33 +2273,6 @@ def test_standard_coordinate_frames_do_not_warn_as_legacy():
     assert not any("is_high_level" in str(w.message) for w in captured)
 
 
-def test_legacy_frame_validation_does_not_recheck_after_patch(monkeypatch):
-    """
-    Regression test for Python 3.11 legacy-frame flow where legacy detection
-    should not be recomputed after patching ``is_high_level`` onto the frame.
-    """
-
-    from gwcs.wcs import _step as step_mod
-
-    legacy_input = LegacyFrameAdapter(cf.Frame2D(name="legacy_detector_recheck"))
-
-    # Emulate the 3.11-style behavior where legacy status depends on the
-    # presence of is_high_level and nominal coordinate-frame checks fail.
-    monkeypatch.setattr(step_mod, "_is_coordinate_frame", lambda frame: False)
-
-    def _legacy_check(frame):
-        return hasattr(frame, "to_high_level_coordinates") and not hasattr(
-            frame, "is_high_level"
-        )
-
-    monkeypatch.setattr(step_mod, "_is_legacy_coordinate_frame", _legacy_check)
-
-    with pytest.warns(DeprecationWarning, match=r"is_high_level"):
-        step = wcs.Step(legacy_input, m)
-
-    assert hasattr(step.frame, "is_high_level")
-
-
 def test_fitswcs_imaging(fits_wcs_imaging_simple):
     """Test simple FITS type imaging WCS."""
     gwcs, astwcs = fits_wcs_imaging_simple

--- a/gwcs/typing.py
+++ b/gwcs/typing.py
@@ -7,7 +7,7 @@ making them available for users and improving Sphinx documentation resolution.
 from __future__ import annotations
 
 from collections.abc import Sequence
-from typing import TypeAlias, TypeVar, Union
+from typing import Union
 
 from astropy.coordinates import BaseCoordinateFrame
 from astropy.modeling import Model
@@ -35,24 +35,22 @@ __all__ = [
     "WorldAxisObjectClasses",
 ]
 
-_DtypeGeneric = TypeVar("_DtypeGeneric", bound=generic)
-
-AstropyBuiltInFrame: TypeAlias = Time | BaseCoordinateFrame
-LowLevelArray: TypeAlias = ndarray[tuple[int, ...], dtype[_DtypeGeneric]]
-LowLevelInput: TypeAlias = LowLevelArray | Quantity
+type AstropyBuiltInFrame = Time | BaseCoordinateFrame
+type LowLevelArray[Dtype: generic] = ndarray[tuple[int, ...], dtype[Dtype]]
+type LowLevelInput = LowLevelArray | Quantity
 
 
-WorldAxisObjectClasses: TypeAlias = (
+type WorldAxisObjectClasses = (
     dict[str, WorldAxisObjectClass]
     | dict[str, WorldAxisObjectClassConverter]
     | dict[str, WorldAxisObjectClass | WorldAxisObjectClassConverter]
 )
 
 
-AxesType: TypeAlias = tuple[AxisType | str, ...] | AxisType | str
+type AxesType = tuple[AxisType | str, ...] | AxisType | str
 
 
 # Type aliases due to the use of the `|` for type hints not working with Model
-Mdl: TypeAlias = Union[Model, None]  # noqa: UP007
-StepTuple: TypeAlias = tuple[CoordinateFrameProtocol, Mdl]
-ForwardTransform: TypeAlias = Union[Model, Sequence[Step | StepTuple] | _BasePipeline]  # noqa: UP007
+type Mdl = Union[Model, None]  # noqa: UP007
+type StepTuple = tuple[CoordinateFrameProtocol, Mdl]
+type ForwardTransform = Union[Model, Sequence[Step | StepTuple] | _BasePipeline]  # noqa: UP007

--- a/gwcs/wcs/_pipeline.py
+++ b/gwcs/wcs/_pipeline.py
@@ -280,8 +280,9 @@ class _BasePipeline:
 _T = TypeVar("_T", bound=_BasePipeline)
 
 
+# Temporary solution for UP046 while other UP issues are being resolved
 @dataclass(frozen=True, slots=True)
-class DirectionalWCS(Generic[_T]):
+class DirectionalWCS(Generic[_T]):  # noqa: UP046
     """
     Dataclass to hold the WCS and the direction of the WCS's pipeline between
     two frames.

--- a/gwcs/wcs/_pipeline.py
+++ b/gwcs/wcs/_pipeline.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import warnings
 from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Generic, Self, TypeVar, overload
+from typing import TYPE_CHECKING, Self, overload
 
 from astropy.modeling import Model
 from astropy.modeling.bounding_box import CompoundBoundingBox, ModelBoundingBox
@@ -277,12 +277,8 @@ class _BasePipeline:
         return direction.wcs.backward_transform
 
 
-_T = TypeVar("_T", bound=_BasePipeline)
-
-
-# Temporary solution for UP046 while other UP issues are being resolved
 @dataclass(frozen=True, slots=True)
-class DirectionalWCS(Generic[_T]):  # noqa: UP046
+class DirectionalWCS[Wcs: _BasePipeline]:
     """
     Dataclass to hold the WCS and the direction of the WCS's pipeline between
     two frames.
@@ -300,7 +296,7 @@ class DirectionalWCS(Generic[_T]):  # noqa: UP046
         or backward (to_frame to from_frame), False.
     """
 
-    wcs: _T
+    wcs: Wcs
     forward: bool
 
 

--- a/gwcs/wcs/_step.py
+++ b/gwcs/wcs/_step.py
@@ -1,16 +1,12 @@
 from __future__ import annotations
 
-import sys
 import warnings
 from copy import copy
-from inspect import getattr_static
 from typing import TYPE_CHECKING, NamedTuple, Self
 
 from astropy.modeling.core import Model
 
 from gwcs.coordinate_frames import (
-    BaseCoordinateFrame,
-    CoordinateFrame,
     CoordinateFrameProtocol,
     EmptyFrame,
 )
@@ -20,65 +16,6 @@ if TYPE_CHECKING:
     from gwcs.typing import Mdl
 
 __all__ = ["IndexedStep", "Step"]
-
-
-# Runtime checkable isinstance check evaluates the actual properties of the object
-#    in Python 3.11, so EmptyFrame causes an error to be raised if we attempt to
-#    check if it is a CoordinateFrameProtocol. In Python 3.12+, the check does not
-#    evaluate the properties of the object, so it does not cause an error.
-# Temporary solution for UP036 while other UP issues are being resolved
-if sys.version_info >= (3, 12):  # noqa: UP036
-
-    def _is_coordinate_frame(frame: str | CoordinateFrameProtocol) -> bool:
-        return isinstance(frame, CoordinateFrameProtocol)
-
-    def _is_legacy_coordinate_frame(
-        frame: str | CoordinateFrameProtocol | _LegacyCoordinateFrameProtocol,
-    ) -> bool:
-        return isinstance(frame, _LegacyCoordinateFrameProtocol) and not isinstance(
-            frame, CoordinateFrameProtocol
-        )
-else:
-
-    def _is_coordinate_frame(frame: str | CoordinateFrameProtocol) -> bool:
-        return isinstance(frame, BaseCoordinateFrame | CoordinateFrame | EmptyFrame)
-
-    def _has_legacy_coordinate_frame_interface(frame: object) -> bool:
-        """
-        Return `True` if ``frame`` looks like a legacy coordinate frame object.
-
-        This supports duck-typed frames implementing the historical coordinate
-        frame API without ``is_high_level``.
-        """
-
-        required_members = (
-            "naxes",
-            "name",
-            "unit",
-            "axes_names",
-            "axes_order",
-            "reference_frame",
-            "axes_type",
-            "axis_physical_types",
-            "world_axis_object_classes",
-            "world_axis_object_components",
-            "add_units",
-            "remove_units",
-            "to_high_level_coordinates",
-            "from_high_level_coordinates",
-        )
-
-        return all(
-            getattr_static(frame, member, None) is not None
-            for member in required_members
-        )
-
-    def _is_legacy_coordinate_frame(
-        frame: str | CoordinateFrameProtocol,
-    ) -> bool:
-        return _has_legacy_coordinate_frame_interface(frame) and not hasattr(
-            frame, "is_high_level"
-        )
 
 
 class Step:
@@ -99,11 +36,12 @@ class Step:
     ) -> None:
         # Allow for a string to be passed in for the frame but be turned into a
         # frame object
-        # This is correct type-wise, but the Python 3.11 bugfix causes a MyPy error
         self.frame = (
             frame
-            if _is_coordinate_frame(frame) or _is_legacy_coordinate_frame(frame)
-            else EmptyFrame.from_transform(frame, transform)  # type: ignore[assignment, arg-type]
+            if isinstance(
+                frame, (CoordinateFrameProtocol, _LegacyCoordinateFrameProtocol)
+            )
+            else EmptyFrame.from_transform(frame, transform)
         )
         self.transform = transform
 
@@ -113,7 +51,11 @@ class Step:
 
     @frame.setter
     def frame(self, val: CoordinateFrameProtocol) -> None:
-        if is_legacy := _is_legacy_coordinate_frame(val):
+        if not isinstance(val, CoordinateFrameProtocol):
+            if not isinstance(val, _LegacyCoordinateFrameProtocol):
+                msg = '"frame" should be an instance of CoordinateFrameProtocol.'
+                raise TypeError(msg)
+
             msg = (
                 "Coordinate frames that do not implement `is_high_level` are "
                 "deprecated. Please update your coordinate frame to add "
@@ -123,10 +65,6 @@ class Step:
             # Copy the value to avoid mutating the original object.
             val = copy(val)
             val.is_high_level = lambda *args: _is_high_level(val, *args)  # type: ignore[method-assign]
-
-        if not (_is_coordinate_frame(val) or is_legacy):
-            msg = '"frame" should be an instance of CoordinateFrameProtocol.'
-            raise TypeError(msg)
 
         self._frame = val
 

--- a/gwcs/wcs/_step.py
+++ b/gwcs/wcs/_step.py
@@ -26,7 +26,8 @@ __all__ = ["IndexedStep", "Step"]
 #    in Python 3.11, so EmptyFrame causes an error to be raised if we attempt to
 #    check if it is a CoordinateFrameProtocol. In Python 3.12+, the check does not
 #    evaluate the properties of the object, so it does not cause an error.
-if sys.version_info >= (3, 12):
+# Temporary solution for UP036 while other UP issues are being resolved
+if sys.version_info >= (3, 12):  # noqa: UP036
 
     def _is_coordinate_frame(frame: str | CoordinateFrameProtocol) -> bool:
         return isinstance(frame, CoordinateFrameProtocol)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "gwcs"
 description = "Generalized World Coordinate System"
-requires-python = ">=3.11"
+requires-python = ">=3.12"
 authors = [{ name = "gwcs developers" }]
 dependencies = [
   "asdf >= 3.3.0",
@@ -191,7 +191,7 @@ ignore = [
 warn_return_any = true
 warn_unused_configs = true
 disable_error_code = "import-untyped" # do not check imports
-python_version = "3.11"
+python_version = "3.12"
 
 # Always ignore tests and docs
 [[tool.mypy.overrides]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,9 +4,9 @@ description = "Generalized World Coordinate System"
 requires-python = ">=3.12"
 authors = [{ name = "gwcs developers" }]
 dependencies = [
-  "asdf >= 3.3.0",
-  "astropy >= 6.0",
-  "numpy>=1.25",
+  "asdf >= 4.0.0",
+  "astropy >= 7.0",
+  "numpy>=2.0",
   "scipy>=1.14.1",
   "asdf_wcs_schemas >= 0.5.0",
   "asdf-astropy >= 0.8.0",


### PR DESCRIPTION
<!-- describe the changes comprising this PR here -->

This PR drops support for Python 3.11 in GWCS per [SPEC 0](https://scientific-python.org/specs/spec-0000/)

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->

## Tasks

- [ ] Update or add relevant `gwcs` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [ ] Does this PR need a changelog entry? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).

<details><summary>News fragment change types:</summary>

- `changes/<PR#>.feature.rst`: new feature
- `changes/<PR#>.breaking.rst`: any change or deprecation of the public API
- `changes/<PR#>.bugfix.rst`: fixes an issue
- `changes/<PR#>.doc.rst`: documentation change
- `changes/<PR#>.misc.rst`: infrastructure or miscellaneous change

</details
