### PR TITLE
Fix numerical inverse projection handling

### DIFF
--- a/changes/761.bugfix.rst
+++ b/changes/761.bugfix.rst
@@ -1,0 +1,1 @@
+Fix numerical inverse handling for forward transforms containing projection model instances.

--- a/gwcs/tests/test_numerical_inverse_projection.py
+++ b/gwcs/tests/test_numerical_inverse_projection.py
@@ -1,0 +1,72 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""Regression tests for numerical inverse projection handling."""
+
+from astropy import coordinates as coord
+from astropy import units as u
+from astropy.modeling import models
+
+from gwcs import coordinate_frames as cf
+from gwcs import wcs
+
+
+def test_calc_approx_inv_handles_projection_model_instance():
+    """A Pix2Sky model in the forward transform should build an approximate inverse."""
+    crpix = (2044, 2044)
+    shift_by_crpix = models.Shift(-crpix[0]) & models.Shift(-crpix[1])
+
+    distortion_x = models.Polynomial2D(
+        4,
+        c0_0=0.0,
+        c1_0=0.00002993,
+        c2_0=-0.0,
+        c3_0=-0.0,
+        c4_0=-0.0,
+        c0_1=-0.00000451,
+        c0_2=0.0,
+        c0_3=-0.0,
+        c0_4=-0.0,
+        c1_1=-0.0,
+        c1_2=-0.0,
+        c1_3=-0.0,
+        c2_1=-0.0,
+        c2_2=-0.0,
+        c3_1=-0.0,
+    )
+    distortion_y = models.Polynomial2D(
+        4,
+        c0_0=0.0,
+        c1_0=0.00000397,
+        c2_0=-0.0,
+        c3_0=0.0,
+        c4_0=0.0,
+        c0_1=0.00002904,
+        c0_2=-0.0,
+        c0_3=-0.0,
+        c0_4=-0.0,
+        c1_1=-0.0,
+        c1_2=0.0,
+        c1_3=0.0,
+        c2_1=0.0,
+        c2_2=0.0,
+        c3_1=0.0,
+    )
+    distortion = models.Mapping([0, 1, 0, 1]) | (distortion_x & distortion_y)
+    transform = (
+        shift_by_crpix
+        | distortion
+        | models.Pix2Sky_TAN()
+        | models.RotateNative2Celestial(5.63056810618, -72.05457184279, 180)
+    )
+
+    detector_frame = cf.Frame2D(
+        name="detector", axes_names=("x", "y"), unit=(u.pix, u.pix)
+    )
+    sky_frame = cf.CelestialFrame(
+        reference_frame=coord.ICRS(), name="icrs", unit=(u.deg, u.deg)
+    )
+    gwcs = wcs.WCS([(detector_frame, transform), (sky_frame, None)])
+    gwcs.bounding_box = ((0, crpix[0] * 2), (0, crpix[1] * 2))
+
+    gwcs._calc_approx_inv()
+
+    assert gwcs._approx_inverse is not None

--- a/gwcs/wcs/_wcs.py
+++ b/gwcs/wcs/_wcs.py
@@ -2837,14 +2837,14 @@ class WCS(Pipeline, WCSAPIMixin):
             if isinstance(transform, projections.Projection):
                 sky2pix_proj = transform
                 break
-        if sky2pix_proj.__name__.startswith("Pix2Sky"):
+        if isinstance(sky2pix_proj, projections.Pix2SkyProjection):
             sky2pix_proj = sky2pix_proj.inverse
         lon_pole = _compute_lon_pole((crval1, crval2), sky2pix_proj)
         ntransform = (
             (Shift(crpix[0]) & Shift(crpix[1]))
             | self.forward_transform
             | RotateCelestial2Native(crval1, crval2, lon_pole)
-            | sky2pix_proj()
+            | sky2pix_proj
         )
 
         # standard sampling:


### PR DESCRIPTION
This PR addresses #726.

`_calc_approx_inv` takes projection models from `self.forward_transform`, so `sky2pix_proj` is a projection model instance. The current code treats it like a class twice: first by reading `.__name__`, and then by calling it with no inputs when composing `ntransform`.

This changes the projection-direction check to use `isinstance(..., projections.Pix2SkyProjection)` and composes the existing model instance directly. This preserves the existing fallback to `Sky2Pix_TAN` while allowing numerical inverse setup for transforms that contain a `Pix2Sky` projection.

A regression test exercises the numerical-inverse approximation path with the transform from #726 and verifies that an approximate inverse is constructed.

## Tasks

- [x] Update or add relevant `gwcs` tests.
- [x] No documentation change needed; this fixes internal numerical inverse handling.
- [ ] Add the changelog fragment after the PR number is assigned.