### PR TITLE
[TEMPLATE] move towncrier config to its own file and explicitly order changelog categories to put breaking changes on top

### DIFF
--- a/changes/README.md
+++ b/changes/README.md
@@ -1,0 +1,10 @@
+# Writing News Fragments for the Changelog
+
+This `changes/` directory contains "news fragments": small reStructuredText (`.rst`) files describing a change in a few sentences.
+When making a release, run `towncrier build --version <VERSION>` to consume existing fragments in `changes/`
+and insert them as a full changelog entry at the top of [`CHANGES.rst`](../CHANGES.rst) for the released version.
+
+News fragment filenames consist of the pull request number and the changelog category.
+Make a news fragment for every relevant category affected by your change.
+A single change can have more than one news fragment, if it spans multiple categories.
+Categories are listed in [`towncrier.toml`](../towncrier.toml).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -197,26 +197,3 @@ python_version = "3.12"
 [[tool.mypy.overrides]]
 module = ["gwcs.tests.*", "docs.*"]
 ignore_errors = true
-
-[tool.towncrier]
-filename = "CHANGES.rst"
-directory = "changes"
-package = "gwcs"
-title_format = "{version} ({project_date})"
-ignore = [".gitkeep"]
-wrap = true
-issue_format = "`#{issue} <https://github.com/spacetelescope/gwcs/issues/{issue}>`_"
-
-[tool.towncrier.fragment.feature]
-name = "New Features"
-
-[tool.towncrier.fragment.breaking]
-name = "Breaking Changes"
-
-[tool.towncrier.fragment.bugfix]
-name = "Bug Fixes"
-
-[tool.towncrier.fragment.doc]
-name = "Documentation"
-
-[tool.towncrier.fragment.misc]

--- a/towncrier.toml
+++ b/towncrier.toml
@@ -1,0 +1,28 @@
+[tool.towncrier]
+filename = "CHANGES.rst"
+directory = "changes"
+package = "gwcs"
+title_format = "{version} ({project_date})"
+ignore = ["README.md"]
+wrap = true
+issue_format = "`#{issue} <https://github.com/spacetelescope/gwcs/issues/{issue}>`_"
+
+[[tool.towncrier.type]]
+directory = "breaking"
+name = "Breaking Changes"
+
+[[tool.towncrier.type]]
+directory = "feature"
+name = "New Features"
+
+[[tool.towncrier.type]]
+directory = "bugfix"
+name = "Bug Fixes"
+
+[[tool.towncrier.type]]
+directory = "doc"
+name = "Documentation"
+
+[[tool.towncrier.type]]
+directory = "misc"
+name = "Other Changes"


### PR DESCRIPTION
1. putting changelog categories in their own file makes them easier to find for people looking to make new news fragments, and we can link directly to `towncrier.toml` from the `changes/README.md`
2. we can order changelog categories using the `[[tool.towncrier.type]]` table syntax